### PR TITLE
Improve performance by using a simple in-memory cache.

### DIFF
--- a/PUBLISHING.asciidoc
+++ b/PUBLISHING.asciidoc
@@ -14,11 +14,13 @@ I was able to do this by publishing a DNS TXT record that referenced the Jira ti
 All published files https://central.sonatype.org/pages/requirements.html#sign-files-with-gpgpgp[must be signed].
 . Configure publishing for your project with the `maven-publish` and `java-gradle-plugin` plugins.
 . Ensure your POM meets https://central.sonatype.org/pages/requirements.html#sufficient-metadata[OSS Sonatype standards].
-. Ensure you are also https://central.sonatype.org/pages/requirements.html#supply-javadoc-and-sources[publishing javadoc and sources].
+. Ensure you are also https://central.sonatype.org/pages/requirements.html#supply-javadoc-and-sources[publishing javadoc
+and sources].
 . Publish to the Sonatype snapshots repository and verify you can apply your plugin to a real project.
 . Publish to the staging repository and:
 .. "Close" the project (this triggers validation of your publication by Sonatype).
-.. Fix any validation errors that might occur (for example, maybe you didn't sign all your artifacts, or maybe you forgot to publish your GPG key to a public keyserver).
+.. Fix any validation errors that might occur (for example, maybe you didn't sign all your artifacts, or maybe you
+forgot to publish your GPG key to a public keyserver).
 .. "Release" the project. It will automatically drop after successfully releasing.
 .. Comment on your original Jira ticket that you have promoted your first artifact.
 A human will review and then sync your project with Maven Central.
@@ -63,13 +65,15 @@ If it failed to publish, you will instead see
     gpg: no valid OpenPGP data found.
     gpg: Total number processed: 0
 
-I struggled for a while to publish my key, and only succeeded after seeing https://github.com/pop-os/iso/issues/207#issuecomment-385195545[this comment] on a random Github issue tracker.
+I struggled for a while to publish my key, and only succeeded after seeing
+ ttps://github.com/pop-os/iso/issues/207#issuecomment-385195545[this comment] on a random Github issue tracker.
 
 Like I said, magic.
 
 === Set up signing for your build artifacts
 
-The following is largely distilled from https://docs.gradle.org/current/userguide/signing_plugin.html[the documentation] on the Gradle `signing` plugin.
+The following is largely distilled from https://docs.gradle.org/current/userguide/signing_plugin.html[the documentation]
+on the Gradle `signing` plugin.
 
 https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials[Export your keys]:
 
@@ -93,7 +97,9 @@ step requires two publications be available to sign.
 
 === Export your key to another computer
 Now that you have a key for signing your artifacts, you'll want to store it somewhere safe in the event
-you need to do work on another computer. I found a short https://makandracards.com/makandra/37763-gpg-extract-private-key-and-import-on-different-machine[guide] on the subject, but here are the steps:
+you need to do work on another computer. I found a short
+https://makandracards.com/makandra/37763-gpg-extract-private-key-and-import-on-different-machine[guide] on the subject,
+but here are the steps:
 
     $ gpg --list-secret-keys
     W7WQ5NZWC8S339RVAAOCR0SCMV7T00FKDHG570SZ
@@ -107,6 +113,9 @@ Now export the key:
 Copy the key somewhere (consider `scp`), and on the second machine, import with:
 
     $ gpg --import my-private-key.asc
+
+You will then need to follow the advice from <<Set up signing for your build artifacts>> to set up signing on the new
+computer.
 
 == Creating publications
 

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -6,8 +6,8 @@ import com.android.build.gradle.AppExtension
 import com.android.build.gradle.LibraryExtension
 import com.autonomousapps.internal.*
 import com.autonomousapps.internal.android.AgpVersion
-import com.autonomousapps.services.InMemoryCache
 import com.autonomousapps.internal.utils.log
+import com.autonomousapps.services.InMemoryCache
 import com.autonomousapps.tasks.*
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
@@ -242,16 +242,6 @@ class DependencyAnalysisPlugin : Plugin<Project> {
 
         logger.quiet("Advice report (aggregated): ${adviceReport.get().projectReport.get().asFile.path}")
         logger.quiet("(pretty-printed)          : ${adviceReport.get().projectReportPretty.get().asFile.path}")
-
-        val inst = inMemoryCacheProvider.get()
-        val baseDir = project.file("build/reports/dependency-analysis/instrumentation")
-        baseDir.mkdirs()
-        val jars = baseDir.resolve("jars.txt")
-        jars.writeText("max: ${inst.largestJarCount?.key}: ${inst.largestJarCount?.value}\n")
-        jars.appendText(inst.jars().entries.joinToString("\n") { "${it.key}: ${it.value}" })
-        val classes = baseDir.resolve("classes.txt")
-        classes.writeText("max: ${inst.largestClassesCount?.key}: ${inst.largestClassesCount?.value}\n")
-        classes.appendText(inst.classes().entries.joinToString("\n") { "${it.key}: ${it.value}" })
       }
     }
 

--- a/src/main/kotlin/com/autonomousapps/internal/AnalyzedJar.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/AnalyzedJar.kt
@@ -36,10 +36,6 @@ internal class AnalyzedJar(private val analyzedClasses: Set<AnalyzedClass>) {
             if (!isEnum(analyzedClass)) {
               return false
             }
-            // it's ok if it's public, if it's self-referencing
-//                        if (isNotSelfReferencing(analyzedClass)) {
-//                            return false
-//                        }
           }
         }
       }
@@ -50,27 +46,18 @@ internal class AnalyzedJar(private val analyzedClasses: Set<AnalyzedClass>) {
   private fun RetentionPolicy?.isCompileOnly() = this == RetentionPolicy.CLASS || this == RetentionPolicy.SOURCE
 
   private fun isCompileOnlyAnnotation(analyzedClass: AnalyzedClass): Boolean =
-      analyzedClass.retentionPolicy.isCompileOnly()
+    analyzedClass.retentionPolicy.isCompileOnly()
 
   private fun isNotCompileOnlyAnnotation(analyzedClass: AnalyzedClass): Boolean =
-      !isCompileOnlyAnnotation(analyzedClass)
+    !isCompileOnlyAnnotation(analyzedClass)
 
   private fun isNamespaceClass(analyzedClass: AnalyzedClass): Boolean =
-      analyzedClass.hasNoMembers && analyzedClasses
-          .filter { analyzedClass.innerClasses.contains(it.className) }
-          .reallyAll { isCompileOnlyAnnotation(it) }
+    analyzedClass.hasNoMembers && analyzedClasses
+      .filter { analyzedClass.innerClasses.contains(it.className) }
+      .reallyAll { isCompileOnlyAnnotation(it) }
 
   private fun isPublic(analyzedClass: AnalyzedClass): Boolean =
-      analyzedClass.access == Access.PUBLIC || analyzedClass.access == Access.PROTECTED
+    analyzedClass.access == Access.PUBLIC || analyzedClass.access == Access.PROTECTED
 
   private fun isEnum(analyzedClass: AnalyzedClass): Boolean = analyzedClass.superClassName == "java/lang/Enum"
-
-  // A class is self-referenced if is used by the set of classes. An imperfect test, but I suspect there's no perfect
-  // one.
-  private fun isNotSelfReferencing(analyzedClass: AnalyzedClass): Boolean {
-    val allTypes = analyzedClasses.flatMap { it.methods }
-        .flatMap { it.types }
-        .toSet()
-    return !allTypes.contains(analyzedClass.className.replace(".", "/"))
-  }
 }

--- a/src/main/kotlin/com/autonomousapps/internal/instrumentation/InstrumentationBuildService.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/instrumentation/InstrumentationBuildService.kt
@@ -1,0 +1,37 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.autonomousapps.internal.instrumentation
+
+import com.autonomousapps.internal.AnalyzedJar
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentSkipListMap
+
+abstract class InstrumentationBuildService : BuildService<BuildServiceParameters.None> {
+  private val jars: MutableMap<String, Int> = ConcurrentSkipListMap()
+  private val classes: MutableMap<String, Int> = ConcurrentSkipListMap()
+
+  internal fun updateJars(jarName: String) {
+    jars.merge(jarName, 1) { oldValue, increment -> oldValue + increment }
+  }
+
+  internal fun updateClasses(className: String) {
+    classes.merge(className, 1) { oldValue, increment -> oldValue + increment }
+  }
+
+  internal fun jars(): Map<String, Int> = jars
+  internal fun classes(): Map<String, Int> = classes
+
+  internal val largestJarCount by lazy { jars.maxBy { it.value } }
+  internal val largestClassesCount by lazy { classes.maxBy { it.value } }
+
+  // AnalyzedJar cache
+  internal val analyzedJars: MutableMap<String, AnalyzedJar> = ConcurrentHashMap()
+
+  // Constant members cache
+  internal val constantMembers: MutableMap<String, Set<String>> = ConcurrentHashMap()
+
+  // Inline members cache
+  internal val inlineMembers: MutableMap<String, List<String>> = ConcurrentHashMap()
+}

--- a/src/main/kotlin/com/autonomousapps/services/InMemoryCache.kt
+++ b/src/main/kotlin/com/autonomousapps/services/InMemoryCache.kt
@@ -1,6 +1,6 @@
 @file:Suppress("UnstableApiUsage")
 
-package com.autonomousapps.internal.instrumentation
+package com.autonomousapps.services
 
 import com.autonomousapps.internal.AnalyzedJar
 import org.gradle.api.services.BuildService
@@ -8,7 +8,7 @@ import org.gradle.api.services.BuildServiceParameters
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentSkipListMap
 
-abstract class InstrumentationBuildService : BuildService<BuildServiceParameters.None> {
+abstract class InMemoryCache : BuildService<BuildServiceParameters.None> {
   private val jars: MutableMap<String, Int> = ConcurrentSkipListMap()
   private val classes: MutableMap<String, Int> = ConcurrentSkipListMap()
 
@@ -26,12 +26,8 @@ abstract class InstrumentationBuildService : BuildService<BuildServiceParameters
   internal val largestJarCount by lazy { jars.maxBy { it.value } }
   internal val largestClassesCount by lazy { classes.maxBy { it.value } }
 
-  // AnalyzedJar cache
+  // Caches
   internal val analyzedJars: MutableMap<String, AnalyzedJar> = ConcurrentHashMap()
-
-  // Constant members cache
   internal val constantMembers: MutableMap<String, Set<String>> = ConcurrentHashMap()
-
-  // Inline members cache
   internal val inlineMembers: MutableMap<String, List<String>> = ConcurrentHashMap()
 }

--- a/src/main/kotlin/com/autonomousapps/tasks/ConstantUsageDetectionTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ConstantUsageDetectionTask.kt
@@ -5,6 +5,7 @@ package com.autonomousapps.tasks
 import com.autonomousapps.TASK_GROUP_DEP
 import com.autonomousapps.internal.*
 import com.autonomousapps.internal.asm.ClassReader
+import com.autonomousapps.internal.instrumentation.InstrumentationBuildService
 import com.autonomousapps.internal.utils.fromJsonList
 import com.autonomousapps.internal.utils.getLogger
 import com.autonomousapps.internal.utils.toJson
@@ -12,6 +13,7 @@ import com.autonomousapps.internal.utils.toPrettyString
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
@@ -21,7 +23,7 @@ import javax.inject.Inject
 
 @CacheableTask
 abstract class ConstantUsageDetectionTask @Inject constructor(
-    private val workerExecutor: WorkerExecutor
+  private val workerExecutor: WorkerExecutor
 ) : DefaultTask() {
 
   init {
@@ -49,12 +51,16 @@ abstract class ConstantUsageDetectionTask @Inject constructor(
   @get:OutputFile
   abstract val constantUsageReport: RegularFileProperty
 
+  @get:Internal
+  abstract val instrumentationProvider: Property<InstrumentationBuildService>
+
   @TaskAction
   fun action() {
     workerExecutor.noIsolation().submit(ConstantUsageDetectionWorkAction::class.java) {
       artifacts.set(this@ConstantUsageDetectionTask.artifacts)
       importsFile.set(this@ConstantUsageDetectionTask.imports)
       constantUsageReport.set(this@ConstantUsageDetectionTask.constantUsageReport)
+      instrumentationProvider.set(this@ConstantUsageDetectionTask.instrumentationProvider)
     }
   }
 }
@@ -63,6 +69,7 @@ interface ConstantUsageDetectionParameters : WorkParameters {
   val artifacts: RegularFileProperty
   val importsFile: RegularFileProperty
   val constantUsageReport: RegularFileProperty
+  val instrumentationProvider: Property<InstrumentationBuildService>
 }
 
 abstract class ConstantUsageDetectionWorkAction : WorkAction<ConstantUsageDetectionParameters> {
@@ -78,7 +85,7 @@ abstract class ConstantUsageDetectionWorkAction : WorkAction<ConstantUsageDetect
     val artifacts = parameters.artifacts.get().asFile.readText().fromJsonList<Artifact>()
     val imports = parameters.importsFile.get().asFile.readText().fromJsonList<Imports>().flatten()
 
-    val usedComponents = JvmConstantDetector(logger, artifacts, imports).find()
+    val usedComponents = JvmConstantDetector(parameters.instrumentationProvider, logger, artifacts, imports).find()
 
     logger.debug("Constants usage:\n${usedComponents.toPrettyString()}")
     constantUsageReportFile.writeText(usedComponents.toJson())
@@ -93,9 +100,10 @@ abstract class ConstantUsageDetectionWorkAction : WorkAction<ConstantUsageDetect
  */
 
 internal class JvmConstantDetector(
-    private val logger: Logger,
-    private val artifacts: List<Artifact>,
-    private val actualImports: Set<String>
+  private val instrumentationProvider: Property<InstrumentationBuildService>,
+  private val logger: Logger,
+  private val artifacts: List<Artifact>,
+  private val actualImports: Set<String>
 ) {
 
   fun find(): Set<Dependency> {
@@ -106,17 +114,17 @@ internal class JvmConstantDetector(
   // from the upstream bytecode. Therefore "candidates" (not necessarily used)
   private fun findConstantImportCandidates(): Set<ComponentWithConstantMembers> {
     return artifacts
-        .map { artifact ->
-          artifact to JvmConstantMemberFinder(logger, ZipFile(artifact.file)).find()
-        }.filterNot { (_, imports) ->
-          imports.isEmpty()
-        }.map { (artifact, imports) ->
-          ComponentWithConstantMembers(artifact.dependency, imports)
-        }.toSortedSet()
+      .map { artifact ->
+        artifact to JvmConstantMemberFinder(instrumentationProvider, logger, ZipFile(artifact.file)).find()
+      }.filterNot { (_, imports) ->
+        imports.isEmpty()
+      }.map { (artifact, imports) ->
+        ComponentWithConstantMembers(artifact.dependency, imports)
+      }.toSortedSet()
   }
 
   private fun findUsedConstantImports(
-      constantImportCandidates: Set<ComponentWithConstantMembers>
+    constantImportCandidates: Set<ComponentWithConstantMembers>
   ): Set<Dependency> {
     return actualImports.flatMap { actualImport ->
       findUsedConstantImports(actualImport, constantImportCandidates)
@@ -129,7 +137,7 @@ internal class JvmConstantDetector(
    * * `com.myapp.BuildConfig.*`
    */
   private fun findUsedConstantImports(
-      actualImport: String, constantImportCandidates: Set<ComponentWithConstantMembers>
+    actualImport: String, constantImportCandidates: Set<ComponentWithConstantMembers>
   ): List<Dependency> {
     // TODO@tsr it's a little disturbing there can be multiple matches. An issue with this naive algorithm.
     // TODO@tsr I need to be more intelligent in source parsing. Look at actual identifiers being used and associate those with their star-imports
@@ -145,9 +153,12 @@ internal class JvmConstantDetector(
  * Parses bytecode looking for constant declarations.
  */
 private class JvmConstantMemberFinder(
-    private val logger: Logger,
-    private val zipFile: ZipFile
+  instrumentationProvider: Property<InstrumentationBuildService>,
+  private val logger: Logger,
+  private val zipFile: ZipFile
 ) {
+
+  private val instrumentation = instrumentationProvider.get()
 
   /**
    * Returns either an empty list, if there are no constants, or a list of import candidates. E.g.:
@@ -161,34 +172,41 @@ private class JvmConstantMemberFinder(
    * the "com.myapp" module.
    */
   fun find(): Set<String> {
+    val alreadyFoundConstantMembers: Set<String>? = instrumentation.constantMembers[zipFile.name]
+    if (alreadyFoundConstantMembers != null) {
+      return alreadyFoundConstantMembers
+    }
+
     val entries = zipFile.entries().toList()
 
     return entries
-        .filter { it.name.endsWith(".class") }
-        .flatMap { entry ->
-          val classReader = zipFile.getInputStream(entry).use { ClassReader(it.readBytes()) }
-          val constantVisitor = ConstantVisitor(logger)
-          classReader.accept(constantVisitor, 0)
+      .filter { it.name.endsWith(".class") }
+      .flatMap { entry ->
+        val classReader = zipFile.getInputStream(entry).use { ClassReader(it.readBytes()) }
+        val constantVisitor = ConstantVisitor(logger)
+        classReader.accept(constantVisitor, 0)
 
-          val fqcn = constantVisitor.className
-              .replace("/", ".")
-              .replace("$", ".")
-          val constantMembers = constantVisitor.classes
+        val fqcn = constantVisitor.className
+          .replace("/", ".")
+          .replace("$", ".")
+        val constantMembers = constantVisitor.classes
 
-          if (constantMembers.isNotEmpty()) {
-            listOf(
-                // import com.myapp.BuildConfig -> BuildConfig.DEBUG
-                fqcn,
-                // import com.myapp.BuildConfig.* -> DEBUG
-                "$fqcn.*"
-            ) +
-              // import com.myapp.* -> /* Kotlin file with top-level const val declarations */
-              optionalStarImport(fqcn) +
-              constantMembers.map { name -> "$fqcn.$name" }
-          } else {
-            emptyList()
-          }
-        }.toSortedSet()
+        if (constantMembers.isNotEmpty()) {
+          listOf(
+            // import com.myapp.BuildConfig -> BuildConfig.DEBUG
+            fqcn,
+            // import com.myapp.BuildConfig.* -> DEBUG
+            "$fqcn.*"
+          ) +
+            // import com.myapp.* -> /* Kotlin file with top-level const val declarations */
+            optionalStarImport(fqcn) +
+            constantMembers.map { name -> "$fqcn.$name" }
+        } else {
+          emptyList()
+        }
+      }.toSortedSet().also {
+        instrumentation.constantMembers.putIfAbsent(zipFile.name, it)
+      }
   }
 
   private fun optionalStarImport(fqcn: String): List<String> {

--- a/src/main/kotlin/com/autonomousapps/tasks/DependencyReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DependencyReportTask.kt
@@ -6,7 +6,7 @@ import com.autonomousapps.TASK_GROUP_DEP
 import com.autonomousapps.internal.Artifact
 import com.autonomousapps.internal.ArtifactToComponentTransformer
 import com.autonomousapps.internal.Component
-import com.autonomousapps.internal.instrumentation.InstrumentationBuildService
+import com.autonomousapps.services.InMemoryCache
 import com.autonomousapps.internal.utils.fromJsonList
 import com.autonomousapps.internal.utils.toJson
 import com.autonomousapps.internal.utils.toPrettyString
@@ -65,7 +65,7 @@ abstract class DependencyReportTask : DefaultTask() {
   abstract val allComponentsReportPretty: RegularFileProperty
 
   @get:Internal
-  abstract val instrumentationProvider: Property<InstrumentationBuildService>
+  abstract val inMemoryCacheProvider: Property<InMemoryCache>
 
   @TaskAction
   fun action() {
@@ -81,7 +81,7 @@ abstract class DependencyReportTask : DefaultTask() {
     outputPrettyFile.delete()
 
     // Build services
-    val instrumentation = instrumentationProvider.get()
+    val inMemoryCache = inMemoryCacheProvider.get()
 
     // Actual work
     val components = ArtifactToComponentTransformer(
@@ -89,7 +89,7 @@ abstract class DependencyReportTask : DefaultTask() {
       configuration,
       allArtifacts,
       logger,
-      instrumentation
+      inMemoryCache
     ).components()
 
     // Write output to disk

--- a/src/main/kotlin/com/autonomousapps/tasks/InlineMemberExtractionTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/InlineMemberExtractionTask.kt
@@ -177,7 +177,7 @@ internal class InlineDependenciesFinder(
  * Use to find inline members (functions or properties).
  */
 internal class InlineMemberFinder(
-  private val inMemoryCacheProvider: Property<InMemoryCache>,
+  private val inMemoryCacheProvider: Property<out InMemoryCache>,
   private val logger: Logger,
   private val zipFile: ZipFile
 ) {

--- a/src/main/kotlin/com/autonomousapps/tasks/InlineMemberExtractionTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/InlineMemberExtractionTask.kt
@@ -5,6 +5,7 @@ package com.autonomousapps.tasks
 import com.autonomousapps.TASK_GROUP_DEP
 import com.autonomousapps.internal.*
 import com.autonomousapps.internal.asm.ClassReader
+import com.autonomousapps.internal.instrumentation.InstrumentationBuildService
 import com.autonomousapps.internal.utils.fromJsonList
 import com.autonomousapps.internal.utils.getLogger
 import com.autonomousapps.internal.utils.toJson
@@ -17,6 +18,7 @@ import kotlinx.metadata.jvm.KotlinClassMetadata
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
@@ -36,7 +38,7 @@ import javax.inject.Inject
  */
 @CacheableTask
 abstract class InlineMemberExtractionTask @Inject constructor(
-    private val workerExecutor: WorkerExecutor
+  private val workerExecutor: WorkerExecutor
 ) : DefaultTask() {
 
   init {
@@ -61,6 +63,9 @@ abstract class InlineMemberExtractionTask @Inject constructor(
   @get:OutputFile
   abstract val inlineUsageReport: RegularFileProperty
 
+  @get:Internal
+  abstract val instrumentationProvider: Property<InstrumentationBuildService>
+
   @TaskAction
   fun action() {
     workerExecutor.noIsolation().submit(InlineMemberExtractionWorkAction::class.java) {
@@ -68,6 +73,7 @@ abstract class InlineMemberExtractionTask @Inject constructor(
       imports.set(this@InlineMemberExtractionTask.imports)
       inlineMembersReport.set(this@InlineMemberExtractionTask.inlineMembersReport)
       inlineUsageReport.set(this@InlineMemberExtractionTask.inlineUsageReport)
+      instrumentationProvider.set(this@InlineMemberExtractionTask.instrumentationProvider)
     }
   }
 }
@@ -77,6 +83,7 @@ interface InlineMemberExtractionParameters : WorkParameters {
   val imports: RegularFileProperty
   val inlineMembersReport: RegularFileProperty
   val inlineUsageReport: RegularFileProperty
+  val instrumentationProvider: Property<InstrumentationBuildService>
 }
 
 abstract class InlineMemberExtractionWorkAction : WorkAction<InlineMemberExtractionParameters> {
@@ -97,7 +104,7 @@ abstract class InlineMemberExtractionWorkAction : WorkAction<InlineMemberExtract
 
     // In principle, there may not be any Kotlin source, although a current implementation detail is that "imports"
     // will never be null, only empty. Making this null-safe seems harmless enough, however.
-    val usedComponents = imports?.let { InlineDependenciesFinder(logger, artifacts, it).find() } ?: emptySet()
+    val usedComponents = imports?.let { InlineDependenciesFinder(parameters.instrumentationProvider, logger, artifacts, it).find() } ?: emptySet()
 
     logger.debug("Inline usage:\n${usedComponents.toPrettyString()}")
     inlineUsageReportFile.writeText(usedComponents.toJson())
@@ -111,9 +118,10 @@ abstract class InlineMemberExtractionWorkAction : WorkAction<InlineMemberExtract
 }
 
 internal class InlineDependenciesFinder(
-    private val logger: Logger,
-    private val artifacts: List<Artifact>,
-    private val actualImports: Set<String>
+  private val instrumentationProvider: Property<InstrumentationBuildService>,
+  private val logger: Logger,
+  private val artifacts: List<Artifact>,
+  private val actualImports: Set<String>
 ) {
 
   /**
@@ -130,17 +138,17 @@ internal class InlineDependenciesFinder(
   // from the upstream bytecode. Therefore "candidates" (not necessarily used)
   private fun findInlineImportCandidates(): Set<ComponentWithInlineMembers> {
     return artifacts
-        .map { artifact ->
-          artifact to InlineMemberFinder(logger, ZipFile(artifact.file)).find().toSortedSet()
-        }.filterNot { (_, imports) ->
-          imports.isEmpty()
-        }.map { (artifact, imports) ->
-          ComponentWithInlineMembers(artifact.dependency, imports)
-        }.toSortedSet()
+      .map { artifact ->
+        artifact to InlineMemberFinder(instrumentationProvider, logger, ZipFile(artifact.file)).find().toSortedSet()
+      }.filterNot { (_, imports) ->
+        imports.isEmpty()
+      }.map { (artifact, imports) ->
+        ComponentWithInlineMembers(artifact.dependency, imports)
+      }.toSortedSet()
   }
 
   private fun findUsedInlineImports(
-      inlineImportCandidates: Set<ComponentWithInlineMembers>
+    inlineImportCandidates: Set<ComponentWithInlineMembers>
   ): Set<Dependency> {
     return actualImports.flatMap { actualImport ->
       findUsedInlineImports(actualImport, inlineImportCandidates)
@@ -153,7 +161,7 @@ internal class InlineDependenciesFinder(
    * * `com.myapp.BuildConfig.*`
    */
   private fun findUsedInlineImports(
-      actualImport: String, constantImportCandidates: Set<ComponentWithInlineMembers>
+    actualImport: String, constantImportCandidates: Set<ComponentWithInlineMembers>
   ): List<Dependency> {
     // TODO@tsr it's a little disturbing there can be multiple matches. An issue with this naive algorithm.
     // TODO@tsr I need to be more intelligent in source parsing. Look at actual identifiers being used and associate those with their star-imports
@@ -169,8 +177,9 @@ internal class InlineDependenciesFinder(
  * Use to find inline members (functions or properties).
  */
 internal class InlineMemberFinder(
-    private val logger: Logger,
-    private val zipFile: ZipFile
+  private val instrumentationProvider: Property<InstrumentationBuildService>,
+  private val logger: Logger,
+  private val zipFile: ZipFile
 ) {
 
   /**
@@ -185,6 +194,12 @@ internal class InlineMemberFinder(
    * "org.jetbrains.kotlin:kotlin-stdlib-jdk7" module.
    */
   fun find(): List<String> {
+    val instrumentation = instrumentationProvider.get()
+    val alreadyFoundInlineMembers: List<String>? = instrumentation.inlineMembers[zipFile.name]
+    if (alreadyFoundInlineMembers != null) {
+      return alreadyFoundInlineMembers
+    }
+
     val entries = zipFile.entries().toList()
     // Only look at jars that have actual Kotlin classes in them
     if (entries.none { it.name.endsWith(".kotlin_module") }) {
@@ -192,50 +207,52 @@ internal class InlineMemberFinder(
     }
 
     return entries
-        .filter { it.name.endsWith(".class") }
-        .flatMap { entry ->
-          // TODO an entry with `META-INF/proguard/androidx-annotations.pro`
-          val classReader = zipFile.getInputStream(entry).use { ClassReader(it.readBytes()) }
-          val metadataVisitor = KotlinMetadataVisitor(logger)
-          classReader.accept(metadataVisitor, 0)
+      .filter { it.name.endsWith(".class") }
+      .flatMap { entry ->
+        // TODO an entry with `META-INF/proguard/androidx-annotations.pro`
+        val classReader = zipFile.getInputStream(entry).use { ClassReader(it.readBytes()) }
+        val metadataVisitor = KotlinMetadataVisitor(logger)
+        classReader.accept(metadataVisitor, 0)
 
-          val inlineMembers = metadataVisitor.builder?.let { header ->
-            when (val metadata = KotlinClassMetadata.read(header.build())) {
-              is KotlinClassMetadata.Class -> inlineMembers(metadata.toKmClass())
-              is KotlinClassMetadata.FileFacade -> inlineMembers(metadata.toKmPackage())
-              is KotlinClassMetadata.MultiFileClassPart -> inlineMembers(metadata.toKmPackage())
-              is KotlinClassMetadata.SyntheticClass -> {
-                logger.debug("Ignoring SyntheticClass $entry")
-                emptyList()
-              }
-              is KotlinClassMetadata.MultiFileClassFacade -> {
-                logger.debug("Ignoring MultiFileClassFacade $entry")
-                emptyList()
-              }
-              is KotlinClassMetadata.Unknown -> {
-                logger.debug("Ignoring Unknown $entry")
-                emptyList()
-              }
-              null -> {
-                logger.debug("Ignoring null $entry")
-                emptyList()
-              }
+        val inlineMembers = metadataVisitor.builder?.let { header ->
+          when (val metadata = KotlinClassMetadata.read(header.build())) {
+            is KotlinClassMetadata.Class -> inlineMembers(metadata.toKmClass())
+            is KotlinClassMetadata.FileFacade -> inlineMembers(metadata.toKmPackage())
+            is KotlinClassMetadata.MultiFileClassPart -> inlineMembers(metadata.toKmPackage())
+            is KotlinClassMetadata.SyntheticClass -> {
+              logger.debug("Ignoring SyntheticClass $entry")
+              emptyList()
             }
-          } ?: emptyList()
-
-          if (inlineMembers.isNotEmpty()) {
-            if (entry.name.contains("/")) {
-              // entry is in a package
-              val pn = entry.name.substring(0, entry.name.lastIndexOf("/")).replace("/", ".")
-              listOf("$pn.*") + inlineMembers.map { name -> "$pn.$name" }
-            } else {
-              // entry is in root; no package
-              inlineMembers
+            is KotlinClassMetadata.MultiFileClassFacade -> {
+              logger.debug("Ignoring MultiFileClassFacade $entry")
+              emptyList()
             }
-          } else {
-            emptyList()
+            is KotlinClassMetadata.Unknown -> {
+              logger.debug("Ignoring Unknown $entry")
+              emptyList()
+            }
+            null -> {
+              logger.debug("Ignoring null $entry")
+              emptyList()
+            }
           }
+        } ?: emptyList()
+
+        if (inlineMembers.isNotEmpty()) {
+          if (entry.name.contains("/")) {
+            // entry is in a package
+            val pn = entry.name.substring(0, entry.name.lastIndexOf("/")).replace("/", ".")
+            listOf("$pn.*") + inlineMembers.map { name -> "$pn.$name" }
+          } else {
+            // entry is in root; no package
+            inlineMembers
+          }
+        } else {
+          emptyList()
         }
+      }.also {
+        instrumentation.inlineMembers.putIfAbsent(zipFile.name, it)
+      }
   }
 
   private fun inlineMembers(kmDeclaration: KmDeclarationContainer): List<String> {
@@ -244,13 +261,13 @@ internal class InlineMemberFinder(
 
   private fun inlineFunctions(functions: List<KmFunction>): List<String> {
     return functions
-        .filter { Flag.Function.IS_INLINE(it.flags) }
-        .map { it.name }
+      .filter { Flag.Function.IS_INLINE(it.flags) }
+      .map { it.name }
   }
 
   private fun inlineProperties(properties: List<KmProperty>): List<String> {
     return properties
-        .filter { Flag.PropertyAccessor.IS_INLINE(it.flags) }
-        .map { it.name }
+      .filter { Flag.PropertyAccessor.IS_INLINE(it.flags) }
+      .map { it.name }
   }
 }

--- a/src/test/kotlin/com/autonomousapps/InlineMemberFinderTest.kt
+++ b/src/test/kotlin/com/autonomousapps/InlineMemberFinderTest.kt
@@ -1,8 +1,11 @@
 package com.autonomousapps
 
 import com.autonomousapps.internal.utils.getLogger
+import com.autonomousapps.stubs.StubInMemoryCache
+import com.autonomousapps.stubs.StubProperty
 import com.autonomousapps.tasks.InlineMemberFinder
 import com.autonomousapps.utils.fileFromResource
+import org.gradle.api.provider.Property
 import org.junit.Test
 import java.util.zip.ZipFile
 
@@ -12,10 +15,11 @@ class InlineMemberFinderTest {
 
   @Test fun `stdlib-jdk7 has two inline members`() {
     // Given
+    val cacheProperty: Property<StubInMemoryCache> = StubProperty(StubInMemoryCache())
     val stdlib = ZipFile(fileFromResource("kotlin-stdlib-jdk7-1.3.60.jar"))
 
     // When
-    val actual = InlineMemberFinder(logger, stdlib).find()
+    val actual = InlineMemberFinder(cacheProperty, logger, stdlib).find()
 
     // Then
     val expected = listOf("kotlin.jdk7.*", "kotlin.jdk7.use")
@@ -24,10 +28,11 @@ class InlineMemberFinderTest {
 
   @Test fun `annotations has no inline members`() {
     // Given
+    val cacheProperty: Property<StubInMemoryCache> = StubProperty(StubInMemoryCache())
     val annotations = ZipFile(fileFromResource("annotations-13.0.jar"))
 
     // When
-    val actual = InlineMemberFinder(logger, annotations).find()
+    val actual = InlineMemberFinder(cacheProperty, logger, annotations).find()
 
     // Then
     val expected = emptyList<String>()
@@ -36,10 +41,11 @@ class InlineMemberFinderTest {
 
   @Test fun `java file has no inline members`() {
     // Given
+    val cacheProperty: Property<StubInMemoryCache> = StubProperty(StubInMemoryCache())
     val annotations = ZipFile(fileFromResource("guava-28.0-jre.jar"))
 
     // When
-    val actual = InlineMemberFinder(logger, annotations).find()
+    val actual = InlineMemberFinder(cacheProperty, logger, annotations).find()
 
     // Then
     val expected = emptyList<String>()

--- a/src/test/kotlin/com/autonomousapps/internal/ArtifactToComponentTransformerTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/ArtifactToComponentTransformerTest.kt
@@ -1,6 +1,7 @@
 package com.autonomousapps.internal
 
 import com.autonomousapps.fixtures.SeattleShelterDbModule
+import com.autonomousapps.stubs.StubInMemoryCache
 import com.nhaarman.mockitokotlin2.mock
 import org.junit.Test
 
@@ -16,9 +17,10 @@ class ArtifactToComponentTransformerTest {
   @Test fun `can transform artifacts to components`() {
     // Given
     val transformer = ArtifactToComponentTransformer(
-        fixture.mockConfiguration,
-        fixture.givenArtifacts,
-        mock()
+      fixture.mockConfiguration,
+      fixture.givenArtifacts,
+      mock(),
+      StubInMemoryCache()
     )
 
     // When

--- a/src/test/kotlin/com/autonomousapps/stubs/StubInMemoryCache.kt
+++ b/src/test/kotlin/com/autonomousapps/stubs/StubInMemoryCache.kt
@@ -1,0 +1,13 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.autonomousapps.stubs
+
+import com.autonomousapps.services.InMemoryCache
+import org.gradle.api.services.BuildServiceParameters
+
+class StubInMemoryCache : InMemoryCache() {
+  override fun getParameters(): BuildServiceParameters.None {
+    error("There are no parameters")
+  }
+
+}

--- a/src/test/kotlin/com/autonomousapps/stubs/StubProperty.kt
+++ b/src/test/kotlin/com/autonomousapps/stubs/StubProperty.kt
@@ -1,0 +1,80 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.autonomousapps.stubs
+
+import org.gradle.api.Transformer
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+
+class StubProperty<T>(
+  private val thing: T
+) : Property<T> {
+
+  override fun get(): T {
+    return thing
+  }
+
+  override fun finalizeValueOnRead() {
+    TODO("Not yet implemented")
+  }
+
+  override fun disallowChanges() {
+    TODO("Not yet implemented")
+  }
+
+  override fun getOrElse(defaultValue: T): T {
+    TODO("Not yet implemented")
+  }
+
+  override fun value(value: T?): Property<T> {
+    TODO("Not yet implemented")
+  }
+
+  override fun value(provider: Provider<out T>): Property<T> {
+    TODO("Not yet implemented")
+  }
+
+  override fun getOrNull(): T? {
+    TODO("Not yet implemented")
+  }
+
+  override fun set(value: T?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun set(provider: Provider<out T>) {
+    TODO("Not yet implemented")
+  }
+
+  override fun isPresent(): Boolean {
+    TODO("Not yet implemented")
+  }
+
+  override fun convention(value: T?): Property<T> {
+    TODO("Not yet implemented")
+  }
+
+  override fun convention(valueProvider: Provider<out T>): Property<T> {
+    TODO("Not yet implemented")
+  }
+
+  override fun <S : Any?> map(transformer: Transformer<out S, in T>): Provider<S> {
+    TODO("Not yet implemented")
+  }
+
+  override fun finalizeValue() {
+    TODO("Not yet implemented")
+  }
+
+  override fun <S : Any?> flatMap(transformer: Transformer<out Provider<out S>, in T>): Provider<S> {
+    TODO("Not yet implemented")
+  }
+
+  override fun orElse(value: T): Provider<T> {
+    TODO("Not yet implemented")
+  }
+
+  override fun orElse(provider: Provider<out T>): Provider<T> {
+    TODO("Not yet implemented")
+  }
+}


### PR DESCRIPTION
This saves us from repeatedly re-analyzing the same bytecode.