### PR TITLE
Trying to account for use of both the application and kotlin-jvm plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Dependency Analysis Plugin Changelog
 
 # Version 0.42.0 (unreleased)
+* [New] Support the `application` plugin.
 * [Fixed] Detects usages that only appear in a generic context, and javadoc too (as a side effect).
 * Now publishing snapshots on every push to master.
 * Building plugin with Gradle 6.4, and testing against same.

--- a/src/functionalTest/groovy/com/autonomousapps/fixtures/jvm/Dependency.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/fixtures/jvm/Dependency.groovy
@@ -11,6 +11,12 @@ final class Dependency {
     this.dependency = dependency
   }
 
+  static Dependency kotlinStdlib(String configuration) {
+    return new Dependency(
+      configuration, "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
+    )
+  }
+
   static Dependency kotlinStdlibJdk7(String configuration) {
     return new Dependency(
       configuration, "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"

--- a/src/functionalTest/groovy/com/autonomousapps/fixtures/jvm/Plugin.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/fixtures/jvm/Plugin.groovy
@@ -20,6 +20,10 @@ final class Plugin {
     )
   }
 
+  static Plugin kotlinPluginNoVersion() {
+    return plugin('org.jetbrains.kotlin.jvm', null, true)
+  }
+
   static Plugin kotlinPlugin(boolean apply = true, String version = KOTLIN_VERSION) {
     return plugin('org.jetbrains.kotlin.jvm', version, apply)
   }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ApplicationSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ApplicationSpec.groovy
@@ -2,6 +2,8 @@ package com.autonomousapps.jvm
 
 import com.autonomousapps.AbstractFunctionalSpec
 import com.autonomousapps.fixtures.jvm.JvmProject
+import com.autonomousapps.fixtures.jvm.Plugin
+import com.autonomousapps.fixtures.jvm.SourceType
 import com.autonomousapps.jvm.projects.ApplicationProject
 import spock.lang.Unroll
 
@@ -19,9 +21,41 @@ final class ApplicationSpec extends AbstractFunctionalSpec {
   }
 
   @Unroll
-  def "can analyze jvm application projects (#gradleVersion)"() {
+  def "can analyze java-jvm application projects (#gradleVersion)"() {
     given:
     jvmProject = new ApplicationProject().jvmProject
+
+    when:
+    build(gradleVersion, jvmProject.rootDir, ':buildHealth')
+
+    then:
+    assertThat(jvmProject.adviceForFirstProject()).containsExactlyElementsIn(ApplicationProject.expectedAdvice)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  @Unroll
+  def "can analyze kotlin-jvm application projects when kotlin-jvm is applied first(#gradleVersion)"() {
+    given:
+    def plugins = [Plugin.kotlinPluginNoVersion(), Plugin.applicationPlugin()]
+    jvmProject = new ApplicationProject(plugins, SourceType.KOTLIN).jvmProject
+
+    when:
+    build(gradleVersion, jvmProject.rootDir, ':buildHealth')
+
+    then:
+    assertThat(jvmProject.adviceForFirstProject()).containsExactlyElementsIn(ApplicationProject.expectedAdvice)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  @Unroll
+  def "can analyze kotlin-jvm application projects when application is applied first(#gradleVersion)"() {
+    given:
+    def plugins = [Plugin.applicationPlugin(), Plugin.kotlinPluginNoVersion()]
+    jvmProject = new ApplicationProject(plugins, SourceType.KOTLIN).jvmProject
 
     when:
     build(gradleVersion, jvmProject.rootDir, ':buildHealth')

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ApplicationProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ApplicationProject.groovy
@@ -1,6 +1,7 @@
 package com.autonomousapps.jvm.projects
 
 import com.autonomousapps.advice.Advice
+import com.autonomousapps.fixtures.jvm.Dependency
 import com.autonomousapps.fixtures.jvm.JvmProject
 import com.autonomousapps.fixtures.jvm.Plugin
 import com.autonomousapps.fixtures.jvm.Source
@@ -13,39 +14,37 @@ import static com.autonomousapps.fixtures.jvm.Dependency.*
  * implementation.
  */
 final class ApplicationProject {
+
+  private final List<Plugin> plugins
+  private final SourceType sourceType
   final JvmProject jvmProject
 
-  ApplicationProject() {
+  ApplicationProject(
+    List<Plugin> plugins = [Plugin.applicationPlugin()], SourceType sourceType = SourceType.JAVA
+  ) {
+    this.plugins = plugins
+    this.sourceType = sourceType
     this.jvmProject = build()
   }
 
-  private static JvmProject build() {
+  private JvmProject build() {
     def builder = new JvmProject.Builder()
 
-    def plugins = [Plugin.applicationPlugin()]
     def dependencies = [
       commonsMath("compile"),
       commonsIO("compile"),
       commonsCollections("compile")
     ]
-    def source = new Source(
-      SourceType.JAVA, "Main", "com/example",
-      """\
-        package com.example;
-        
-        import java.io.FileFilter;
-        import org.apache.commons.io.filefilter.EmptyFileFilter; 
-        import org.apache.commons.collections4.bag.HashBag;
+    if (sourceType == SourceType.KOTLIN) {
+      dependencies.add(kotlinStdlib("implementation"))
+    }
 
-        public class Main {
-          public FileFilter f = EmptyFileFilter.EMPTY;
-          
-          public HashBag<String> getBag() {
-            return new HashBag<String>();
-          }
-        }
-      """.stripIndent()
-    )
+    def source
+    if (sourceType == SourceType.JAVA) {
+      source = JAVA_SOURCE
+    } else {
+      source = KOTLIN_SOURCE
+    }
 
     builder.addSubproject(plugins, dependencies, [source], 'main', '')
 
@@ -53,6 +52,44 @@ final class ApplicationProject {
     project.writer().write()
     return project
   }
+
+  private static final Source JAVA_SOURCE = new Source(
+    SourceType.JAVA, "Main", "com/example",
+    """\
+      package com.example;
+      
+      import java.io.FileFilter;
+      import org.apache.commons.io.filefilter.EmptyFileFilter; 
+      import org.apache.commons.collections4.bag.HashBag;
+      
+      public class Main {
+        public FileFilter f = EmptyFileFilter.EMPTY;
+        
+        public HashBag<String> getBag() {
+          return new HashBag<String>();
+        }
+      }
+     """.stripIndent()
+  )
+
+  private static final Source KOTLIN_SOURCE = new Source(
+    SourceType.KOTLIN, "Main", "com/example",
+    """\
+      package com.example
+      
+      import java.io.FileFilter
+      import org.apache.commons.io.filefilter.EmptyFileFilter
+      import org.apache.commons.collections4.bag.HashBag
+      
+      class Main {
+        val f: FileFilter = EmptyFileFilter.EMPTY
+        
+        fun getBag(): HashBag<String> {
+          return HashBag<String>()
+        }
+      }
+     """.stripIndent()
+  )
 
   static final List<Advice> expectedAdvice = ApplicationAdvice.expectedAdvice
 }

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -136,7 +136,22 @@ internal class JavaLibAnalyzer(project: Project, sourceSet: SourceSet)
     }
 }
 
-internal class KotlinJvmAnalyzer(project: Project, sourceSet: JbKotlinSourceSet)
+internal abstract class KotlinJvmAnalyzer(project: Project, sourceSet: JbKotlinSourceSet)
   : JvmAnalyzer(project, KotlinSourceSet(sourceSet)) {
-  override val javaSourceFiles: FileTree? = null
+  final override val javaSourceFiles: FileTree? = null
+}
+
+internal class KotlinJvmAppAnalyzer(project: Project, sourceSet: JbKotlinSourceSet)
+  : KotlinJvmAnalyzer(project, sourceSet)
+
+internal class KotlinJvmLibAnalyzer(project: Project, sourceSet: JbKotlinSourceSet)
+  : KotlinJvmAnalyzer(project, sourceSet) {
+  override fun registerAbiAnalysisTask(dependencyReportTask: TaskProvider<DependencyReportTask>) =
+    project.tasks.register<AbiAnalysisTask>("abiAnalysis$variantNameCapitalized") {
+      jar.set(getJarTask().flatMap { it.archiveFile })
+      dependencies.set(dependencyReportTask.flatMap { it.allComponentsReport })
+
+      output.set(outputPaths.abiAnalysisPath)
+      abiDump.set(outputPaths.abiDumpPath)
+    }
 }


### PR DESCRIPTION
Resolves an issue that leads to runtime crash when both are applied and the plugin tries to add duplicate tasks.