### PR TITLE
Kotlin stdlib should be a dependency bundle by default.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/DependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/DependenciesSpec.groovy
@@ -12,32 +12,7 @@ import static com.google.common.truth.Truth.assertThat
 final class DependenciesSpec extends AbstractAndroidSpec {
 
   @Unroll
-  def "kotlin stdlib can be declared a dependency bundle (#gradleVersion)"() {
-    given:
-    def additions = """\
-      dependencyAnalysis {
-        dependencies {
-          bundle("kotlin-stdlib") {
-            includeGroup("org.jetbrains.kotlin")
-          }
-        }
-      }
-    """
-    def project = new KotlinStdlibProject(additions)
-    gradleProject = project.gradleProject
-
-    when:
-    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
-
-    then: 'no advice'
-    assertThat(actualAdvice()).containsExactlyElementsIn(project.expectedFacadeAdvice())
-
-    where:
-    gradleVersion << gradleVersions()
-  }
-
-  @Unroll
-  def "kotlin stdlib should be changed when NOT declared a dependency bundle (#gradleVersion)"() {
+  def "kotlin stdlib is a dependency bundle by default (#gradleVersion)"() {
     given:
     def project = new KotlinStdlibProject()
     gradleProject = project.gradleProject
@@ -46,7 +21,7 @@ final class DependenciesSpec extends AbstractAndroidSpec {
     build(gradleVersion, gradleProject.rootDir, 'buildHealth')
 
     then: 'advice to change stdlib deps'
-    assertThat(actualAdvice()).containsExactlyElementsIn(project.expectedNoFacadeAdvice())
+    assertThat(actualAdvice()).containsExactlyElementsIn(project.expectedBundleAdvice())
 
     where:
     gradleVersion << gradleVersions()

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/KotlinStdlibProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/KotlinStdlibProject.groovy
@@ -59,12 +59,12 @@ final class KotlinStdlibProject extends AbstractProject {
   ]
 
   @SuppressWarnings("GrMethodMayBeStatic")
-  Set<Advice> expectedNoFacadeAdvice() {
+  Set<Advice> expectedNoBundleAdvice() {
     return [addCoreStdlib(), removeStdlib7()] as Set<Advice>
   }
 
   @SuppressWarnings("GrMethodMayBeStatic")
-  Set<Advice> expectedFacadeAdvice() {
+  Set<Advice> expectedBundleAdvice() {
     return [] as Set<Advice>
   }
 

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
@@ -15,16 +15,14 @@ import org.gradle.kotlin.dsl.property
 @Suppress("MemberVisibilityCanBePrivate")
 open class DependencyAnalysisExtension(objects: ObjectFactory) : AbstractExtension(objects) {
 
-  internal val autoApply: Property<Boolean> = objects.property<Boolean>().also {
-    it.convention(true)
-  }
+  internal val autoApply: Property<Boolean> = objects.property<Boolean>().convention(true)
 
   override val issueHandler = objects.newInstance(IssueHandler::class)
   internal val abiHandler = objects.newInstance(AbiHandler::class)
   internal val dependenciesHandler = objects.newInstance(DependenciesHandler::class)
 
-  @Deprecated("This is now a no-op; you should stop using it. It will be removed in v1.0.0")
   fun setVariants(vararg v: String) {
+    throw UnsupportedOperationException("This is now a no-op; you should stop using it. It will be removed in v1.0.0")
   }
 
   /**
@@ -37,8 +35,8 @@ open class DependencyAnalysisExtension(objects: ObjectFactory) : AbstractExtensi
     autoApply.disallowChanges()
   }
 
-  @Deprecated("This is now a no-op. Will be removed in 1.0")
   fun chatty(isChatty: Boolean) {
+    throw UnsupportedOperationException("This is now a no-op; you should stop using it. It will be removed in v1.0.0")
   }
 
   /**
@@ -52,23 +50,12 @@ open class DependencyAnalysisExtension(objects: ObjectFactory) : AbstractExtensi
    * ```
    * See the documentation on [DependenciesHandler] for more information.
    */
-  @Deprecated("Use dependencies { } instead. Will be removed in 1.0")
   fun setFacadeGroups(vararg facadeGroups: String) {
+    throw UnsupportedOperationException("Use dependencies { } instead. Will be removed in 1.0")
   }
 
-  /**
-   * This is now a no-op. Use instead
-   * ```
-   * dependencies {
-   *   bundle("my-group") {
-   *     ...
-   *   }
-   * }
-   * ```
-   * See the documentation on [DependenciesHandler] for more information.
-   */
-  @Deprecated("Use dependencies { bundle(\"my-group\") { ... } } instead. Will be removed in 1.0")
   fun setFacadeGroups(facadeGroups: Iterable<String>) {
+    throw UnsupportedOperationException("Use dependencies { bundle(\"my-group\") { ... } } instead. Will be removed in 1.0")
   }
 
   /**

--- a/src/main/kotlin/com/autonomousapps/extension/DependenciesHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/DependenciesHandler.kt
@@ -2,7 +2,10 @@
 
 package com.autonomousapps.extension
 
-import org.gradle.api.*
+import org.gradle.api.Action
+import org.gradle.api.GradleException
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.Named
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.SetProperty
 import org.gradle.kotlin.dsl.setProperty
@@ -30,7 +33,16 @@ import javax.inject.Inject
  */
 open class DependenciesHandler @Inject constructor(objects: ObjectFactory) {
 
-  val bundles: NamedDomainObjectContainer<BundleHandler> = objects.domainObjectContainer(BundleHandler::class.java)
+  val bundles = objects.domainObjectContainer(BundleHandler::class.java)
+
+  init {
+    // With Kotlin plugin 1.4, the stdlib is now applied by default. It makes no sense to warn users
+    // about this, even if it is "incorrect." So make all stdlib-related libraries a bundle and call
+    // it a day.
+    bundle("__kotlin-stdlib") {
+      include(".*kotlin-stdlib.*")
+    }
+  }
 
   fun bundle(name: String, action: Action<BundleHandler>) {
     try {


### PR DESCRIPTION
Improve support for Kotlin 1.4, wherein the plugin adds the stdlib by default.

Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/262.