### PR TITLE
Added support for setting subproject whitelist.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
@@ -4,7 +4,9 @@ package com.autonomousapps
 
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.SetProperty
+import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.setProperty
 import java.io.Serializable
 import javax.inject.Inject
@@ -34,6 +36,12 @@ open class DependencyAnalysisExtension(objects: ObjectFactory) {
     fun issues(action: Action<IssueHandler>) {
         action.execute(issueHandler)
     }
+
+    /**
+     * A whitelist of subprojects to perform dependency analysis on. The default, empty, means analyze all subprojects.
+     * Specify subprojects by path (exactly as you do for `settings.gradle`'s `include` statements).
+     */
+    val projects: ListProperty<String> = objects.listProperty()
 }
 
 /**

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -43,19 +43,6 @@ class DependencyAnalysisPlugin : Plugin<Project> {
     private val artifactAdded = AtomicBoolean(false)
 
     override fun apply(project: Project): Unit = project.run {
-        pluginManager.withPlugin(ANDROID_APP_PLUGIN) {
-            logger.log("Adding Android tasks to ${project.path}")
-            configureAndroidAppProject()
-        }
-        pluginManager.withPlugin(ANDROID_LIBRARY_PLUGIN) {
-            logger.log("Adding Android tasks to ${project.path}")
-            configureAndroidLibProject()
-        }
-        pluginManager.withPlugin(JAVA_LIBRARY_PLUGIN) {
-            logger.log("Adding JVM tasks to ${project.path}")
-            configureJavaLibProject()
-        }
-
         if (this == rootProject) {
             logger.log("Adding root project tasks")
 
@@ -64,7 +51,35 @@ class DependencyAnalysisPlugin : Plugin<Project> {
             subprojects {
                 apply(plugin = "com.autonomousapps.dependency-analysis")
             }
+            return@run
         }
+
+        pluginManager.withPlugin(ANDROID_APP_PLUGIN) {
+            if (shouldConfigure()) {
+                logger.log("Adding Android tasks to ${project.path}")
+                configureAndroidAppProject()
+            }
+        }
+        pluginManager.withPlugin(ANDROID_LIBRARY_PLUGIN) {
+            if (shouldConfigure()) {
+                logger.log("Adding Android tasks to ${project.path}")
+                configureAndroidLibProject()
+            }
+        }
+        pluginManager.withPlugin(JAVA_LIBRARY_PLUGIN) {
+            if (shouldConfigure()) {
+                logger.log("Adding JVM tasks to ${project.path}")
+                configureJavaLibProject()
+            }
+        }
+    }
+
+    /**
+     * Configure a project if the whitelist is empty, or if it's in the whitelist.
+     */
+    private fun Project.shouldConfigure(): Boolean {
+        val projects = getExtension().projects.get()
+        return projects.isEmpty() || projects.contains(path)
     }
 
     /**


### PR DESCRIPTION
Projects not on the list will not be analyzed. If the list is empty, all subprojects are analyzed (which is the current behavior).

Example usage:
```kotlin
// Kotlin
dependencyAnalysis {
    projects.set(listOf(":entities"))
}
```

```groovy
// Groovy
dependencyAnalysis {
    projects.set([":entities"])
}

// or
// I'm actually not sure this works, but I think Groovy / Gradle magic adds an `=` 
// overload to `Property`s. 
dependencyAnalysis {
    projects = [":entities"]
}

```