### PR TITLE
Use more lazy APIs for tasks and files

### DIFF
--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -447,7 +447,8 @@ class DependencyAnalysisPlugin : Plugin<Project> {
       finalizedBy(failOrWarn)
 
       doLast {
-        logger.debug("Advice report (aggregated)  : ${adviceReport.get().projectReport.get().asFile.path}")
+        val reportPath = adviceReport.flatMap { it.projectReport.map { it.asFile.path } }
+        logger.debug("Advice report (aggregated)  : $reportPath")
       }
     }
 

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmSourceSet.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmSourceSet.kt
@@ -2,9 +2,9 @@ package com.autonomousapps.internal.analyzer
 
 import com.android.builder.model.SourceProvider
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.tasks.SourceSet
-import java.io.File
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet as JbKotlinSourceSet
 
 internal interface JvmSourceSet {
@@ -12,8 +12,8 @@ internal interface JvmSourceSet {
   val jarTaskName: String
   val sourceCode: SourceDirectorySet
 
-  fun asFiles(project: Project): Set<File> =
-    project.files(sourceCode.sourceDirectories).asFileTree.files
+  fun asFiles(project: Project): FileCollection =
+    project.layout.files(sourceCode.sourceDirectories)
 }
 
 internal class JavaSourceSet(sourceSet: SourceSet) : JvmSourceSet {

--- a/src/main/kotlin/com/autonomousapps/tasks/AbiAnalysisTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AbiAnalysisTask.kt
@@ -127,7 +127,7 @@ abstract class AbiAnalysisWorkAction : WorkAction<AbiAnalysisParameters> {
   }
 
   private fun allClassFiles(): Set<File> =
-    parameters.javaClasses.asFileTree.files.plus(parameters.kotlinClasses.asFileTree.files)
+    parameters.javaClasses.plus(parameters.kotlinClasses)
       .filterToSet { it.path.endsWith(".class") }
 
   private fun lineItem(dependency: Dependency): String {


### PR DESCRIPTION
In this PR I try to:
* use more task providers APIs instead of using `get()` on them. Even though the target classes have probably been realized already at this point, it is a bit cleaner.
* use more lazy file collections instead of files to limit CPU usage during the configuration phase.