### PR TITLE
Initial pass at making the variant ABI more accessible.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/AbstractAbiPostProcessingTask.kt
+++ b/src/main/kotlin/com/autonomousapps/AbstractAbiPostProcessingTask.kt
@@ -1,0 +1,22 @@
+package com.autonomousapps
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+
+abstract class AbstractAbiPostProcessingTask : DefaultTask() {
+
+  init {
+    group = TASK_GROUP_DEP
+  }
+
+  @get:PathSensitive(PathSensitivity.NONE)
+  @get:InputFile
+  abstract val input: RegularFileProperty
+
+  fun abiDump(): String {
+    return input.get().asFile.readText()
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/AbstractExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/AbstractExtension.kt
@@ -3,26 +3,40 @@
 package com.autonomousapps
 
 import com.autonomousapps.extension.IssueHandler
-import org.gradle.api.Action
+import com.autonomousapps.internal.utils.getLogger
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.kotlin.dsl.newInstance
 
 @Suppress("MemberVisibilityCanBePrivate")
 abstract class AbstractExtension(private val objects: ObjectFactory) {
 
+  private val logger = getLogger<DependencyAnalysisPlugin>()
+
   internal abstract val issueHandler: IssueHandler
 
   private val adviceOutput = objects.fileProperty()
+  private val abiDumpOutputs = mutableMapOf<String, RegularFileProperty>()
+
+  internal var postProcessingTask: TaskProvider<out AbstractPostProcessingTask>? = null
+  private val abiPostProcessingTasks = mutableMapOf<String, TaskProvider<out AbstractAbiPostProcessingTask>>()
 
   internal fun storeAdviceOutput(provider: Provider<RegularFile>) {
     val output = objects.fileProperty().also {
       it.set(provider)
     }
     adviceOutput.set(output)
+  }
+
+  internal fun storeAbiDumpOutput(provider: Provider<RegularFile>, variantName: String) {
+    val output = objects.fileProperty().also {
+      it.set(provider)
+    }
+    abiDumpOutputs.putIfAbsent(variantName, output)?.also {
+      logger.warn("Attempt to add output to $variantName ignored")
+    }
   }
 
   /**
@@ -36,7 +50,16 @@ abstract class AbstractExtension(private val objects: ObjectFactory) {
     return adviceOutput
   }
 
-  internal var postProcessingTask: TaskProvider<out AbstractPostProcessingTask>? = null
+  /**
+   * Returns the output from the variant-level ABI dump task, produced by the
+   * [AbiAnalysisTask][com.autonomousapps.tasks.AbiAnalysisTask].
+   * This output is a simple text file.
+   *
+   * Never null, but may _contain_ a null value. Use with [RegularFileProperty.getOrNull].
+   */
+  fun abiDumpOutputFor(variantName: String): RegularFileProperty {
+    return abiDumpOutputs[variantName] ?: error("Missing ABI dump output for $variantName")
+  }
 
   /**
    * Register your custom task that post-processes the [com.autonomousapps.advice.ComprehensiveAdvice]
@@ -44,8 +67,23 @@ abstract class AbstractExtension(private val objects: ObjectFactory) {
    */
   fun registerPostProcessingTask(task: TaskProvider<out AbstractPostProcessingTask>) {
     postProcessingTask = task
-    postProcessingTask.configure {
+    task.configure {
       input.set(adviceOutput())
     }
+  }
+
+  fun registerAbiPostProcessingTask(
+    task: TaskProvider<out AbstractAbiPostProcessingTask>, variantName: String
+  ) {
+    abiPostProcessingTasks.putIfAbsent(variantName, task)?.also {
+      logger.warn("An ABI post-processing task has already been registered for variant $variantName")
+    }
+    task.configure {
+      input.set(abiDumpOutputFor(variantName))
+    }
+  }
+
+  fun abiPostProcessingTaskFor(variantName: String): TaskProvider<out AbstractAbiPostProcessingTask>? {
+    return abiPostProcessingTasks[variantName]
   }
 }

--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -38,7 +38,7 @@ internal class OutputPaths(private val project: Project, variantName: String) {
   val declaredProcPrettyPath = layout("${intermediatesDir}/procs-declared-pretty.json")
   val unusedProcPath = layout("${intermediatesDir}/procs-unused.json")
   val abiAnalysisPath = layout("${intermediatesDir}/abi.json")
-  val abiDumpPath = layout("${intermediatesDir}/abi-dump.txt")
+  val abiDumpPath = layout("${variantDirectory}/abi-dump.txt")
   val advicePath = layout("${variantDirectory}/advice.json")
   val advicePrettyPath = layout("${variantDirectory}/advice-pretty.json")
   val adviceConsolePath = layout("${variantDirectory}/advice-console.json")


### PR DESCRIPTION
Intended to resolve https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/237.

This can be tested as follows:
```groovy
// Create a new task with type `AbstractPostProcessingTask`
def postDebug = tasks.register("postProcessDebug", AbstractAbiPostProcessingTask) {
  doLast {
    String abiDump = abiDump()
    println(abiDump)
  }
}

dependencyAnalysis {
  registerAbiPostProcessingTask(postDebug, "debug")
}
```
and then `./gradlew lib:postProcess`. You should see your ABI dump get printed to console.

This is very similar to the existing facility to consume the advice output, described in the wiki [here](https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/wiki/Post-processing).