### PR TITLE
Move some heavy configuration to a task action.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Dependency Analysis Plugin Changelog
 
 # Version 0.56.0 (unreleased)
+* [Fixed] Don't do too much work during configuration for the `LocateDependenciesTask`.
+* No longer disable plugin configuration when in the context of Android Studio. This was causing
+more problems than it solved (and may not even have solved anything). 
 * Improved warning message about using a version of AGP outside of the known-good range.
 
 # Version 0.55.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,9 @@ dependencies {
     because("Auto-wiring into Kotlin projects")
   }
 
-  testImplementation("org.spockframework:spock-core:2.0-M3-groovy-2.5") {//1.3-groovy-2.5//2.0-M3-groovy-2.5//2.0-M3-groovy-3.0
+  // Cannot use groovy-3.0 because it conflicts with Gradle itself
+  // Cannot use JUnit5 because I use JUnit4 Rules
+  testImplementation("org.spockframework:spock-core:1.3-groovy-2.5") {//1.3-groovy-2.5//2.0-M3-groovy-2.5//2.0-M3-groovy-3.0
     exclude(module = "groovy-all")
     because("For Spock tests")
   }
@@ -105,10 +107,6 @@ dependencies {
   }
 
   functionalTestImplementation(project(":testkit"))
-  functionalTestImplementation("org.spockframework:spock-core:2.0-M3-groovy-2.5") {//1.3-groovy-2.5//2.0-M3-groovy-2.5//2.0-M3-groovy-3.0
-    exclude(module = "groovy-all")
-    because("For Spock tests")
-  }
   functionalTestImplementation("commons-io:commons-io:2.6") {
     because("For FileUtils.deleteDirectory()")
   }

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -479,12 +479,8 @@ class DependencyAnalysisPlugin : Plugin<Project> {
     // declared
     val locateDependencies =
       tasks.register<LocateDependenciesTask>("locateDependencies$variantTaskName") {
-        val dependencyConfs = ConfigurationsToDependenciesTransformer(
-          flavorName = flavorName,
-          variantName = variantName,
-          project = project
-        ).dependencyConfigurations()
-        dependencyConfigurations.set(dependencyConfs)
+        this@register.flavorName.set(flavorName)
+        this@register.variantName.set(variantName)
 
         output.set(outputPaths.locationsPath)
       }

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -108,10 +108,6 @@ class DependencyAnalysisPlugin : Plugin<Project> {
       subExtension = extensions.create(EXTENSION_NAME, objects, getExtension(), path)
     }
 
-    // this is done _after_ creating the extension so that AS doesn't report configuration issues
-    // The goal is fundamentally to avoid configuring any tasks, but adding the extensions is ok
-    if (isInAndroidStudio()) return@run
-
     pluginManager.withPlugin(ANDROID_APP_PLUGIN) {
       logger.log("Adding Android tasks to ${project.path}")
       configureAndroidAppProject()
@@ -403,20 +399,10 @@ class DependencyAnalysisPlugin : Plugin<Project> {
       pluginManager.hasPlugin(SPRING_BOOT_PLUGIN) ||
       pluginManager.hasPlugin(ANDROID_APP_PLUGIN)
 
-  private fun Project.isInAndroidStudio(): Boolean {
-    return hasProperty("android.injected.invoked.from.ide").also {
-      logger.log("Plugin has been invoked from the IDE. Configuring no tasks")
-    }
-  }
-
   /**
    * Root project. Configures lifecycle tasks that aggregates reports across all subprojects.
    */
   private fun Project.configureRootProject() {
-    // this is done _after_ creating the extension so that AS doesn't report configuration issues
-    // The goal is fundamentally to avoid configuring any tasks, but adding the extensions is ok
-    if (isInAndroidStudio()) return
-
     val outputPaths = RootOutputPaths(this)
 
     val adviceAllConf = configurations.create(CONF_ADVICE_ALL_CONSUMER) {

--- a/src/main/kotlin/com/autonomousapps/internal/asm.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/asm.kt
@@ -127,7 +127,7 @@ internal class ProcClassVisitor(
  */
 internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : ClassVisitor(ASM8) {
 
-  private lateinit var className: String private set
+  private lateinit var className: String
   private lateinit var access: Access
   private var superClassName: String? = null
   private val retentionPolicyHolder = AtomicReference("")
@@ -192,7 +192,7 @@ internal class ClassNameAndAnnotationsVisitor(private val logger: Logger) : Clas
   override fun visitMethod(
     access: Int, name: String?, descriptor: String, signature: String?, exceptions: Array<out String>?
   ): MethodVisitor? {
-    log("- visitMethod: descriptor=$descriptor ame=$name signature=$signature")
+    log("- visitMethod: descriptor=$descriptor name=$name signature=$signature")
     if (!("()V" == descriptor && ("<init>" == name || "<clinit>" == name))) {
       // ignore constructors and static initializers
       methodCount++

--- a/src/main/kotlin/com/autonomousapps/tasks/LocateDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/LocateDependenciesTask.kt
@@ -1,36 +1,43 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.TASK_GROUP_DEP
-import com.autonomousapps.internal.DependencyConfiguration
+import com.autonomousapps.internal.ConfigurationsToDependenciesTransformer
+import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.toJson
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.model.ObjectFactory
-import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import javax.inject.Inject
 
-@CacheableTask
-abstract class LocateDependenciesTask @Inject constructor(objects: ObjectFactory): DefaultTask() {
+abstract class LocateDependenciesTask : DefaultTask() {
 
   init {
     group = TASK_GROUP_DEP
     description = "Produces a report of all dependencies and the configurations on which they are declared"
   }
 
+  @get:Optional
   @get:Input
-  val dependencyConfigurations = objects.setProperty(DependencyConfiguration::class.java)
+  abstract val flavorName: Property<String>
+
+  @get:Input
+  abstract val variantName: Property<String>
 
   @get:OutputFile
   abstract val output: RegularFileProperty
 
   @TaskAction fun action() {
-    val outputFile = output.get().asFile
-    outputFile.delete()
+    val outputFile = output.getAndDelete()
 
-    val locations = dependencyConfigurations.get()
+    val locations = ConfigurationsToDependenciesTransformer(
+      flavorName = flavorName.orNull,
+      variantName = variantName.get(),
+      project = project
+    ).dependencyConfigurations()
+
     outputFile.writeText(locations.toJson())
   }
 }


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/244.

It's still not great, since the task is no longer cacheable and uses the `Project` instance directly, but at least it's lazy now. I will follow-up later and see if I can change how this task does its work.