### PR TITLE
Emit warning when a dependency is on multiple configurations.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/DoubleDeclarationSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/DoubleDeclarationSpec.groovy
@@ -1,0 +1,29 @@
+package com.autonomousapps.android
+
+import com.autonomousapps.android.projects.DoubleDeclarationsProject
+import com.autonomousapps.android.projects.NativeLibProject
+import com.autonomousapps.fixtures.AndroidConstantsProject
+import com.autonomousapps.fixtures.LeakCanaryProject
+import spock.lang.Unroll
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class DoubleDeclarationSpec extends AbstractAndroidSpec {
+  @SuppressWarnings('GroovyAssignabilityCheck')
+  @Unroll
+  def "doesn't advise to move to api if on api and implementation (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new DoubleDeclarationsProject(agpVersion)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.expectedAdvice).containsExactlyElementsIn(project.actualAdvice())
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/DoubleDeclarationsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/DoubleDeclarationsProject.groovy
@@ -1,0 +1,72 @@
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.AdviceHelper
+import com.autonomousapps.advice.Advice
+import com.autonomousapps.kit.*
+
+import static com.autonomousapps.kit.Dependency.*
+import static com.autonomousapps.kit.Plugin.KOTLIN_VERSION
+
+final class DoubleDeclarationsProject extends AbstractProject {
+
+  final GradleProject gradleProject
+  private final String agpVersion
+
+  DoubleDeclarationsProject(String agpVersion) {
+    this.agpVersion = agpVersion
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withRootProject { root ->
+      root.gradleProperties = GradleProperties.minimalAndroidProperties()
+      root.withBuildScript { bs ->
+        bs.buildscript = BuildscriptBlock.defaultAndroidBuildscriptBlock(agpVersion)
+        bs.additions = """\
+          subprojects {
+            apply plugin: 'com.android.library'
+            dependencies {
+              implementation 'org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION'
+            }
+          }
+        """.stripIndent()
+      }
+    }
+    builder.withAndroidSubproject('lib') { a ->
+      a.withBuildScript { bs ->
+        bs.plugins = [Plugin.androidLibPlugin, Plugin.kotlinAndroidPlugin]
+        bs.android = AndroidBlock.defaultAndroidLibBlock(true)
+        bs.dependencies = dependencies
+      }
+      a.sources = sources
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private List<Dependency> dependencies = [
+    kotlinStdLib("api"),
+    appcompat("implementation"),
+  ]
+
+  private sources = [new Source(
+    SourceType.KOTLIN, "Main", "com/example", """\
+      package com.example
+      
+      // The annotation makes the stdlib part of the ABI
+      class Main @JvmOverloads constructor(i: Int = 0, j: Int = 0) {
+        fun magic() = 42
+      }
+    """.stripIndent()
+  )]
+
+  List<Advice> actualAdvice() {
+    return AdviceHelper.actualAdviceForFirstSubproject(gradleProject)
+  }
+
+  final List<Advice> expectedAdvice = []
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/NativeLibProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/NativeLibProject.groovy
@@ -5,9 +5,6 @@ import com.autonomousapps.AdviceHelper
 import com.autonomousapps.advice.Advice
 import com.autonomousapps.kit.*
 
-import static com.autonomousapps.AdviceHelper.dependency
-import static com.autonomousapps.AdviceHelper.transitiveDependency
-
 final class NativeLibProject extends AbstractProject {
 
   final GradleProject gradleProject

--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -67,6 +67,10 @@ internal inline fun <T, R> Iterable<T>.mapToOrderedSet(transform: (T) -> R): Set
 }
 
 internal inline fun <T, R> Iterable<T>.flatMapToSet(transform: (T) -> Iterable<R>): Set<R> {
+  return flatMapToMutableSet(transform)
+}
+
+internal inline fun <T, R> Iterable<T>.flatMapToMutableSet(transform: (T) -> Iterable<R>): MutableSet<R> {
   return flatMapTo(HashSet(collectionSizeOrDefault(10)), transform)
 }
 


### PR DESCRIPTION
Partially resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/257. This is likely to change based on response to [this question](https://gradle-community.slack.com/archives/CAH4ZP3GX/p1598847778029900) in the gradle slack.

nb I suspect I can make the algorithm a tad more efficient.