### PR TITLE
Filter for compile only dependencies via DSL

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AdviceSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AdviceSpec.groovy
@@ -18,23 +18,27 @@ final class AdviceSpec extends AbstractAndroidSpec {
       dependencyAnalysis {
         issues {
           onAny {
-              severity 'fail'
-              exclude '$KOTLIN_STDLIB_JDK7_ID'
+            severity 'fail'
+            exclude '$KOTLIN_STDLIB_JDK7_ID'
           }
           onUnusedDependencies {
-              severity 'fail'
-              exclude ':lib_android'
+            severity 'fail'
+            exclude ':lib_android'
           }
           onUsedTransitiveDependencies {
-              severity 'fail'
-              exclude '$CORE_ID'
+            severity 'fail'
+            exclude '$CORE_ID'
           }
           onIncorrectConfiguration {
-              severity 'fail'
-              exclude '$COMMONS_COLLECTIONS_ID'
+            severity 'fail'
+            exclude '$COMMONS_COLLECTIONS_ID'
+          }
+          onCompileOnly {
+            severity 'fail'
+            exclude '$ANDROIDX_ANNOTATIONS_ID'
           }
           onUnusedAnnotationProcessors {
-              exclude 'fail'
+            severity 'fail'
           }
         }
         setFacadeGroups()
@@ -53,7 +57,9 @@ final class AdviceSpec extends AbstractAndroidSpec {
     result.task(':lib_jvm:adviceMain').outcome == TaskOutcome.SUCCESS
 
     and: 'reports are as expected for app'
-    def expectedAppAdvice = NeedsAdviceProject.expectedAppAdvice([KOTLIN_STDLIB_JDK7_ID, ':lib_android'] as Set<String>)
+    def expectedAppAdvice = NeedsAdviceProject.expectedAppAdvice(
+      [KOTLIN_STDLIB_JDK7_ID, ANDROIDX_ANNOTATIONS_ID, ':lib_android'] as Set<String>
+    )
     def actualAppAdvice = androidProject.adviceFor('app')
     assertThat(actualAppAdvice).containsExactlyElementsIn(expectedAppAdvice)
 

--- a/src/functionalTest/kotlin/com/autonomousapps/fixtures/adviceTestProject.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/fixtures/adviceTestProject.kt
@@ -55,7 +55,7 @@ fun androidProjectThatNeedsAdvice(
         }""".trimIndent()),
       dependencies = DEPENDENCIES_KOTLIN_STDLIB + listOf(
         //"implementation" to APPCOMPAT
-        // should be "implementation"
+        // should be "compileOnly"
         "api" to ANDROIDX_ANNOTATIONS,
         // should be removed. Needed to compile against lib-android, which doesn't declare it correctly
         "implementation" to CORE_KTX,
@@ -167,6 +167,10 @@ private val coreKtxComponent = ComponentWithTransitives(
     Dependency("org.jetbrains.kotlin:kotlin-stdlib")
   )
 )
+private val androidXAnnotationsComponent = ComponentWithTransitives(
+  dependency = Dependency(ANDROIDX_ANNOTATIONS_ID, configurationName = "api"),
+  usedTransitiveDependencies = mutableSetOf()
+)
 private val coreKtxComponent2 = ComponentWithTransitives(
   dependency = Dependency(CORE_KTX_ID, configurationName = "implementation"),
   usedTransitiveDependencies = mutableSetOf(
@@ -204,7 +208,9 @@ private val libAndroidComponent = ComponentWithTransitives(
 fun expectedAppAdvice(ignore: Set<String> = emptySet()): Set<Advice> = mutableSetOf(
   Advice.ofAdd(transitiveStdLib, toConfiguration = "implementation"),
   Advice.ofAdd(transitiveAppCompat, toConfiguration = "implementation"),
-  Advice.ofChange(Dependency(ANDROIDX_ANNOTATIONS_ID, configurationName = "api"), "compileOnly"),
+  Advice.ofChange(
+    hasDependency = androidXAnnotationsComponent,
+    toConfiguration = "compileOnly"),
   Advice.ofRemove(libAndroidComponent),
   Advice.ofRemove(coreKtxComponent),
   Advice.ofRemove(commonsIoComponent),

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
@@ -189,6 +189,7 @@ open class IssueHandler @Inject constructor(objects: ObjectFactory) {
   internal val usedTransitiveDependenciesIssue = objects.newInstance(Issue::class.java)
   internal val incorrectConfigurationIssue = objects.newInstance(Issue::class.java)
   internal val unusedAnnotationProcessorsIssue = objects.newInstance(Issue::class.java)
+  internal val compileOnlyIssue = objects.newInstance(Issue::class.java)
 
   internal val ignoreKtx = objects.property<Boolean>().also {
     it.convention(false)
@@ -217,6 +218,10 @@ open class IssueHandler @Inject constructor(objects: ObjectFactory) {
 
   fun onUnusedAnnotationProcessors(action: Action<Issue>) {
     action.execute(unusedAnnotationProcessorsIssue)
+  }
+
+  fun onCompileOnly(action: Action<Issue>) {
+    action.execute(compileOnlyIssue)
   }
 }
 

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -370,6 +370,7 @@ class DependencyAnalysisPlugin : Plugin<Project> {
         failOnUsedTransitiveDependencies.set(usedTransitiveDependenciesIssue.behavior())
         failOnIncorrectConfiguration.set(incorrectConfigurationIssue.behavior())
         failOnUnusedProcs.set(unusedAnnotationProcessorsIssue.behavior())
+        failOnCompileOnly.set(compileOnlyIssue.behavior())
       }
     }
   }
@@ -615,6 +616,7 @@ class DependencyAnalysisPlugin : Plugin<Project> {
         failOnUsedTransitiveDependencies.set(usedTransitiveDependenciesIssue.behavior())
         failOnIncorrectConfiguration.set(incorrectConfigurationIssue.behavior())
         failOnUnusedProcs.set(unusedAnnotationProcessorsIssue.behavior())
+        failOnCompileOnly.set(compileOnlyIssue.behavior())
       }
 
       adviceReport.set(outputPaths.advicePath)

--- a/src/main/kotlin/com/autonomousapps/advice/Advice.kt
+++ b/src/main/kotlin/com/autonomousapps/advice/Advice.kt
@@ -63,12 +63,6 @@ data class Advice(
       dependency = hasDependency.dependency,
       fromConfiguration = hasDependency.dependency.configurationName, toConfiguration = toConfiguration
     )
-
-    @JvmStatic
-    fun ofCompileOnly(dependency: Dependency, toConfiguration: String) = Advice(
-      dependency = dependency,
-      fromConfiguration = dependency.configurationName, toConfiguration = toConfiguration
-    )
   }
 
   /**

--- a/src/main/kotlin/com/autonomousapps/internal/advice/ComputedAdvice.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/ComputedAdvice.kt
@@ -23,15 +23,6 @@ internal class ComputedAdvice(
 
   private val filterSpec = filterSpecBuilder.build()
 
-  val compileOnlyDependencies: Set<Dependency> = compileOnlyCandidates
-    // We want to exclude transitives here. In other words, don't advise people to declare
-    // used-transitive components.
-    .filterToOrderedSet { !it.isTransitive }
-    .mapToOrderedSet { it.dependency }
-    // Don't advise changing dependencies that are already compileOnly
-    .filterToOrderedSet { it.configurationName?.endsWith("compileOnly") == false }
-    .filterToOrderedSet(filterSpec.compileOnlyAdviceFilter)
-
   val filterRemove = filterSpec.filterRemove
   val filterAdd = filterSpec.filterAdd
   val filterChange = filterSpec.filterChange
@@ -95,10 +86,16 @@ internal class ComputedAdvice(
     }
   }
 
-  val compileOnlyAdvice: Set<Advice> = compileOnlyDependencies
+  val compileOnlyAdvice: Set<Advice> = compileOnlyCandidates
+    // We want to exclude transitives here. In other words, don't advise people to declare
+    // used-transitive components.
+    .filterToOrderedSet { !it.isTransitive }
+    .mapToOrderedSet { it.dependency }
+    // Don't advise changing dependencies that are already compileOnly
+    .filterToOrderedSet { it.configurationName?.endsWith("compileOnly") == false }
     .filterToOrderedSet(filterSpec.compileOnlyAdviceFilter)
     // TODO be variant-aware
-    .mapToOrderedSet { Advice.ofCompileOnly(it, "compileOnly") }
+    .mapToOrderedSet { Advice.ofChange(it, "compileOnly") }
 
   val unusedProcsAdvice: Set<Advice> = unusedProcs
     .filterToOrderedSet(filterSpec.unusedProcsAdviceFilter)

--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -430,7 +430,7 @@ internal data class ConsoleReport(
         changeToImplAdvice = computedAdvice.changeToImplAdvice
       }
 
-      if (!computedAdvice.filterCompileOnly && computedAdvice.compileOnlyDependencies.isNotEmpty()) {
+      if (!computedAdvice.filterCompileOnly && computedAdvice.compileOnlyAdvice.isNotEmpty()) {
         compileOnlyDependencies = computedAdvice.compileOnlyAdvice
       }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/AdviceTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AdviceTask.kt
@@ -102,6 +102,9 @@ abstract class AdviceTask : DefaultTask() {
   abstract val failOnUnusedProcs: Property<Behavior>
 
   @get:Input
+  abstract val failOnCompileOnly: Property<Behavior>
+
+  @get:Input
   abstract val chatty: Property<Boolean>
 
   @get:OutputFile
@@ -184,6 +187,7 @@ abstract class AdviceTask : DefaultTask() {
     usedTransitivesBehavior = failOnUsedTransitiveDependencies.get()
     incorrectConfigurationsBehavior = failOnIncorrectConfiguration.get()
     unusedProcsBehavior = failOnUnusedProcs.get()
+    compileOnlyBehavior = failOnCompileOnly.get()
   }
 
   private val filters: List<DependencyFilter> by lazy(mode = LazyThreadSafetyMode.NONE) {

--- a/src/test/kotlin/com/autonomousapps/internal/ConsoleReportTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/ConsoleReportTest.kt
@@ -88,7 +88,7 @@ class ConsoleReportTest {
   @Test fun `isEmpty should return false when has compileOnlyDependencies`() {
     // When
     val consoleReport = createReport(compileOnlyDependencies = setOf(
-      Advice.ofCompileOnly(orgDotSomething, "compileOnly")
+      Advice.ofChange(orgDotSomething, "compileOnly")
     ))
 
     // Then


### PR DESCRIPTION
Solves issue #172.
Ignore/warn/fails on errors related to dependencies that "could be compile only".
Adds an issue handler method to the DSL:
```
onAdvisedCompileOnly {
  fail(<"foo">)
}
```

@autonomousapps , we need to update the wiki after this is merged.