### PR TITLE
Extracted class from DependencyReportTask.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/ArtifactToComponentTransformer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/ArtifactToComponentTransformer.kt
@@ -1,0 +1,100 @@
+package com.autonomousapps.internal
+
+import com.autonomousapps.internal.asm.ClassReader
+import org.gradle.api.GradleException
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.artifacts.result.DependencyResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.logging.Logger
+import java.util.*
+import java.util.zip.ZipFile
+
+internal class ArtifactToComponentTransformer(
+    private val configuration: Configuration,
+    private val allArtifacts: List<Artifact>,
+    private val logger: Logger
+) {
+
+    fun components(): List<Component> {
+        computeTransitivity()
+        return allArtifacts.asComponents()
+    }
+
+    private fun computeTransitivity() {
+        val directArtifacts = configuration.directArtifacts()
+
+        // "All artifacts" is everything used to compile the project. If there is a direct artifact with a matching
+        // identifier, then that artifact is NOT transitive. Otherwise, it IS transitive.
+        allArtifacts.forEach { dep ->
+            dep.isTransitive = !directArtifacts.any { it.dependency.identifier == dep.dependency.identifier }
+        }
+    }
+
+    /**
+     * Maps collection of [Artifact]s to [Component]s, basically by exploding the contents of [Artifact.file] into a set
+     * of class names ([Component.classes]).
+     */
+    private fun Iterable<Artifact>.asComponents(): List<Component> =
+        map { artifact ->
+            val classes = extractClassesFromJar(artifact)
+            Component(artifact.dependency, artifact.isTransitive!!, classes)
+        }.sorted()
+
+    /**
+     * Analyzes bytecode (using ASM) in order to extract class names from jar ([Artifact.file]).
+     */
+    private fun extractClassesFromJar(artifact: Artifact): Set<String> {
+        Objects.requireNonNull(artifact.file, "file must not be null")
+        val zip = ZipFile(artifact.file)
+
+        return zip.entries().toList()
+            .filterNot { it.isDirectory }
+            .filter { it.name.endsWith(".class") }
+            .map { classEntry ->
+                ClassNameCollector(logger).apply {
+                    val reader = ClassReader(zip.getInputStream(classEntry).readBytes())
+                    reader.accept(this, 0)
+                }
+            }
+            .mapNotNull { it.className }
+            .filterNot {
+                // Filter out `java` packages, but not `javax`
+                it.startsWith("java/")
+            }
+            .map { it.replace("/", ".") }
+            .toSortedSet()
+    }
+}
+
+/**
+ * Traverses the top level of the dependency graph to get all "direct" dependencies, and their associated artifacts, as
+ * a set of [Artifact]s.
+ */
+private fun Configuration.directArtifacts(): Set<Artifact> {
+    // Update all-artifacts list: transitive or not?
+    // runtime classpath will give me only the direct dependencies
+    val dependencies: Set<DependencyResult> =
+        incoming
+            .resolutionResult
+            .root
+            .dependencies
+
+    return traverseDependencies(dependencies)
+}
+
+/**
+ * This was heavily modified from code found in the Gradle 5.6.x documentation. Can't find the link any more.
+ */
+private fun traverseDependencies(results: Set<DependencyResult>): Set<Artifact> = results
+    .filterIsInstance<ResolvedDependencyResult>()
+    .map { result ->
+        val componentResult = result.selected
+
+        when (val componentIdentifier = componentResult.id) {
+            is ProjectComponentIdentifier -> Artifact(componentIdentifier)
+            is ModuleComponentIdentifier -> Artifact(componentIdentifier)
+            else -> throw GradleException("Unexpected ComponentIdentifier type: ${componentIdentifier.javaClass.simpleName}")
+        }
+    }.toSet()

--- a/src/main/kotlin/com/autonomousapps/internal/utils.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils.kt
@@ -6,10 +6,8 @@ import org.gradle.api.GradleException
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
-import java.io.File
-import java.util.*
-
-fun String.capitalize() = substring(0, 1).toUpperCase(Locale.ROOT) + substring(1)
+import org.gradle.api.artifacts.result.DependencyResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
 
 fun Sequence<MatchResult>.allItems(): List<String> =
     flatMap { matchResult ->
@@ -23,8 +21,6 @@ fun ComponentIdentifier.asString(): String {
     return when (this) {
         is ProjectComponentIdentifier -> projectPath
         is ModuleComponentIdentifier -> moduleIdentifier.toString()
-        // OpaqueComponentArtifactIdentifier implements ComponentArtifactIdentifier, ComponentIdentifier
-//        is ComponentArtifactIdentifier -> toString()
         else -> throw GradleException("Cannot identify ComponentIdentifier subtype. Was ${javaClass.simpleName}, named $this")
     }
 }
@@ -36,8 +32,6 @@ fun ComponentIdentifier.resolvedVersion(): String? {
         else -> throw GradleException("Cannot identify ComponentIdentifier subtype. Was ${javaClass.simpleName}, named $this")
     }
 }
-
-internal fun File.asURL() = toURI().toURL()
 
 // Begins with an 'L'
 // followed by at least one word character
@@ -53,3 +47,14 @@ val DESC_REGEX = """L(\w[\w/$]+);""".toRegex()
 // https://stackoverflow.com/questions/5205339/regular-expression-matching-fully-qualified-class-names#comment5855158_5205467
 val JAVA_FQCN_REGEX =
     "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\.)+\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*".toRegex()
+
+
+// Print dependency tree (like running the `dependencies` task). Very similar to above function.
+@Suppress("unused")
+fun printDependencyTree(dependencies: Set<DependencyResult>, level: Int = 0) {
+    dependencies.filterIsInstance<ResolvedDependencyResult>().forEach { result ->
+        val resolvedComponentResult = result.selected
+        println("${"  ".repeat(level)}- ${resolvedComponentResult.id}")
+        printDependencyTree(resolvedComponentResult.dependencies, level + 1)
+    }
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/DependencyReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DependencyReportTask.kt
@@ -3,29 +3,20 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.internal.*
-import com.autonomousapps.internal.asm.ClassReader
 import org.gradle.api.DefaultTask
-import org.gradle.api.GradleException
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier
-import org.gradle.api.artifacts.result.DependencyResult
 import org.gradle.api.artifacts.result.ResolutionResult
-import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
-import java.util.*
-import java.util.zip.ZipFile
 import javax.inject.Inject
 
 /**
  * This task generates a report of all dependencies, whether or not they're transitive, and the
  * classes they contain. Currently uses `${variant}RuntimeClasspath`, which has visibility into all dependencies,
  * including transitive (and including those 'hidden' by `implementation`), as well as `runtimeOnly`.
- * TODO this is perhaps wrong/unnecessary. See TODO below
+ * TODO this is perhaps wrong/unnecessary. See TODO below.
  */
 @CacheableTask
 open class DependencyReportTask @Inject constructor(objects: ObjectFactory) : DefaultTask() {
@@ -72,97 +63,16 @@ open class DependencyReportTask @Inject constructor(objects: ObjectFactory) : De
         outputPrettyFile.delete()
 
         // Actual work
-        computeTransitivity(allArtifacts)
-        val components = allArtifacts.asComponents()
+        val transformer = ArtifactToComponentTransformer(
+            // TODO I suspect I don't need to use the runtimeClasspath for getting this set of "direct artifacts"
+            project.configurations.getByName(configurationName.get()),
+            allArtifacts,
+            logger
+        )
+        val components = transformer.components()
 
         // Write output to disk
         outputFile.writeText(components.toJson())
         outputPrettyFile.writeText(components.toPrettyString())
-    }
-
-    private fun computeTransitivity(allArtifacts: List<Artifact>) {
-        // TODO I suspect I don't need to use the runtimeClasspath for getting this set of "direct artifacts"
-        val directArtifacts = project.configurations.getByName(configurationName.get()).directArtifacts()
-
-        // "All artifacts" is everything used to compile the project. If there is a direct artifact with a matching
-        // identifier, then that artifact is NOT transitive. Otherwise, it IS transitive.
-        allArtifacts.forEach { dep ->
-            dep.isTransitive = !directArtifacts.any { it.dependency.identifier == dep.dependency.identifier }
-        }
-    }
-
-    /**
-     * Maps collection of [Artifact]s to [Component]s, basically by exploding the contents of [Artifact.file] into a set
-     * of class names ([Component.classes]).
-     */
-    private fun Iterable<Artifact>.asComponents(): List<Component> =
-        map { artifact ->
-            val classes = extractClassesFromJar(artifact)
-            Component(artifact.dependency, artifact.isTransitive!!, classes)
-        }.sorted()
-
-    /**
-     * Analyzes bytecode (using ASM) in order to extract class names from jar ([Artifact.file]).
-     */
-    private fun extractClassesFromJar(artifact: Artifact): Set<String> {
-        Objects.requireNonNull(artifact.file, "file must not be null")
-        val zip = ZipFile(artifact.file)
-
-        return zip.entries().toList()
-            .filterNot { it.isDirectory }
-            .filter { it.name.endsWith(".class") }
-            .map { classEntry ->
-                ClassNameCollector(logger).apply {
-                    val reader = ClassReader(zip.getInputStream(classEntry).readBytes())
-                    reader.accept(this, 0)
-                }
-            }
-            .mapNotNull { it.className }
-            .filterNot {
-                // Filter out `java` packages, but not `javax`
-                it.startsWith("java/")
-            }
-            .map { it.replace("/", ".") }
-            .toSortedSet()
-    }
-}
-
-/**
- * Traverses the top level of the dependency graph to get all "direct" dependencies, and their associated artifacts, as
- * a set of [Artifact]s.
- */
-private fun Configuration.directArtifacts(): Set<Artifact> {
-    // Update all-artifacts list: transitive or not?
-    // runtime classpath will give me only the direct dependencies
-    val dependencies: Set<DependencyResult> =
-        incoming
-            .resolutionResult
-            .root
-            .dependencies
-
-    return traverseDependencies(dependencies)
-}
-
-/**
- * This was heavily modified from code found in the Gradle 5.6.x documentation. Can't find the link any more.
- */
-private fun traverseDependencies(results: Set<DependencyResult>): Set<Artifact> = results
-    .filterIsInstance<ResolvedDependencyResult>()
-    .map { result ->
-        val componentResult = result.selected
-
-        when (val componentIdentifier = componentResult.id) {
-            is ProjectComponentIdentifier -> Artifact(componentIdentifier)
-            is ModuleComponentIdentifier -> Artifact(componentIdentifier)
-            else -> throw GradleException("Unexpected ComponentIdentifier type: ${componentIdentifier.javaClass.simpleName}")
-        }
-    }.toSet()
-
-// Print dependency tree (like running the `dependencies` task). Very similar to above function.
-fun printDependencyTree(dependencies: Set<DependencyResult>, level: Int = 0) {
-    dependencies.filterIsInstance<ResolvedDependencyResult>().forEach { result ->
-        val resolvedComponentResult = result.selected
-        println("${"  ".repeat(level)}- ${resolvedComponentResult.id}")
-        printDependencyTree(resolvedComponentResult.dependencies, level + 1)
     }
 }


### PR DESCRIPTION
I would like to do further refactors, and begin to extract classes that wrap the classes in `asm.kt` to facilitate unit testing.

I would also like to eventually make this task use the Worker API, but before I can do that I need to figure out what to do about my usage of `project.configurations.getByName(...)`, etc. Maybe that can be pulled back into the configuration phase, and the result given to the task as an input?