### PR TITLE
Don't suggest removing security providers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Dependency Analysis Plugin Changelog
 # Version 0.42.0 (unreleased)
 * [New] Support the `application` plugin.
 * [Fixed] Detects usages that only appear in a generic context, and javadoc too (as a side effect).
+* [Fixed] Does not suggest removing dependencies that supply security providers (such as Conscrypt).
 * Now publishing snapshots on every push to master.
 * Building plugin with Gradle 6.4, and testing against same.
 * Updated to latest AGP, 4.1.0-alpha09.

--- a/src/functionalTest/groovy/com/autonomousapps/fixtures/jvm/Dependency.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/fixtures/jvm/Dependency.groovy
@@ -24,27 +24,27 @@ final class Dependency {
   }
 
   static Dependency guava(String configuration) {
-    return new Dependency(
-      configuration, "com.google.guava:guava:28.2-jre"
-    )
+    return new Dependency(configuration, "com.google.guava:guava:28.2-jre")
   }
 
   static Dependency commonsMath(String configuration) {
-    return new Dependency(
-      configuration, "org.apache.commons:commons-math3:3.6.1"
-    )
+    return new Dependency(configuration, "org.apache.commons:commons-math3:3.6.1")
   }
 
   static Dependency commonsIO(String configuration) {
-    return new Dependency(
-      configuration, "commons-io:commons-io:2.6"
-    )
+    return new Dependency(configuration, "commons-io:commons-io:2.6")
   }
 
   static Dependency commonsCollections(String configuration) {
-    return new Dependency(
-      configuration, "org.apache.commons:commons-collections4:4.4"
-    )
+    return new Dependency(configuration, "org.apache.commons:commons-collections4:4.4")
+  }
+
+  static Dependency conscryptUber(String configuration) {
+    return new Dependency(configuration, "org.conscrypt:conscrypt-openjdk-uber:2.4.0")
+  }
+
+  static Dependency okHttp(String configuration) {
+    return new Dependency(configuration, "com.squareup.okhttp3:okhttp:4.6.0")
   }
 
   @Override

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/SecurityProviderSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/SecurityProviderSpec.groovy
@@ -1,0 +1,37 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.AbstractFunctionalSpec
+import com.autonomousapps.fixtures.jvm.JvmProject
+import com.autonomousapps.jvm.projects.ApplicationProject
+import com.autonomousapps.jvm.projects.SecurityProviderProject
+import spock.lang.Unroll
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class SecurityProviderSpec extends AbstractFunctionalSpec {
+
+  private JvmProject jvmProject = null
+
+  def cleanup() {
+    if (jvmProject != null) {
+      clean(jvmProject.rootDir)
+    }
+  }
+
+  @Unroll
+  def "does not recommend removing conscrypt (#gradleVersion)"() {
+    given:
+    def project = new SecurityProviderProject()
+    jvmProject = project.jvmProject
+
+    when:
+    build(gradleVersion, jvmProject.rootDir, ':buildHealth')
+
+    then:
+    assertThat(jvmProject.adviceForFirstProject()).containsExactlyElementsIn(project.expectedAdvice)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SecurityProviderProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SecurityProviderProject.groovy
@@ -1,0 +1,51 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.advice.Advice
+import com.autonomousapps.fixtures.jvm.JvmProject
+import com.autonomousapps.fixtures.jvm.Plugin
+import com.autonomousapps.fixtures.jvm.Source
+import com.autonomousapps.fixtures.jvm.SourceType
+
+import static com.autonomousapps.fixtures.jvm.Dependency.conscryptUber
+import static com.autonomousapps.fixtures.jvm.Dependency.okHttp
+
+class SecurityProviderProject {
+
+  final JvmProject jvmProject
+
+  SecurityProviderProject() {
+    this.jvmProject = build()
+  }
+
+  private JvmProject build() {
+    def builder = new JvmProject.Builder()
+
+    def plugins = [Plugin.javaLibraryPlugin()]
+    def dependencies = [
+      conscryptUber("implementation"),
+      okHttp("api")
+    ]
+    def source = new Source(
+      SourceType.JAVA, "Main", "com/example",
+      """\
+        package com.example;
+        
+        import okhttp3.OkHttpClient;
+
+        public class Main {
+          public OkHttpClient ok() {
+            return new OkHttpClient.Builder().build();
+          }
+        }
+      """.stripIndent()
+    )
+
+    builder.addSubproject(plugins, dependencies, [source], 'main', '')
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  final List<Advice> expectedAdvice = SecurityProviderAdvice.expectedAdvice
+}

--- a/src/functionalTest/kotlin/com/autonomousapps/jvm/projects/SecurityProviderAdvice.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/jvm/projects/SecurityProviderAdvice.kt
@@ -1,0 +1,7 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.advice.Advice
+
+object SecurityProviderAdvice {
+  val expectedAdvice = listOf<Advice>()
+}

--- a/src/main/kotlin/com/autonomousapps/internal/AnalyzedJar.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/AnalyzedJar.kt
@@ -44,6 +44,10 @@ internal class AnalyzedJar(private val analyzedClasses: Set<AnalyzedClass>) {
     return true
   }
 
+  val isSecurityProvider: Boolean by lazy {
+    analyzedClasses.any { it.superClassName == "java/security/Provider" }
+  }
+
   private fun RetentionPolicy?.isCompileOnly() = this == RetentionPolicy.CLASS || this == RetentionPolicy.SOURCE
 
   private fun isCompileOnlyAnnotation(analyzedClass: AnalyzedClass): Boolean =

--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -74,6 +74,10 @@ data class Component(
    */
   val isCompileOnlyAnnotations: Boolean = false,
   /**
+   * True if this dependency contains a class that extends [java.security.Provider].
+   */
+  val isSecurityProvider: Boolean = false,
+  /**
    * The classes declared by this library.
    */
   val classes: Set<String>
@@ -83,6 +87,7 @@ data class Component(
     dependency = artifact.dependency,
     isTransitive = artifact.isTransitive!!,
     isCompileOnlyAnnotations = analyzedJar.isCompileOnlyCandidate(),
+    isSecurityProvider = analyzedJar.isSecurityProvider,
     classes = analyzedJar.classNames()
   )
 


### PR DESCRIPTION
Addresses https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/153.

Ideally I will extend this solution to only ignore security providers when there's something on the classpath that actually tries to use one. There is already prior art for this, but the bytecode analysis that would do it is currently only performed on the project's code itself, not any of its dependencies. Introducing that might have negative performance implications, potentially not worth the small (is it?) benefit.