### PR TITLE
Resolves issue 255. LocateDependenciesTask cannot declare all its inputs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Dependency Analysis Plugin Changelog
 
+# Version 0.57.0 (unreleased)
+* [Fixed] LocateDependenciesTask remains up to date even after changing dependency configurations
+([Issue 255](https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/255)).
+
 # Version 0.56.0
 * [Fixed] Unhook plugin from `assemble` task, to which it was yoked against its will. The upshot is
 that running `assemble` will no longer trigger the plugin's tasks to run. Using the 

--- a/src/main/kotlin/com/autonomousapps/tasks/LocateDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/LocateDependenciesTask.kt
@@ -17,6 +17,10 @@ abstract class LocateDependenciesTask : DefaultTask() {
   init {
     group = TASK_GROUP_DEP
     description = "Produces a report of all dependencies and the configurations on which they are declared"
+
+    // This task can never be up to date because we do not yet know a way to model having the
+    // configurations themselves (not the files they resolve to!) as an input
+    outputs.upToDateWhen { false }
   }
 
   @get:Optional


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/255.