### PR TITLE
Support star imports for finding annotation processors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Dependency Analysis Plugin Changelog
 
+# Version 0.49.0 (unreleased)
+* [Fixed] Detect star imports as supported annotation types.
+
 # Version 0.48.0
 * [New] Analyze test source in order to provide advice relating to test dependencies.
 * Updated to latest AGPs at time of writing (4.1.0-beta01 and 4.2.0-alpha01) 

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/LombokSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/LombokSpec.groovy
@@ -1,19 +1,20 @@
 package com.autonomousapps.jvm
 
-import com.autonomousapps.jvm.projects.GradleApiProject
+
+import com.autonomousapps.jvm.projects.LombokProject
 import spock.lang.Unroll
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
 
-final class GradleApiSpec extends AbstractJvmSpec {
+final class LombokSpec extends AbstractJvmSpec {
   @Unroll
-  def "gradleApi doesn't break the build (#gradleVersion)"() {
+  def "can find lombok usage (#gradleVersion)"() {
     given:
-    def project = new GradleApiProject()
+    def project = new LombokProject()
     gradleProject = project.gradleProject
 
-    when: 'build does not fail'
+    when:
     build(gradleVersion, gradleProject.rootDir, ':buildHealth')
 
     then: 'and there is no advice'

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/PostProcessingSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/PostProcessingSpec.groovy
@@ -8,7 +8,7 @@ import spock.lang.Unroll
 
 import static com.autonomousapps.utils.Runner.build
 
-class PostProcessingSpec extends AbstractJvmSpec {
+final class PostProcessingSpec extends AbstractJvmSpec {
 
   private ProjectDirProvider javaLibraryProject = null
 

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiExclusionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiExclusionsProject.groovy
@@ -10,7 +10,7 @@ import com.autonomousapps.kit.SourceType
 
 import static com.autonomousapps.kit.Dependency.okHttp
 
-class AbiExclusionsProject extends AbstractProject {
+final class AbiExclusionsProject extends AbstractProject {
 
   final GradleProject gradleProject
 

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ConstantsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ConstantsProject.groovy
@@ -10,7 +10,7 @@ import com.autonomousapps.kit.SourceType
 import static com.autonomousapps.kit.Dependency.kotlinStdLib
 import static com.autonomousapps.kit.Dependency.project
 
-class ConstantsProject extends AbstractProject {
+final class ConstantsProject extends AbstractProject {
 
   final GradleProject gradleProject
 

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/LombokProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/LombokProject.groovy
@@ -1,0 +1,76 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.advice.Advice
+import com.autonomousapps.kit.Dependency
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+
+final class LombokProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  LombokProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('proj') { s ->
+      s.sources = sources
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.dependencies = [
+          new Dependency('compileOnly', 'org.projectlombok:lombok:1.18.12'),
+          new Dependency('annotationProcessor', 'org.projectlombok:lombok:1.18.12')
+        ]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private sources = [
+    new Source(
+      SourceType.JAVA, "Country", "com/example",
+      """\
+      package com.example;
+      
+      import lombok.AccessLevel;
+      import lombok.Getter;
+      import lombok.NoArgsConstructor;
+      
+      @Getter
+      @NoArgsConstructor(access = AccessLevel.PROTECTED)
+      public class Country {
+        private Long id;
+        private String alpha2;
+        private String alpha3;
+        private String name;
+        private boolean active;
+
+        private Country(final String alpha2, final String alpha3, final String name) {
+            this.alpha2 = alpha2;
+            this.alpha3 = alpha3;
+            this.name = name;
+            this.active = Boolean.TRUE;
+        }
+
+        public static Country of(final String alpha2, final String alpha3, final String name) {
+          return new Country(alpha2, alpha3, name);
+        }
+
+        public void setActive(boolean active) {
+          this.active = active;
+        }
+      }
+      """.stripIndent()
+    )
+  ]
+
+  final List<Advice> expectedAdvice = []
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SecurityProviderProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SecurityProviderProject.groovy
@@ -7,7 +7,7 @@ import com.autonomousapps.kit.*
 import static com.autonomousapps.kit.Dependency.conscryptUber
 import static com.autonomousapps.kit.Dependency.okHttp
 
-class SecurityProviderProject extends AbstractProject {
+final class SecurityProviderProject extends AbstractProject {
 
   final GradleProject gradleProject
 

--- a/src/main/kotlin/com/autonomousapps/internal/utils/regex.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/regex.kt
@@ -16,3 +16,5 @@ internal val JAVA_FQCN_REGEX =
   "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\.)+\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*".toRegex()
 internal val JAVA_FQCN_REGEX_SLASHY =
   "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*/)+\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*".toRegex()
+
+internal const val JAVA_SUB_PACKAGE = "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)+"


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/188. (except that it doesn't handle when the jar task has been disabled)