### PR TITLE
Allow to publish plugin to maven repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out
 *~
 # sometimes antlr barfs, and I don't want to add those files by accident
 src/main/gen/
+local.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+    id("maven-publish")
     id("java-gradle-plugin")
     id("com.gradle.plugin-publish") version "0.10.1"
     id("org.jetbrains.kotlin.jvm") version "1.3.70"
@@ -146,6 +147,12 @@ pluginBundle {
             tags = listOf("android", "dependencies")
         }
     }
+
+    mavenCoordinates {
+        groupId = "com.autonomousapps"
+        artifactId = "dependency-analysis-gradle-plugin"
+        version = project.version
+    }
 }
 
 gradlePlugin.testSourceSets(functionalTestSourceSet, smokeTestSourceSet)
@@ -223,5 +230,13 @@ tasks.named("publishPlugins") {
     // Note that publishing non-snapshots requires a successful smokeTest
     if (!(project.version as String).endsWith("SNAPSHOT")) {
         dependsOn(check, smokeTest)
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("dependency-analysis-gradle-plugin") {
+            from(components["java"])
+        }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,7 +151,7 @@ pluginBundle {
     mavenCoordinates {
         groupId = "com.autonomousapps"
         artifactId = "dependency-analysis-gradle-plugin"
-        version = project.version
+        version = project.version.toString()
     }
 }
 


### PR DESCRIPTION
I have:
* added the `local.properties` file to `.gitignore` so that I could use Android Studio to code in the plugin.
* added the [`maven-publish` plugin](https://plugins.gradle.org/docs/publish-plugin) so we can install the plugin locally to a maven local repo, easier for contributors to test a version of their own.
* overridden the maven coordinates of the plugin. If you look at the [portal page of the plugin](https://plugins.gradle.org/plugin/com.autonomousapps.dependency-analysis), the maven `groupId` currently starts with `gradle.plugin`. It was a burden for contributions: we would have to use this form over the `plugins {}` block so that we can pick the classpath dependency from a local maven repo. So I made the maven coordinates simpler:
```
groupId = "com.autonomousapps"
artifactId = "dependency-analysis-gradle-plugin"
```
which is the default `groupId:artifactId` for the maven publish plugin. 
It will break backward compatibility but it is better because you can easily switch back and forth between a stable version and a snapshot version now in a test app. If we don't do that, snapshots and stable version will have different group ids, which is not good.

To contributors, we could create a `CONTRIBUTING.MD` file in the repo: 
* to publish a snapshot of the plugin to your local maven repo for testing, use:
`./gradlew publishToMavenLocal`
* to use this version from a test app, use 
```
builscript {
 repositories {
   mavenLocal() 
  }
  classpath "com.autonomousapps:dependency-analysis-gradle-plugin:version-SNAPSHOT"
}
```