### PR TITLE
Support ABI exclusions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,6 +110,12 @@ dependencies {
   testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0") {
     because("Writing manual stubs for Configuration seems stupid")
   }
+  testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.2.8") {
+    because("Easy in-memory compilation as a means to get compiled Kotlin class files")
+  }
+  testImplementation("com.squareup.okio:okio:2.6.0") {
+    because("Easy IO APIs")
+  }
   val truthVersion = "1.0.1"
   testImplementation("com.google.truth:truth:$truthVersion") {
     because("Groovy's == behavior on Comparable classes is beyond stupid")

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/AbiExclusionsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/AbiExclusionsSpec.groovy
@@ -1,0 +1,26 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.AbiExclusionsProject
+import spock.lang.Unroll
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class AbiExclusionsSpec extends AbstractJvmSpec {
+
+  @Unroll
+  def "abi exclusion smoke test (#gradleVersion)"() {
+    given:
+    def project = new AbiExclusionsProject()
+    jvmProject = project.jvmProject
+
+    when:
+    build(gradleVersion, jvmProject.rootDir, ':buildHealth')
+
+    then:
+    assertThat(jvmProject.adviceForFirstProject()).containsExactlyElementsIn(project.expectedAdvice)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiExclusionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiExclusionsProject.groovy
@@ -1,0 +1,61 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.advice.Advice
+import com.autonomousapps.fixtures.jvm.JvmProject
+import com.autonomousapps.fixtures.jvm.Plugin
+import com.autonomousapps.fixtures.jvm.Source
+import com.autonomousapps.fixtures.jvm.SourceType
+
+import static com.autonomousapps.fixtures.jvm.Dependency.conscryptUber
+import static com.autonomousapps.fixtures.jvm.Dependency.okHttp
+
+class AbiExclusionsProject {
+
+  final JvmProject jvmProject
+
+  AbiExclusionsProject() {
+    this.jvmProject = build()
+  }
+
+  private JvmProject build() {
+    def builder = new JvmProject.Builder()
+
+    def plugins = [Plugin.javaLibraryPlugin()]
+
+    builder.rootAdditions = """\
+      dependencyAnalysis {
+        abi {
+          exclusions {
+            excludeClasses("com\\\\.example\\\\.Main")
+          }
+        }
+      }
+    """.stripIndent()
+
+    def dependencies = [
+      okHttp("implementation")
+    ]
+    def source = new Source(
+      SourceType.JAVA, "Main", "com/example",
+      """\
+        package com.example;
+        
+        import okhttp3.OkHttpClient;
+
+        public class Main {
+          public OkHttpClient ok() {
+            return new OkHttpClient.Builder().build();
+          }
+        }
+      """.stripIndent()
+    )
+
+    builder.addSubproject(plugins, dependencies, [source], 'main', '')
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  final List<Advice> expectedAdvice = AbiExclusionsAdvice.expectedAdvice
+}

--- a/src/functionalTest/kotlin/com/autonomousapps/jvm/projects/AbiExclusionsAdvice.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/jvm/projects/AbiExclusionsAdvice.kt
@@ -1,0 +1,7 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.advice.Advice
+
+object AbiExclusionsAdvice {
+  val expectedAdvice = listOf<Advice>()
+}

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
@@ -6,8 +6,10 @@ import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
+import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.setProperty
+import org.intellij.lang.annotations.Language
 import java.io.Serializable
 import javax.inject.Inject
 
@@ -36,7 +38,9 @@ open class DependencyAnalysisExtension(objects: ObjectFactory) : AbstractExtensi
     it.convention(true)
   }
 
-  internal val issueHandler: IssueHandler = objects.newInstance(IssueHandler::class.java)
+  internal val issueHandler: IssueHandler = objects.newInstance(IssueHandler::class)
+
+  internal val abiHandler: AbiHandler = objects.newInstance(AbiHandler::class)
 
   internal fun getFallbacks() = theVariants.get() + defaultVariants
 
@@ -91,6 +95,71 @@ open class DependencyAnalysisExtension(objects: ObjectFactory) : AbstractExtensi
   fun issues(action: Action<IssueHandler>) {
     action.execute(issueHandler)
   }
+
+  fun abi(action: Action<AbiHandler>) {
+    action.execute(abiHandler)
+  }
+}
+
+/**
+ * Initial goal:
+ * ```
+ * abi {
+ *   exclusions {
+ *     ignoreSubPackage("internal")
+ *     ignoreInternalPackages()
+ *     ignoreGeneratedCode()
+ *     excludeAnnotations(".*\\.Generated")
+ *     excludeClasses(".*\\.internal\\..*")
+ *   }
+ * }
+ * ```
+ */
+open class AbiHandler @Inject constructor(objects: ObjectFactory) {
+
+  internal val exclusionsHandler: ExclusionsHandler = objects.newInstance(ExclusionsHandler::class)
+
+  fun exclusions(action: Action<ExclusionsHandler>) {
+    action.execute(exclusionsHandler)
+  }
+}
+
+abstract class ExclusionsHandler @Inject constructor(objects: ObjectFactory) {
+
+  internal val classExclusions = objects.setProperty<String>().convention(emptySet())
+  internal val annotationExclusions = objects.setProperty<String>().convention(emptySet())
+  internal val pathExclusions = objects.setProperty<String>().convention(emptySet())
+
+  fun ignoreInternalPackages() {
+    ignoreSubPackage("internal")
+  }
+
+  fun ignoreSubPackage(packageFragment: String) {
+    excludeClasses("(.*\\.)?$packageFragment(\\..*)?")
+  }
+
+  /**
+   * Best-effort attempts to ignore generated code by ignoring any bytecode in classes annotated
+   * with an annotation ending in `Generated`. It's important to note that the standard
+   * `javax.annotation.Generated` (or its JDK9+ successor) does _not_ work with this due to it
+   * using `SOURCE` retention. It's recommended to use your own `Generated` annotation.
+   */
+  fun ignoreGeneratedCode() {
+    excludeAnnotations(".*\\.Generated")
+  }
+
+  fun excludeClasses(@Language("RegExp") vararg classRegexes: String) {
+    classExclusions.addAll(*classRegexes)
+  }
+
+  fun excludeAnnotations(@Language("RegExp") vararg annotationRegexes: String) {
+    annotationExclusions.addAll(*annotationRegexes)
+  }
+
+  // TODO Excluded for now but left as a toe-hold for future use
+//  fun excludePaths(@Language("RegExp") vararg pathRegexes: String) {
+//    pathExclusions.addAll(*pathRegexes)
+//  }
 }
 
 /**

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
@@ -237,11 +237,13 @@ internal class AndroidLibAnalyzer(
     }
 
   override fun registerAbiAnalysisTask(
-    dependencyReportTask: TaskProvider<DependencyReportTask>
+    dependencyReportTask: TaskProvider<DependencyReportTask>,
+    abiExclusions: Provider<String>
   ): TaskProvider<AbiAnalysisTask> =
     project.tasks.register<AbiAnalysisTask>("abiAnalysis$variantNameCapitalized") {
       jar.set(getBundleTaskOutput())
       dependencies.set(dependencyReportTask.flatMap { it.allComponentsReport })
+      exclusions.set(abiExclusions)
 
       output.set(outputPaths.abiAnalysisPath)
       abiDump.set(outputPaths.abiDumpPath)

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
@@ -71,7 +71,8 @@ internal interface DependencyAnalyzer<T : ClassAnalysisTask> {
    * no meaningful ABI.
    */
   fun registerAbiAnalysisTask(
-    dependencyReportTask: TaskProvider<DependencyReportTask>
+    dependencyReportTask: TaskProvider<DependencyReportTask>,
+    abiExclusions: Provider<String>
   ): TaskProvider<AbiAnalysisTask>? = null
 }
 

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -150,7 +150,10 @@ internal class KotlinJvmAppAnalyzer(project: Project, sourceSet: JbKotlinSourceS
 
 internal class KotlinJvmLibAnalyzer(project: Project, sourceSet: JbKotlinSourceSet)
   : KotlinJvmAnalyzer(project, sourceSet) {
-  override fun registerAbiAnalysisTask(dependencyReportTask: TaskProvider<DependencyReportTask>) =
+  override fun registerAbiAnalysisTask(
+    dependencyReportTask: TaskProvider<DependencyReportTask>,
+    abiExclusions: Provider<String>
+  ) =
     project.tasks.register<AbiAnalysisTask>("abiAnalysis$variantNameCapitalized") {
       jar.set(getJarTask().flatMap { it.archiveFile })
       dependencies.set(dependencyReportTask.flatMap { it.allComponentsReport })

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -126,10 +126,14 @@ internal class JavaAppAnalyzer(project: Project, sourceSet: SourceSet)
 internal class JavaLibAnalyzer(project: Project, sourceSet: SourceSet)
   : JvmAnalyzer(project, JavaSourceSet(sourceSet)) {
 
-  override fun registerAbiAnalysisTask(dependencyReportTask: TaskProvider<DependencyReportTask>) =
+  override fun registerAbiAnalysisTask(
+    dependencyReportTask: TaskProvider<DependencyReportTask>,
+    abiExclusions: Provider<String>
+  ): TaskProvider<AbiAnalysisTask>? =
     project.tasks.register<AbiAnalysisTask>("abiAnalysis$variantNameCapitalized") {
       jar.set(getJarTask().flatMap { it.archiveFile })
       dependencies.set(dependencyReportTask.flatMap { it.allComponentsReport })
+      exclusions.set(abiExclusions)
 
       output.set(outputPaths.abiAnalysisPath)
       abiDump.set(outputPaths.abiDumpPath)

--- a/src/main/kotlin/com/autonomousapps/internal/kotlin/abiDependencies.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/kotlin/abiDependencies.kt
@@ -2,6 +2,7 @@ package com.autonomousapps.internal.kotlin
 
 import com.autonomousapps.internal.Component
 import com.autonomousapps.advice.Dependency
+import com.autonomousapps.internal.AbiExclusions
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.internal.utils.DESC_REGEX
 import com.autonomousapps.internal.utils.allItems
@@ -10,10 +11,19 @@ import java.util.jar.JarFile
 
 /**
  * Given a jar and a list of its dependencies (as [Component]s), return the set of [Dependency]s that represents this
- * jar's ABI (or public API). [abiDumpFile] is used only to write a rich ABI representation, and may be omitted.
+ * jar's ABI (or public API).
+ *
+ * [exclusions] indicate exclusion rules (generated code, etc).
+ *
+ * [abiDumpFile] is used only to write a rich ABI representation, and may be omitted.
  */
-fun abiDependencies(jarFile: File, jarDependencies: List<Component>, abiDumpFile: File? = null): Set<Dependency> =
-    getBinaryAPI(JarFile(jarFile)).filterOutNonPublic()
+internal fun abiDependencies(
+  jarFile: File,
+  jarDependencies: List<Component>,
+  exclusions: AbiExclusions,
+  abiDumpFile: File? = null
+): Set<Dependency> =
+    getBinaryAPI(JarFile(jarFile)).filterOutNonPublic(exclusions)
         .also { publicApi ->
           abiDumpFile?.let { file ->
             file.bufferedWriter().use { writer -> publicApi.dump(writer) }

--- a/src/main/kotlin/com/autonomousapps/internal/kotlin/asmUtils.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/kotlin/asmUtils.kt
@@ -35,8 +35,11 @@ data class ClassBinarySignature(
     val memberSignatures: List<MemberBinarySignature>,
     val access: AccessFlags,
     val isEffectivelyPublic: Boolean,
-    val isNotUsedWhenEmpty: Boolean
+    val isNotUsedWhenEmpty: Boolean,
+    val annotations: List<String>,
+    val sourceFileLocation: String?
 ) {
+  val canonicalName = name.replace("/", ".")
   val signature: String
     get() = "${access.getModifierString()} class $name" + if (supertypes.isEmpty()) "" else " : ${supertypes.joinToString()}"
 }

--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -421,3 +421,29 @@ internal data class ConsoleReport(
     }
   }
 }
+
+internal data class AbiExclusions(
+  val annotationExclusions: Set<String> = emptySet(),
+  val classExclusions: Set<String> = emptySet(),
+  val pathExclusions: Set<String> = emptySet()
+) {
+
+  @Transient
+  private val annotationRegexes = annotationExclusions.mapToSet(String::toRegex)
+
+  @Transient
+  private val classRegexes = classExclusions.mapToSet(String::toRegex)
+
+  @Transient
+  private val pathRegexes = pathExclusions.mapToSet(String::toRegex)
+
+  fun excludesAnnotation(fqcn: String): Boolean = annotationRegexes.any { it.containsMatchIn(fqcn) }
+
+  fun excludesClass(fqcn: String) = classRegexes.any { it.containsMatchIn(fqcn) }
+
+  fun excludesPath(path: String) = pathRegexes.any { it.containsMatchIn(path) }
+
+  companion object {
+    val NONE = AbiExclusions()
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -21,8 +21,8 @@ internal fun <T> Iterable<T>.filterNoneMatchingSorted(unwanted: Iterable<T>): Tr
   }
 }
 
-internal inline fun <T, R> Iterable<T>.mapToSet(transform: (T) -> R): HashSet<R> {
-  return mapTo(HashSet(collectionSizeOrDefault(10)), transform)
+internal inline fun <T, R> Iterable<T>.mapToSet(transform: (T) -> R): LinkedHashSet<R> {
+  return mapTo(LinkedHashSet(collectionSizeOrDefault(10)), transform)
 }
 
 internal inline fun <T, R> Iterable<T>.mapToOrderedSet(transform: (T) -> R): TreeSet<R> {

--- a/src/test/kotlin/com/autonomousapps/internal/AbiDependenciesTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/AbiDependenciesTest.kt
@@ -1,0 +1,121 @@
+package com.autonomousapps.internal
+
+import com.autonomousapps.advice.Dependency
+import com.autonomousapps.internal.kotlin.abiDependencies
+import com.autonomousapps.internal.utils.mapToSet
+import com.google.common.truth.Truth.assertThat
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
+import com.tschuchort.compiletesting.SourceFile
+import okio.buffer
+import okio.sink
+import okio.source
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.FileOutputStream
+import java.util.jar.Attributes
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+
+class AbiDependenciesTest {
+
+  @get:Rule
+  val temporaryFolder = TemporaryFolder()
+
+  private val jarDependencies = listOf(
+    Component(
+      dependency = Dependency("junit:junit"),
+      isTransitive = false,
+      isCompileOnlyAnnotations = false,
+      classes = setOf("org.junit.rules.TemporaryFolder")
+    )
+  )
+
+  private val dependencies = jarDependencies.mapToSet { it.dependency }
+
+  private val simpleTestFile = SourceFile.kotlin("Test.kt", """
+        package test
+ 
+        import org.junit.Ignore
+        import org.junit.rules.TemporaryFolder
+        
+        @Ignore
+        class TestClass {
+          fun newTemporaryFolder(): TemporaryFolder {
+            error("Not real code")
+          }
+        }
+      """)
+
+  @Test
+  fun noExclusions() {
+    val jar = compile(simpleTestFile)
+
+    val abiDependencies = abiDependencies(jar, jarDependencies, AbiExclusions.NONE)
+    assertThat(abiDependencies).isEqualTo(dependencies)
+  }
+
+  @Test
+  fun excludeAnnotation() {
+    val jar = compile(simpleTestFile)
+
+    val abiDependencies = abiDependencies(
+      jar,
+      jarDependencies,
+      AbiExclusions(annotationExclusions = setOf(".*\\.Ignore"))
+    )
+    assertThat(abiDependencies).isEmpty()
+  }
+
+  @Test
+  fun excludePackage() {
+    val jar = compile(simpleTestFile)
+
+    val abiDependencies = abiDependencies(
+      jar,
+      jarDependencies,
+      AbiExclusions(classExclusions = setOf("(.*\\.)?test(\\..*)?"))
+    )
+    assertThat(abiDependencies).isEmpty()
+  }
+
+  private fun compile(vararg sourceFiles: SourceFile): File {
+    val outputDir = temporaryFolder.newFolder()
+    val result = KotlinCompilation().apply {
+      sources = sourceFiles.toList()
+      inheritClassPath = true
+      workingDir = outputDir
+      verbose = false
+    }.compile()
+
+    check(result.exitCode == ExitCode.OK) {
+      "Compilation failed"
+    }
+
+    val classesDir = outputDir.resolve("classes")
+    val compiledFiles = result.compiledClassAndResourceFiles
+    val manifest = Manifest()
+    manifest.mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+    val outputJar = temporaryFolder.newFile("output.jar")
+    JarOutputStream(FileOutputStream(outputJar), manifest).use { jar ->
+      for (compiledFile in compiledFiles) {
+        val entry = JarEntry(compiledFile.toRelativeString(classesDir).replace("\\", "/"))
+        entry.time = compiledFile.lastModified()
+        jar.putNextEntry(entry)
+        compiledFile.source().use { fileSource ->
+          jar.sink().buffer().apply {
+            writeAll(fileSource)
+            flush()
+            // We don't close because we're still using the underlying jar
+          }
+        }
+        jar.closeEntry()
+      }
+    }
+
+    return outputJar
+  }
+}


### PR DESCRIPTION
This is intended to resolve #48 by adding a new API to extensions for `abi` handling and `exclusions` configuration.

The API in practice looks like this:

```kotlin
abi {
  exclusions {
    // Convenience helpers
    ignoreSubPackage("internal")
    ignoreInternalPackages()
    ignoreGeneratedCode()

    // Raw, regexp-based APIs
    excludeAnnotations(".*\\.Generated")
    excludeClasses(".*\\.internal\\..*")
  }
}
```

I've left toe-holds in for directory based parsing (i.e. `build/`), but that will take more work as the current code looks only at class files and not where they originated from.

No tests yet as I want to put this up for review of the design before moving further.