### PR TITLE
Renamed 'generic' stuff as 'general' to reflect what it actually does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Dependency Analysis Plugin Changelog
 
+# Version 0.42.0 (unreleased)
+* [Fixed] Detects usages that only appear in a generic context.
+
 # Version 0.41.0
 * [New] Supports the concept of "facade" dependencies. See the new wiki for details.
 * Post-processing support has been improved. See the new wiki for details.

--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -23,7 +23,7 @@ internal class OutputPaths(private val project: Project, variantName: String) {
   val constantUsagePath = layout("${intermediatesDir}/constant-usage.json")
   val androidResToSourceUsagePath = layout("${intermediatesDir}/android-res-by-source-usage.json")
   val androidResToResUsagePath = layout("${intermediatesDir}/android-res-by-res-usage.json")
-  val genericsUsagePath = layout("${intermediatesDir}/generics-usage.json")
+  val generalUsagePath = layout("${intermediatesDir}/general-usage.json")
   val manifestPackagesPath = layout("${intermediatesDir}/manifest-packages.json")
   val allComponentsPath = layout("${intermediatesDir}/all-components-with-transitives.json")
   val unusedComponentsPath = layout("${intermediatesDir}/unused-components-with-transitives.json")

--- a/src/main/kotlin/com/autonomousapps/tasks/DependencyMisuseTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DependencyMisuseTask.kt
@@ -57,7 +57,7 @@ abstract class DependencyMisuseTask : DefaultTask() {
 
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
-  abstract val usedGenerics: RegularFileProperty
+  abstract val usedGenerally: RegularFileProperty
 
   @get:PathSensitive(PathSensitivity.NONE)
   @get:Optional
@@ -101,7 +101,7 @@ abstract class DependencyMisuseTask : DefaultTask() {
       usedClasses = usedClasses.readLines(),
       usedInlineDependencies = usedInlineDependencies.fromJsonSet(),
       usedConstantDependencies = usedConstantDependencies.fromJsonSet(),
-      usedGenerics = usedGenerics.fromJsonSet(),
+      usedGenerally = usedGenerally.fromJsonSet(),
       manifests = manifests.fromNullableJsonSet(),
       usedAndroidResBySourceDependencies = usedAndroidResBySourceDependencies.fromNullableJsonSet(),
       usedAndroidResByResDependencies = usedAndroidResByResDependencies.fromNullableJsonSet(),
@@ -121,7 +121,7 @@ internal class MisusedDependencyDetector(
   private val usedClasses: List<String>,
   private val usedInlineDependencies: Set<Dependency>,
   private val usedConstantDependencies: Set<Dependency>,
-  private val usedGenerics: Set<Dependency>,
+  private val usedGenerally: Set<Dependency>,
   private val manifests: Set<Manifest>?,
   private val usedAndroidResBySourceDependencies: Set<Dependency>?,
   private val usedAndroidResByResDependencies: Set<AndroidPublicRes>?,
@@ -172,8 +172,8 @@ internal class MisusedDependencyDetector(
           && component.hasNoAndroidResByResUsages()
           // Exclude modules that have constant usages
           && component.hasNoConstantUsages()
-          // Exclude modules that have types used in a generic context
-          && component.hasNoGenericsUsages()
+          // Exclude modules that have types used in a general context
+          && component.hasNoGeneralUsages()
           // Exclude modules that appear in the manifest (e.g., they supply Android components like
           // ContentProviders)
           && component.hasNoManifestMatches()
@@ -230,8 +230,8 @@ internal class MisusedDependencyDetector(
     return usedConstantDependencies.none { it == dependency }
   }
 
-  private fun Component.hasNoGenericsUsages(): Boolean {
-    return usedGenerics.none { it == dependency }
+  private fun Component.hasNoGeneralUsages(): Boolean {
+    return usedGenerally.none { it == dependency }
   }
 
   /**

--- a/src/main/kotlin/com/autonomousapps/tasks/GeneralUsageDetectionTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GeneralUsageDetectionTask.kt
@@ -17,16 +17,17 @@ import org.gradle.workers.WorkerExecutor
 import javax.inject.Inject
 
 /**
- * TODO in fact this task looks at all imports, not just those that provide generics. Finding JUST
- * generics would require elaborating on the antlr grammar, which will take a while.
+ * This detects _any_ usage, based on presence of imports that can be associated with dependencies.
+ * It is sort of a catch-all / edge-case detector.
  */
-abstract class GenericsUsageDetectionTask @Inject constructor(
+abstract class GeneralUsageDetectionTask @Inject constructor(
   private val workerExecutor: WorkerExecutor
 ) : DefaultTask() {
 
   init {
     group = TASK_GROUP_DEP
-    description = "Produces a report of types, from other components, that have been used in a generic context"
+    description =
+      "Produces a report of dependencies that are used based on the heuristic that import statements appear in project source"
   }
 
   /**
@@ -50,21 +51,21 @@ abstract class GenericsUsageDetectionTask @Inject constructor(
   abstract val output: RegularFileProperty
 
   @TaskAction fun action() {
-    workerExecutor.noIsolation().submit(GenericsUsageDetectionWorkAction::class.java) {
-      components.set(this@GenericsUsageDetectionTask.components)
-      importsFile.set(this@GenericsUsageDetectionTask.imports)
-      output.set(this@GenericsUsageDetectionTask.output)
+    workerExecutor.noIsolation().submit(GeneralUsageDetectionWorkAction::class.java) {
+      components.set(this@GeneralUsageDetectionTask.components)
+      importsFile.set(this@GeneralUsageDetectionTask.imports)
+      output.set(this@GeneralUsageDetectionTask.output)
     }
   }
 }
 
-interface GenericsUsageDetectionParameters : WorkParameters {
+interface GeneralUsageDetectionParameters : WorkParameters {
   val components: RegularFileProperty
   val importsFile: RegularFileProperty
   val output: RegularFileProperty
 }
 
-abstract class GenericsUsageDetectionWorkAction : WorkAction<GenericsUsageDetectionParameters> {
+abstract class GeneralUsageDetectionWorkAction : WorkAction<GeneralUsageDetectionParameters> {
 
   private val logger = getLogger<ConstantUsageDetectionTask>()
 

--- a/src/test/kotlin/com/autonomousapps/tasks/MisusedDependencyDetectorTest.kt
+++ b/src/test/kotlin/com/autonomousapps/tasks/MisusedDependencyDetectorTest.kt
@@ -59,7 +59,7 @@ class MisusedDependencyDetectorTest {
       usedClasses = usedClasses,
       usedInlineDependencies = usedInlineDependencies,
       usedConstantDependencies = emptySet(),
-      usedGenerics = emptySet(),
+      usedGenerally = emptySet(),
       manifests = null,
       usedAndroidResBySourceDependencies = null,
       usedAndroidResByResDependencies = null,


### PR DESCRIPTION
This heuristic actually seems correct and I see no need to complicate it. If an import statement says com.mycompany.foo.Bar, and a dependency has class com.mycompany.foo.Bar, how else to interpret the situation than that the producer uses the consumer?