### PR TITLE
Resolves Issue 173, misses inline member usage.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AndroidKotlinInlineSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AndroidKotlinInlineSpec.groovy
@@ -1,0 +1,30 @@
+package com.autonomousapps.android
+
+import com.autonomousapps.android.projects.AndroidKotlinInlineProject
+import org.gradle.util.GradleVersion
+import spock.lang.Unroll
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+/**
+ * Regression test for
+ * https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/173.
+ */
+final class AndroidKotlinInlineSpec extends AbstractAndroidSpec {
+  @Unroll
+  def "inline usage in a kotlin source set is recognized (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new AndroidKotlinInlineProject(agpVersion as String)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion as GradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.expectedAdvice).containsExactlyElementsIn(project.actualAdvice())
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidKotlinInlineProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidKotlinInlineProject.groovy
@@ -1,0 +1,75 @@
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.AdviceHelper
+import com.autonomousapps.advice.Advice
+import com.autonomousapps.kit.AndroidBlock
+import com.autonomousapps.kit.BuildscriptBlock
+import com.autonomousapps.kit.Dependency
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.GradleProperties
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+
+final class AndroidKotlinInlineProject extends AbstractProject {
+
+  final GradleProject gradleProject
+  private final String agpVersion
+
+  AndroidKotlinInlineProject(String agpVersion) {
+    this.agpVersion = agpVersion
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withRootProject { root ->
+      root.gradleProperties = GradleProperties.minimalAndroidProperties()
+      root.withBuildScript { bs ->
+        bs.buildscript = BuildscriptBlock.defaultAndroidBuildscriptBlock(agpVersion)
+      }
+    }
+    builder.withAndroidSubproject('lib') { l ->
+      l.withBuildScript { bs ->
+        bs.plugins = [Plugin.androidLibPlugin, Plugin.kotlinAndroidPlugin]
+        bs.android = AndroidBlock.defaultAndroidLibBlock(true)
+        bs.dependencies = [
+          Dependency.coreKtx('implementation'),
+          Dependency.core('implementation'),
+          Dependency.kotlinStdLib('implementation')
+        ]
+      }
+      l.sources = sources
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private sources = [
+    new Source(
+      SourceType.KOTLIN, 'Library', 'com/example',
+      """\
+        package com.example
+        
+        import android.content.Context
+        import android.telephony.TelephonyManager
+        import androidx.core.content.getSystemService
+      
+        class Library {
+          fun provideTelephonyManager(context: Context): TelephonyManager {
+            return context.getSystemService()!!
+          }
+        }
+      """
+    )
+  ]
+
+  List<Advice> actualAdvice() {
+    return AdviceHelper.actualAdviceForFirstSubproject(gradleProject)
+  }
+
+  final List<Advice> expectedAdvice = []
+}

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -219,8 +219,7 @@ class DependencyAnalysisPlugin : Plugin<Project> {
       // If kotlin-android is applied, get the Kotlin source sets
       val kotlinSourceSets = findKotlinSourceSets()
 
-      val libExtension = the<LibraryExtension>()
-      libExtension.libraryVariants.all {
+      the<LibraryExtension>().libraryVariants.all {
         // Container of all source sets relevant to this variant
         val variantSourceSet = newVariantSourceSet(sourceSets, unitTestVariant?.sourceSets, kotlinSourceSets)
         val androidClassAnalyzer = AndroidLibAnalyzer(

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
@@ -176,17 +176,21 @@ internal abstract class AndroidAnalyzer<T : ClassAnalysisTask>(
     }
 
   private fun getSourceDirectories(): ConfigurableFileCollection {
+    // Java dirs regardless of whether they exist
     val javaDirs = variant.sourceSets.flatMap {
       it.javaDirectories
-    }.filter { it.exists() }
+    }
 
+    // Kotlin dirs, only if they exist. If we filtered the above for existence, and there was no
+    // Java dir, then this would also be empty.
     val kotlinDirs = javaDirs
       .map { it.path }
       .map { it.removeSuffix("java") + "kotlin" }
       .map { File(it) }
       .filter { it.exists() }
 
-    return project.files(javaDirs + kotlinDirs)
+    // Now finally filter Java dirs for existence
+    return project.files(javaDirs.filter { it.exists() } + kotlinDirs)
   }
 
   private fun getAndroidRes(): FileTree {

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
@@ -89,6 +89,11 @@ class Dependency @JvmOverloads constructor(
     }
 
     @JvmStatic
+    fun core(configuration: String): Dependency {
+      return Dependency(configuration, "androidx.core:core:1.1.0")
+    }
+
+    @JvmStatic
     fun navUiKtx(configuration: String): Dependency {
       return Dependency(configuration, "androidx.navigation:navigation-ui-ktx:2.1.0")
     }


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/173

The cause was failing to parse Kotlin source in src/main/kotlin in Android projects that failed to use android.sourceSets..., instead wrongly using sourceSets....