### PR TITLE
Fixed: don't consider an android lib unused if it contributes a ContentProvider or Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Dependency Analysis Plugin Changelog
 
+# Version 0.34.0 (unreleased)
+* [Fixed] Check for presence of ContentProvider or Service in contributed Android manifests.
+Such Android libraries are now considered used, even if they don't appear in the compiled classes of a project.
+(nb: this ensures LeakCanary is not considered unused.)
+
 # Version 0.33.0
 * Added extension option for ignoring "-ktx" dependencies. See README for more information.
 * [Fixed] Version badge showed a very old version. (Thanks Pavlos-Petros Tournaris!) 

--- a/src/functionalTest/groovy/com/autonomousapps/AndroidTests.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AndroidTests.groovy
@@ -36,7 +36,25 @@ final class AndroidTests extends AbstractFunctionalTest {
     }
   }
 
-  // IDE doesn't understand where blocks
+  @Unroll
+  def "leakcanary is not reported as unused (#gradleVersion)"() {
+    given:
+    def project = new LeakCanaryProject(agpVersion)
+    androidProject = project.newProject()
+
+    when:
+    build(gradleVersion, androidProject, 'buildHealth')
+
+    then:
+    def actualAdvice = androidProject.adviceFor(project.appSpec)
+    def expectedAdvice = project.expectedAdviceForApp
+    expectedAdvice == actualAdvice
+
+    where:
+    gradleVersion << gradleVersions(agpVersion)
+  }
+
+  // IDE doesn't understand complex where blocks
   @SuppressWarnings("GroovyAssignabilityCheck")
   @Unroll
   def "ktx dependencies are treated per user configuration (#gradleVersion, ignoreKtx=#ignoreKtx, useKtx=#useKtx)"() {
@@ -45,7 +63,7 @@ final class AndroidTests extends AbstractFunctionalTest {
     androidProject = project.newProject()
 
     when:
-    build(gradleVersion, androidProject, 'buildHealth', '-s')
+    build(gradleVersion, androidProject, 'buildHealth')
 
     then:
     def actualAdviceForApp = androidProject.adviceFor(project.appSpec)

--- a/src/functionalTest/kotlin/com/autonomousapps/fixtures/LeakCanaryProject.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/fixtures/LeakCanaryProject.kt
@@ -1,0 +1,31 @@
+package com.autonomousapps.fixtures
+
+import com.autonomousapps.internal.Advice
+
+class LeakCanaryProject(private val agpVersion: String) {
+
+  fun newProject() = AndroidProject(
+    rootSpec = RootSpec(agpVersion = agpVersion),
+    appSpec = appSpec
+  )
+
+  private val sources = mapOf("App.kt" to """
+    package $DEFAULT_PACKAGE_NAME
+    
+    import androidx.appcompat.app.AppCompatActivity
+    
+    class MainActivity : AppCompatActivity() {
+    }
+  """.trimIndent())
+
+  val appSpec = AppSpec(
+    sources = sources,
+    dependencies = listOf(
+      "implementation" to "org.jetbrains.kotlin:kotlin-stdlib:1.3.70",
+      "implementation" to APPCOMPAT,
+      "debugImplementation" to "com.squareup.leakcanary:leakcanary-android:2.2"
+    )
+  )
+
+  val expectedAdviceForApp: Set<Advice> = setOf()
+}

--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -237,6 +237,37 @@ data class Res(
   )
 }
 
+/**
+ * Metadata from an Android manifest.
+ */
+data class Manifest(
+  /**
+   * The package name per `<manifest package="...">`.
+   */
+  val packageName: String,
+  /**
+   * True if the manifest contains Android components (Activity, Service, BroadcastReceiver, ContentProvider).
+   */
+  val hasComponents: Boolean,
+  /**
+   * A tuple of an `identifier` and a resolved version. See [Dependency].
+   */
+  val dependency: Dependency
+) : Comparable<Manifest> {
+  constructor(packageName: String, hasComponents: Boolean, componentIdentifier: ComponentIdentifier) : this(
+    packageName = packageName,
+    hasComponents = hasComponents,
+    dependency = Dependency(
+      identifier = componentIdentifier.asString(),
+      resolvedVersion = componentIdentifier.resolvedVersion()
+    )
+  )
+
+  override fun compareTo(other: Manifest): Int {
+    return dependency.compareTo(other.dependency)
+  }
+}
+
 data class Advice(
   /**
    * The dependency that ought to be modified in some way.

--- a/src/main/kotlin/com/autonomousapps/internal/outputDirectories.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/outputDirectories.kt
@@ -25,14 +25,13 @@ fun getConstantUsagePath(variantName: String) = "${getVariantDirectory(variantNa
 
 fun getAndroidResUsagePath(variantName: String) = "${getVariantDirectory(variantName)}/android-res-usage.json"
 
+fun getManifestPackagesPath(variantName: String) = "${getVariantDirectory(variantName)}/manifest-packages.json"
+
 fun getUnusedDirectDependenciesPath(variantName: String) =
     "${getVariantDirectory(variantName)}/unused-direct-dependencies.json"
 
 fun getUsedTransitiveDependenciesPath(variantName: String) =
     "${getVariantDirectory(variantName)}/used-transitive-dependencies.json"
-
-fun getMisusedDependenciesHtmlPath(variantName: String) =
-    "${getVariantDirectory(variantName)}/misused-dependencies.html"
 
 fun getAbiAnalysisPath(variantName: String) = "${getVariantDirectory(variantName)}/abi.json"
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ManifestPackageExtractionTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ManifestPackageExtractionTask.kt
@@ -1,0 +1,88 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.autonomousapps.tasks
+
+import com.autonomousapps.TASK_GROUP_DEP
+import com.autonomousapps.internal.Manifest
+import com.autonomousapps.internal.utils.toJson
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.artifacts.ArtifactCollection
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.*
+import org.w3c.dom.Document
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+@CacheableTask
+abstract class ManifestPackageExtractionTask : DefaultTask() {
+
+  init {
+    group = TASK_GROUP_DEP
+    description = "Produces a report of packages, from other components, that are included via Android manifests"
+  }
+
+  private lateinit var manifestArtifacts: ArtifactCollection
+
+  fun setArtifacts(manifestArtifacts: ArtifactCollection) {
+    this.manifestArtifacts = manifestArtifacts
+  }
+
+  // Unfortunately the paths are absolute. They look like
+  // ~/.gradle/caches/transforms-2/files-2.1/68044d2f962d3a8fe82e49e8213ba770/jetified-leakcanary-android-2.2/AndroidManifest.xml
+  @PathSensitive(PathSensitivity.ABSOLUTE)
+  @InputFiles
+  fun getManifestFiles(): FileCollection = manifestArtifacts.artifactFiles
+
+  @get:OutputFile
+  abstract val manifestPackagesReport: RegularFileProperty
+
+  @TaskAction fun action() {
+    // Output
+    val outputFile = manifestPackagesReport.get().asFile
+    outputFile.delete()
+
+    val manifests: Set<Manifest> = manifestArtifacts.mapNotNull { manifest ->
+      try {
+        extractPackageDeclarationFromManifest(manifest.file).let { (pn, hasComponent) ->
+          Manifest(
+            packageName = pn,
+            hasComponents = hasComponent,
+            componentIdentifier = manifest.id.componentIdentifier
+          )
+        }
+      } catch (_: GradleException) {
+        null
+      }
+    }.toSortedSet()
+
+    outputFile.writeText(manifests.toJson())
+  }
+
+  private fun extractPackageDeclarationFromManifest(manifest: File): Pair<String, Boolean> {
+    val document = DocumentBuilderFactory.newInstance()
+      .newDocumentBuilder()
+      .parse(manifest)
+    document.documentElement.normalize()
+
+    return packageName(document) to hasAndroidComponent(document)
+  }
+
+  private fun packageName(document: Document): String {
+    return document.getElementsByTagName("manifest").item(0)
+      .attributes
+      .getNamedItem("package")
+      .nodeValue
+  }
+
+  // "service" is enough to catch LeakCanary, and "provider" makes sense in principle. Trying not to be too aggressive.
+  private fun hasAndroidComponent(document: Document): Boolean {
+//    if (document.getElementsByTagName("activity").length > 0) return true
+    if (document.getElementsByTagName("service").length > 0) return true
+//    if (document.getElementsByTagName("receiver").length > 0) return true
+    if (document.getElementsByTagName("provider").length > 0) return true
+
+    return false
+  }
+}


### PR DESCRIPTION
Service is sufficient to capture LeakCanary, and ContentProvider makes sense on principle. Trying not to be too aggressive.

Fixes https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/80