### PR TITLE
Lookup Kotlin classes compiled by the multiplatform plugin

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -172,6 +172,7 @@ internal abstract class JvmAnalyzer(
   protected fun javaCompileTask() = project.tasks.namedOrNull("compileJava")
 
   protected fun kotlinCompileTask() = project.tasks.namedOrNull("compileKotlin")
+    ?: project.tasks.namedOrNull("compileKotlinJvm") // for multiplatform projects
 
   protected fun getJarTask(): TaskProvider<Jar> = project.tasks.named(mainSourceSet.jarTaskName, Jar::class.java)
 

--- a/testkit/build.gradle.kts
+++ b/testkit/build.gradle.kts
@@ -66,7 +66,7 @@ publishing {
 tasks.withType<Sign>().configureEach {
   onlyIf {
     val isNotSnapshot = !version.toString().endsWith("SNAPSHOT")
-    isNotSnapshot //&& gradle.taskGraph.hasTask(publishToMavenCentral.get())
+    isNotSnapshot && (findProperty("signing.keyId") != null)
   }
 }
 


### PR DESCRIPTION
For KMP, the KotlinCompile task is named `compileKotlinJvm` instead of `compileKotlin`. 

On `apollo-android:apollo-api`, this changes the output from:

```
Unused dependencies which should be removed:
- null("org.jetbrains.kotlin:kotlin-stdlib:1.3.72")
Transitively used dependencies that should be declared directly as indicated:
- null("org.jetbrains.kotlin:kotlin-stdlib:1.3.72"
```

to 

```
> Task :apollo-api:aggregateAdvice
Transitively used dependencies that should be declared directly as indicated:
- api("org.jetbrains.kotlin:kotlin-stdlib:1.3.72")
- api("com.squareup.okio:okio:2.7.0")
```

