### PR TITLE
Interrogate consumer proguard files for rules.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
     because("Auto-wiring into Kotlin projects")
   }
 
-  testImplementation("org.spockframework:spock-core:2.0-M3-groovy-2.5") {//1.3-groovy-2.5//2.0-M3-groovy-2.5//2.0-M3-groovy-3.0
+  testImplementation("org.spockframework:spock-core:1.3-groovy-2.5") {//1.3-groovy-2.5//2.0-M3-groovy-2.5//2.0-M3-groovy-3.0
     exclude(module = "groovy-all")
     because("For Spock tests")
   }
@@ -105,7 +105,7 @@ dependencies {
   }
 
   functionalTestImplementation(project(":testkit"))
-  functionalTestImplementation("org.spockframework:spock-core:2.0-M3-groovy-2.5") {//1.3-groovy-2.5//2.0-M3-groovy-2.5//2.0-M3-groovy-3.0
+  functionalTestImplementation("org.spockframework:spock-core:1.3-groovy-2.5") {//1.3-groovy-2.5//2.0-M3-groovy-2.5//2.0-M3-groovy-3.0
     exclude(module = "groovy-all")
     because("For Spock tests")
   }

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -581,6 +581,10 @@ class DependencyAnalysisPlugin : Plugin<Project> {
     // Android resources. Is null for java-library projects.
     val androidResByResUsageTask = dependencyAnalyzer.registerAndroidResToResAnalysisTask()
 
+    // Produces a report that lists every class referenced by consumer proguard files. Only relevant
+    // for Android projects.
+    val proguardRulesFinderTask = dependencyAnalyzer.registerProguardRulesFinderTask()
+
     // Produces a report that list all classes _used by_ the given project. Analyzes bytecode and
     // collects all class references.
     val analyzeClassesTask = dependencyAnalyzer.registerClassAnalysisTask()
@@ -608,6 +612,9 @@ class DependencyAnalysisPlugin : Plugin<Project> {
         }
         androidResByResUsageTask?.let { task ->
           usedAndroidResByResDependencies.set(task.flatMap { it.output })
+        }
+        proguardRulesFinderTask?.let { task ->
+          proguardClasses.set(task.flatMap { it.output })
         }
 
         outputAllComponents.set(outputPaths.allComponentsPath)

--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -36,6 +36,7 @@ internal class OutputPaths(private val project: Project, variantName: String) {
   val declaredProcPath = layout("${intermediatesDir}/procs-declared.json")
   val declaredProcPrettyPath = layout("${intermediatesDir}/procs-declared-pretty.json")
   val unusedProcPath = layout("${intermediatesDir}/procs-unused.json")
+  val proguardRulesPath = layout("${intermediatesDir}/proguard-rules.json")
   val abiAnalysisPath = layout("${intermediatesDir}/abi.json")
   val abiDumpPath = layout("${intermediatesDir}/abi-dump.txt")
   val advicePath = layout("${variantDirectory}/advice.json")

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
@@ -133,6 +133,21 @@ internal abstract class AndroidAnalyzer<T : ClassAnalysisTask>(
     }
   }
 
+  // TODO all android projects, or just app or lib projects?
+  override fun registerProguardRulesFinderTask(): TaskProvider<FindProguardRulesTask> =
+    project.tasks.register<FindProguardRulesTask>("proguardRulesFinder$variantNameCapitalized") {
+      val unfiltered: (ArtifactView.ViewConfiguration).() -> Unit = {
+        attributes.attribute(AndroidArtifacts.ARTIFACT_TYPE, "android-consumer-proguard-rules")
+      }
+      val proguardArtifacts = project.configurations[compileConfigurationName]
+        .incoming
+        .artifactView(unfiltered)
+        .artifacts
+
+      setProguardArtifacts(proguardArtifacts)
+      output.set(outputPaths.proguardRulesPath)
+    }
+
   private fun kaptConf(): Configuration? = try {
     project.configurations["kapt$variantNameCapitalized"]
   } catch (_: UnknownDomainObjectException) {

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
@@ -73,6 +73,8 @@ internal interface DependencyAnalyzer<T : ClassAnalysisTask> {
     importFinder: TaskProvider<ImportFinderTask>
   ): TaskProvider<FindUnusedProcsTask>
 
+  fun registerProguardRulesFinderTask(): TaskProvider<FindProguardRulesTask>? = null
+
   /**
    * This is a no-op for `com.android.application` and JVM `application` projects (including
    * Spring Boot), since they have no meaningful ABI.

--- a/src/main/kotlin/com/autonomousapps/internal/classReferenceParsers.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/classReferenceParsers.kt
@@ -184,8 +184,8 @@ private class BytecodeParser(
   private val logger: Logger
 ) {
   /**
-   * This (currently, maybe forever) fails to detect constant usage in Kotlin-generated class files. Works just fine
-   * for Java.
+   * This (currently, maybe forever) fails to detect constant usage in Kotlin-generated class files.
+   * Works just fine for Java.
    */
   fun parse(): Set<String> {
     // The "onEach"s are for debugging

--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -263,6 +263,29 @@ data class Manifest(
   }
 }
 
+/**
+ * Represents the set of class references in a proguard rules file.
+ */
+data class ProguardClasses(
+  /**
+   * A tuple of an `identifier` and a resolved version. See [Dependency].
+   */
+  val dependency: Dependency,
+  /**
+   * A set of fully-qualified class references.
+   */
+  val classes: Set<String>
+) : Comparable<ProguardClasses> {
+  constructor(classes: Set<String>, componentIdentifier: ComponentIdentifier) : this(
+    classes = classes,
+    dependency = Dependency(componentIdentifier)
+  )
+
+  override fun compareTo(other: ProguardClasses): Int {
+    return dependency.compareTo(other.dependency)
+  }
+}
+
 data class AnalyzedClass(
   val className: String,
   val superClassName: String?,

--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -50,7 +50,7 @@ internal inline fun <T, R : Any> Iterable<T>.mapNotNullToSet(transform: (T) -> R
   return mapNotNullTo(HashSet(), transform)
 }
 
-internal inline fun <T, R : Any> Iterable<T>.mapNotNullToOrderedSet(transform: (T) -> R?): TreeSet<R> {
+internal inline fun <T, R : Any> Iterable<T>.mapNotNullToOrderedSet(transform: (T) -> R?): Set<R> {
   return mapNotNullTo(TreeSet(), transform)
 }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/FindProguardRulesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindProguardRulesTask.kt
@@ -1,0 +1,79 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.autonomousapps.tasks
+
+import com.autonomousapps.TASK_GROUP_DEP
+import com.autonomousapps.internal.ProguardClasses
+import com.autonomousapps.internal.utils.JAVA_FQCN_REGEX
+import com.autonomousapps.internal.utils.getAndDelete
+import com.autonomousapps.internal.utils.mapNotNullToOrderedSet
+import com.autonomousapps.internal.utils.toJson
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.artifacts.ArtifactCollection
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.*
+import java.io.File
+
+/**
+ * Find consumer proguard files in Android libraries. Assume any class reference found therein is
+ * for a "used" class -- don't recommend removing a library that supplies such a class.
+ */
+@CacheableTask
+abstract class FindProguardRulesTask : DefaultTask() {
+
+  //TYPE_UNFILTERED_PROGUARD_RULES = "android-consumer-proguard-rules";
+  //TYPE_FILTERED_PROGUARD_RULES = "android-filtered-proguard-rules";
+  //TYPE_AAPT_PROGUARD_RULES = "android-aapt-proguard-rules";
+
+  init {
+    group = TASK_GROUP_DEP
+    description = "Produces a report of all supported annotation types and their annotation processors"
+  }
+
+  private lateinit var proguardArtifacts: ArtifactCollection
+
+  fun setProguardArtifacts(proguardArtifacts: ArtifactCollection) {
+    this.proguardArtifacts = proguardArtifacts
+  }
+
+  // TODO double-check path-sensitivity
+  @PathSensitive(PathSensitivity.ABSOLUTE)
+  @InputFiles
+  fun getProguardFiles(): FileCollection = proguardArtifacts.artifactFiles
+
+  @get:OutputFile
+  abstract val output: RegularFileProperty
+
+  @TaskAction fun action() {
+    val outputFile = output.getAndDelete()
+
+    val proguardClasses = proguardArtifacts
+      .filter { it.file.isFile }
+      .mapNotNullToOrderedSet { proguardRules ->
+        try {
+          val classes = extractClassReferencesFromProguardFile(proguardRules.file)
+          ProguardClasses(classes, proguardRules.id.componentIdentifier)
+        } catch (_: GradleException) {
+          null
+        }
+      }
+
+//    proguardClasses.forEach { println(it) }
+    outputFile.writeText(proguardClasses.toJson())
+  }
+
+  /**
+   * Uses a simple regex to parse Java class references from proguard rules files.
+   */
+  private fun extractClassReferencesFromProguardFile(file: File): Set<String> {
+    // Find the class reference!
+    // # This is necessary for default initialization using Camera2Config
+    // -keep public class androidx.camera.camera2.Camera2Config$DefaultProvider { *; }
+    val text = file.readText()
+    return JAVA_FQCN_REGEX.findAll(text).map { it.value }
+      .filterNot { it.startsWith("www") }
+      .toSortedSet()
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/ManifestPackageExtractionTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ManifestPackageExtractionTask.kt
@@ -5,6 +5,7 @@ package com.autonomousapps.tasks
 import com.autonomousapps.TASK_GROUP_DEP
 import com.autonomousapps.internal.Manifest
 import com.autonomousapps.internal.utils.buildDocument
+import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.mapNotNullToOrderedSet
 import com.autonomousapps.internal.utils.toJson
 import org.gradle.api.DefaultTask
@@ -38,9 +39,7 @@ abstract class ManifestPackageExtractionTask : DefaultTask() {
   abstract val manifestPackagesReport: RegularFileProperty
 
   @TaskAction fun action() {
-    // Output
-    val outputFile = manifestPackagesReport.get().asFile
-    outputFile.delete()
+    val outputFile = manifestPackagesReport.getAndDelete()
 
     val manifests: Set<Manifest> = manifestArtifacts.mapNotNullToOrderedSet { manifest ->
       try {


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/227.

TODO:
1. Add a test
2. Rename `ProguardClasses` to something not dumb
3. Resolve TODOs.

and as a follow-up:

4. Consider finding a way to make the "metadata" more discoverable. For instance, it would be nice to know _why_ a dependency was not marked unused. We could say "this dependency provides consumer proguard rules and so, out of an abundance of caution, we are saying keep it." Another complementary option would be to provide some kind of DSL configuration.