### PR TITLE
Remove aggregate advice from archives configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Dependency Analysis Plugin Changelog
 
 # Version 0.56.0 (unreleased)
+* [Fixed] Unhook plugin from `assemble` task, to which it was yoked against its will. The upshot is
+that running `assemble` will no longer trigger the plugin's tasks to run. Using the 
+**Build Project** button in Android Studio will also no longer trigger the plugin's tasks.
 * [Fixed] Don't do too much work during configuration for the `LocateDependenciesTask`.
 * No longer disable plugin configuration when in the context of Android Studio. This was causing
 more problems than it solved (and may not even have solved anything). 

--- a/CONTRIBUTING.asciidoc
+++ b/CONTRIBUTING.asciidoc
@@ -5,7 +5,7 @@ This file is meant to help contributors working on the project. Please see the h
 ./gradlew installForFuncTest
 ----
 == Run the tests
-To run all the tests:
+To run all the checks:
 ----
 ./gradlew check
 ----
@@ -23,8 +23,19 @@ This runs all the functional tests against only the latest-support combination o
 ----
 ./gradlew functionalTest -DfuncTest.quick
 ----
+or
+----
+./gradlew quickFunctionalTest
+----
+> Protip. You can also use `./gradlew qFT` and save yourself some typing.
+
 If you want to run tests against only a subset of the suite, use Gradle's `--tests` option
 https://docs.gradle.org/current/userguide/java_testing.html#simple_name_pattern[support]:
 ----
 ./gradlew functionalTest --tests AnnotationProcessorSpec
+----
+You can combine quick tests with test filtering, but you must use the more verbose quick-test
+syntax:
+----
+./gradlew functionalTest --tests AnnotationProcessorSpec -DfuncTest.quick
 ----

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -233,6 +233,7 @@ val publishToMavenCentral = tasks.named("publishToMavenCentral") {
   // Note that publishing non-snapshots requires a successful smokeTest
   if (!(project.version as String).endsWith("SNAPSHOT")) {
     dependsOn(check, smokeTest)
+    finalizedBy(tasks.named("promote"))
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,7 +152,8 @@ val forkEvery =
 
 // Add a task to run the functional tests
 // quickTest only runs against the latest gradle version. For iterating faster
-val quickTest: Boolean = System.getProperty("funcTest.quick") != null
+fun quickTest(): Boolean = System.getProperty("funcTest.quick") != null
+
 val functionalTest by tasks.registering(Test::class) {
   dependsOn(deleteOldFuncTests, installForFuncTest)
   mustRunAfter(tasks.named("test"))
@@ -170,11 +171,16 @@ val functionalTest by tasks.registering(Test::class) {
   // Workaround for https://github.com/gradle/gradle/issues/4506#issuecomment-570815277
   systemProperty("org.gradle.testkit.dir", file("${buildDir}/tmp/test-kit"))
   systemProperty("com.autonomousapps.pluginversion", version.toString())
-  systemProperty("com.autonomousapps.quick", "$quickTest")
+  systemProperty("com.autonomousapps.quick", "${quickTest()}")
 
   beforeTest(closureOf<TestDescriptor> {
     logger.lifecycle("Running test: $this")
   })
+}
+
+val quickFunctionalTest by tasks.registering {
+  dependsOn(functionalTest)
+  System.setProperty("funcTest.quick", "true")
 }
 
 val smokeTestVersionKey = "com.autonomousapps.version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.parallel=true
 # https://docs.gradle.org/6.5-rc-1/userguide/gradle_daemon.html#sec:daemon_watch_fs
 org.gradle.unsafe.watch-fs=true
 
-VERSION=0.55.1-SNAPSHOT
+VERSION=0.56.0-SNAPSHOT
 
 # https://docs.gradle.org/6.5-rc-1/userguide/configuration_cache.html#use_project_during_execution
 # values include `on`, `warn`. The former will lead to build failures. The latter console warnings.

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/AssembleArchivesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/AssembleArchivesSpec.groovy
@@ -1,0 +1,26 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.SimpleJvmLibraryProject
+import spock.lang.Unroll
+
+import static com.autonomousapps.kit.truth.TestKitTruth.assertThat
+import static com.autonomousapps.utils.Runner.build
+
+final class AssembleArchivesSpec extends AbstractJvmSpec {
+  @Unroll
+  def "does not execute advice tasks as part of 'assemble' (#gradleVersion)"() {
+    given:
+    def project = new SimpleJvmLibraryProject()
+    gradleProject = project.gradleProject
+
+    when:
+    def result = build(gradleVersion, gradleProject.rootDir, 'proj:assemble')
+
+    then: 'only `assemble` ran'
+    assertThat(result).task(":proj:aggregateAdvice").isNull()
+    assertThat(result.tasks).containsExactlyPathsIn([":proj:assemble"])
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SimpleJvmLibraryProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SimpleJvmLibraryProject.groovy
@@ -1,0 +1,46 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+
+/**
+ * This project has the `java-library` plugin applied. We are only testing to see if `assemble` also
+ * executes advice tasks (it shouldn't).
+ */
+final class SimpleJvmLibraryProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  SimpleJvmLibraryProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('proj') { s ->
+      s.sources = [JAVA_SOURCE]
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private static final Source JAVA_SOURCE = new Source(
+    SourceType.JAVA, "Main", "com/example",
+    """\
+      package com.example;
+      
+      public class Main {
+        public static void main(String... args) {
+        }
+      }
+     """.stripIndent()
+  )
+}


### PR DESCRIPTION
This ensure it doesn't get hooked into the assemble task, which is bad news.

Finally resolves the issue whereby users executing `assemble` (or some variants thereof) would also have this plugin's artifacts assembled, which was normally not desirable. Per Gradle, this current automagic behavior is deprecated and will eventually be removed (along with the old "archives" configuration).