### PR TITLE
Simplified model classes.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -23,6 +23,11 @@ data class Dependency(
     val resolvedVersion: String? = null
 ) : Comparable<Dependency> {
 
+    constructor(componentIdentifier: ComponentIdentifier) : this(
+        identifier = componentIdentifier.asString(),
+        resolvedVersion = componentIdentifier.resolvedVersion()
+    )
+
     /*
      * These overrides all basically say that we don't care about the resolved version for our algorithms. End-users
      * might care, which is why we include it anyway.
@@ -70,9 +75,9 @@ data class Artifact(
     /**
      * Physical artifact on disk; a jar file.
      */
-    var file: File? = null
+    var file: File
 ) {
-    constructor(componentIdentifier: ComponentIdentifier, file: File? = null) : this(
+    constructor(componentIdentifier: ComponentIdentifier, file: File) : this(
         dependency = Dependency(componentIdentifier.asString(), componentIdentifier.resolvedVersion()),
         file = file
     )

--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -2,10 +2,7 @@
 
 package com.autonomousapps.internal
 
-import org.gradle.api.GradleException
 import org.gradle.api.artifacts.component.ComponentIdentifier
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import java.io.File
 
 // TODO these names could be better
@@ -21,7 +18,7 @@ data class Dependency(
      */
     val identifier: String,
     /**
-     * Resolved version. Will be null for project ([ComponentType.PROJECT]) dependencies.
+     * Resolved version. Will be null for project dependencies.
      */
     val resolvedVersion: String? = null
 ) : Comparable<Dependency> {
@@ -67,10 +64,6 @@ data class Artifact(
      */
     val dependency: Dependency,
     /**
-     * Library (e.g., downloaded from jcenter) or a project ("module" in a multi-module project).
-     */
-    val componentType: ComponentType,
-    /**
      * If false, a direct dependency (declared in the `dependencies {}` block). If true, a transitive dependency.
      */
     var isTransitive: Boolean? = null,
@@ -81,31 +74,8 @@ data class Artifact(
 ) {
     constructor(componentIdentifier: ComponentIdentifier, file: File? = null) : this(
         dependency = Dependency(componentIdentifier.asString(), componentIdentifier.resolvedVersion()),
-        componentType = ComponentType.of(componentIdentifier),
         file = file
     )
-}
-
-/**
- * TODO Currently only used in the artifacts report. Uncertain value.
- */
-enum class ComponentType {
-    /**
-     * A 3rd-party dependency.
-     */
-    LIBRARY,
-    /**
-     * A project dependency, aka a "module" in a multi-module or multi-project build.
-     */
-    PROJECT;
-
-    companion object {
-        fun of(componentIdentifier: ComponentIdentifier) = when (componentIdentifier) {
-            is ModuleComponentIdentifier -> LIBRARY
-            is ProjectComponentIdentifier -> PROJECT
-            else -> throw GradleException("'This shouldn't happen'")
-        }
-    }
 }
 
 /**

--- a/src/main/kotlin/com/autonomousapps/tasks/InlineMemberExtractionTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/InlineMemberExtractionTask.kt
@@ -20,7 +20,6 @@ import org.gradle.api.tasks.*
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
-import java.util.*
 import java.util.zip.ZipFile
 import javax.inject.Inject
 
@@ -111,8 +110,7 @@ internal class InlineDependenciesFinder(
     fun find(): Set<Dependency> {
         val inlineImports: Set<ComponentWithInlineMembers> = artifacts
             .map { artifact ->
-                Objects.requireNonNull(artifact.file, "File must not be null")
-                artifact to InlineMemberFinder(logger, ZipFile(artifact.file!!)).find().toSortedSet()
+                artifact to InlineMemberFinder(logger, ZipFile(artifact.file)).find().toSortedSet()
             }.filterNot { (_, imports) -> imports.isEmpty() }
             .map { (artifact, imports) -> ComponentWithInlineMembers(artifact.dependency, imports) }
             .toSortedSet()

--- a/src/test/kotlin/com/autonomousapps/fixtures/SeattleShelterDbModule.kt
+++ b/src/test/kotlin/com/autonomousapps/fixtures/SeattleShelterDbModule.kt
@@ -39,7 +39,7 @@ class SeattleShelterDbModule {
         fileFromResource(ARTIFACTS_PATH).readText()
             .fromJsonList<Artifact>()
             .onEach {
-                it.file = fileFromResource(it.file!!.path)
+                it.file = fileFromResource(it.file.path)
             }
     }
 


### PR DESCRIPTION
The next thing would be to make `Artifact.file` a `val`, but at least one test relies on it being a `var`, so we can make that change later on.