### PR TITLE
Find lint jars. (But don't do much with them, yet.)

### DIFF
--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -232,7 +232,6 @@ class DependencyAnalysisPlugin : Plugin<Project> {
       val kotlinSourceSets = findKotlinSourceSets()
 
       the<LibraryExtension>().libraryVariants.all {
-        this.productFlavors.any { it.name == "one" }
         // Container of all source sets relevant to this variant
         val variantSourceSet = newVariantSourceSet(sourceSets, unitTestVariant?.sourceSets, kotlinSourceSets)
         val androidClassAnalyzer = AndroidLibAnalyzer(
@@ -479,6 +478,9 @@ class DependencyAnalysisPlugin : Plugin<Project> {
         outputPretty.set(outputPaths.artifactsPrettyPath)
       }
 
+    // A report of dependencies that supply Android linters
+    val androidLintTask = dependencyAnalyzer.registerFindAndroidLintersTask(locateDependencies)
+
     // Produces a report that lists all dependencies, whether or not they're transitive, and
     // associated with the classes they contain.
     val findClassesTask =
@@ -492,6 +494,9 @@ class DependencyAnalysisPlugin : Plugin<Project> {
         )
 
         allArtifacts.set(artifactsReportTask.flatMap { it.output })
+        androidLintTask?.let { task ->
+          androidLinters.set(task.flatMap { it.output })
+        }
 
         allComponentsReport.set(outputPaths.allDeclaredDepsPath)
         allComponentsReportPretty.set(outputPaths.allDeclaredDepsPrettyPath)

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -484,7 +484,7 @@ class DependencyAnalysisPlugin : Plugin<Project> {
     // Produces a report that lists all dependencies, whether or not they're transitive, and
     // associated with the classes they contain.
     val findClassesTask =
-      tasks.register<FindClassesTask>("findClasses$variantTaskName") {
+      tasks.register<AnalyzeJarTask>("analyzeJar$variantTaskName") {
         val runtimeClasspath = configurations.getByName(dependencyAnalyzer.runtimeConfigurationName)
         configuration = runtimeClasspath
         artifactFiles.setFrom(

--- a/src/main/kotlin/com/autonomousapps/advice/ReasonableDependency.kt
+++ b/src/main/kotlin/com/autonomousapps/advice/ReasonableDependency.kt
@@ -12,6 +12,7 @@ data class ReasonableDependency(
   val isTransitive: Boolean,
   val isCompileOnly: Boolean,
   val securityProviders: Set<String>? = null,
+  val androidLinters: String? = null,
 
   // TODO these three have a lot of overlap. Model it somehow?
   val publicClasses: Set<String>?,
@@ -48,7 +49,7 @@ data class ReasonableDependency(
     var providesNativeLibs: Boolean? = null
 
     fun build(): ReasonableDependency {
-      val component = component ?: error("component required")
+      val component = component ?: error("component missing for $dependency")
       val constantFields = component.constantFields.filter { (_, value) ->
         value.isNotEmpty()
       }
@@ -62,6 +63,7 @@ data class ReasonableDependency(
         isTransitive = component.isTransitive,
         isCompileOnly = component.isCompileOnlyAnnotations,
         securityProviders = securityProviders,
+        androidLinters = component.androidLintRegistry,
 
         publicClasses = publicClasses,
         usedTransitiveClasses = usedTransitiveClasses,

--- a/src/main/kotlin/com/autonomousapps/graph/Node.kt
+++ b/src/main/kotlin/com/autonomousapps/graph/Node.kt
@@ -72,6 +72,10 @@ internal object NodePrinter {
       append("- provides these security providers:\n")
       append(securityProviders(reasonableDependency.securityProviders))
     }
+    reasonableDependency.androidLinters?.let { linter ->
+      append("- provides an Android linter:\n")
+      append("  - $linter")
+    }
     if (reasonableDependency.providesInlineMembers == true) append("- provides inline functions\n")
     if (reasonableDependency.manifestComponents?.isNotEmpty() == true) {
       append("- provides these Android manifest components:\n")

--- a/src/main/kotlin/com/autonomousapps/internal/ConfigurationsToDependenciesTransformer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/ConfigurationsToDependenciesTransformer.kt
@@ -23,8 +23,8 @@ internal class ConfigurationsToDependenciesTransformer(
     val candidateConfNames = buildConfNames() + buildAPConfNames()
 
     // Partition all configurations into those we care about and those we don't
-    val (interestingConfs, otherConfs) = configurations.partition {
-      candidateConfNames.contains(it.name)
+    val (interestingConfs, otherConfs) = configurations.partition { conf ->
+      candidateConfNames.contains(conf.name)
     }
 
     // TODO combine these into one sink
@@ -55,13 +55,12 @@ internal class ConfigurationsToDependenciesTransformer(
           isInteresting = false
         )
       }
-    }
+    }.filterToSet { boring ->
       // if a dependency is in both sets, prefer interestingLocations over boringLocations
-      .filterToSet { boring ->
-        interestingLocations.none { interesting ->
-          boring.identifier == interesting.identifier
-        }
+      interestingLocations.none { interesting ->
+        boring.identifier == interesting.identifier
       }
+    }
 
     // Warn if dependency is declared on multiple configurations
     warnings.entries.forEach { (identifier, configurations) ->

--- a/src/main/kotlin/com/autonomousapps/internal/JarAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/JarAnalyzer.kt
@@ -2,11 +2,7 @@ package com.autonomousapps.internal
 
 import com.autonomousapps.advice.Dependency
 import com.autonomousapps.internal.asm.ClassReader
-import com.autonomousapps.internal.utils.asClassFiles
-import com.autonomousapps.internal.utils.mapNotNullToSet
-import com.autonomousapps.internal.utils.mapToOrderedSet
-import com.autonomousapps.internal.utils.mapToSet
-import com.autonomousapps.internal.utils.toIdentifier
+import com.autonomousapps.internal.utils.*
 import com.autonomousapps.services.InMemoryCache
 import org.gradle.api.GradleException
 import org.gradle.api.artifacts.Configuration
@@ -19,11 +15,12 @@ import org.gradle.api.logging.Logger
 import java.util.zip.ZipFile
 
 /**
- * Used by [DependencyReportTask][com.autonomousapps.tasks.FindClassesTask].
+ * Used by [com.autonomousapps.tasks.FindClassesTask].
  */
 internal class JarAnalyzer(
   private val configuration: Configuration,
   private val artifacts: List<Artifact>,
+  private val androidLinters: Set<AndroidLinterDependency>,
   private val logger: Logger,
   private val inMemoryCache: InMemoryCache
 ) {
@@ -50,7 +47,11 @@ internal class JarAnalyzer(
   private fun Iterable<Artifact>.asComponents(): List<Component> =
     map { artifact ->
       val analyzedJar = analyzeJar(artifact)
-      Component(artifact = artifact, analyzedJar = analyzedJar)
+      Component(
+        artifact = artifact,
+        analyzedJar = analyzedJar,
+        androidLinterCandidates = androidLinters
+      )
     }.sorted()
 
   /**

--- a/src/main/kotlin/com/autonomousapps/internal/JarAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/JarAnalyzer.kt
@@ -15,7 +15,7 @@ import org.gradle.api.logging.Logger
 import java.util.zip.ZipFile
 
 /**
- * Used by [com.autonomousapps.tasks.FindClassesTask].
+ * Used by [com.autonomousapps.tasks.AnalyzeJarTask].
  */
 internal class JarAnalyzer(
   private val configuration: Configuration,

--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -34,6 +34,7 @@ internal class OutputPaths(private val project: Project, variantName: String) {
   val usedVariantDependenciesPath = layout("${intermediatesDir}/used-variant-dependencies.json")
   val serviceLoaderDependenciesPath = layout("${intermediatesDir}/service-loaders.json")
   val nativeDependenciesPath = layout("${intermediatesDir}/native-libs.json")
+  val androidLintersPath = layout("${intermediatesDir}/android-linters.json")
   val declaredProcPath = layout("${intermediatesDir}/procs-declared.json")
   val declaredProcPrettyPath = layout("${intermediatesDir}/procs-declared-pretty.json")
   val unusedProcPath = layout("${intermediatesDir}/procs-unused.json")

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
@@ -318,12 +318,12 @@ internal class AndroidLibAnalyzer(
     }
 
   override fun registerAbiAnalysisTask(
-    findClassesTask: TaskProvider<FindClassesTask>,
+    analyzeJarTask: TaskProvider<AnalyzeJarTask>,
     abiExclusions: Provider<String>
   ): TaskProvider<AbiAnalysisTask> =
     project.tasks.register<AbiAnalysisTask>("abiAnalysis$variantNameCapitalized") {
       jar.set(getBundleTaskOutput())
-      dependencies.set(findClassesTask.flatMap { it.allComponentsReport })
+      dependencies.set(analyzeJarTask.flatMap { it.allComponentsReport })
       exclusions.set(abiExclusions)
 
       output.set(outputPaths.abiAnalysisPath)

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
@@ -69,6 +69,10 @@ internal interface DependencyAnalyzer<T : ClassAnalysisTask> {
     locateDependenciesTask: TaskProvider<LocateDependenciesTask>
   ): TaskProvider<FindNativeLibsTask>? = null
 
+  fun registerFindAndroidLintersTask(
+    locateDependenciesTask: TaskProvider<LocateDependenciesTask>
+  ): TaskProvider<FindAndroidLinters>? = null
+
   fun registerFindDeclaredProcsTask(
     inMemoryCacheProvider: Provider<InMemoryCache>,
     locateDependenciesTask: TaskProvider<LocateDependenciesTask>

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
@@ -88,7 +88,7 @@ internal interface DependencyAnalyzer<T : ClassAnalysisTask> {
    * Spring Boot), since they have no meaningful ABI.
    */
   fun registerAbiAnalysisTask(
-    findClassesTask: TaskProvider<FindClassesTask>,
+    analyzeJarTask: TaskProvider<AnalyzeJarTask>,
     abiExclusions: Provider<String>
   ): TaskProvider<AbiAnalysisTask>? = null
 }

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -160,13 +160,13 @@ internal class JavaLibAnalyzer(project: Project, sourceSet: SourceSet, testSourc
   : JvmAnalyzer(project, JavaSourceSet(sourceSet), testSourceSet?.let { JavaSourceSet(it) }) {
 
   override fun registerAbiAnalysisTask(
-    findClassesTask: TaskProvider<FindClassesTask>,
+    analyzeJarTask: TaskProvider<AnalyzeJarTask>,
     abiExclusions: Provider<String>
   ): TaskProvider<AbiAnalysisTask>? =
     project.tasks.register<AbiAnalysisTask>("abiAnalysis$variantNameCapitalized") {
       javaCompileTask()?.let { javaClasses.from(it.get().outputs.files.asFileTree) }
       kotlinCompileTask()?.let { kotlinClasses.from(it.get().outputs.files.asFileTree) }
-      dependencies.set(findClassesTask.flatMap { it.allComponentsReport })
+      dependencies.set(analyzeJarTask.flatMap { it.allComponentsReport })
       exclusions.set(abiExclusions)
 
       output.set(outputPaths.abiAnalysisPath)
@@ -207,12 +207,12 @@ internal class KotlinJvmLibAnalyzer(
 ) {
 
   override fun registerAbiAnalysisTask(
-    findClassesTask: TaskProvider<FindClassesTask>,
+    analyzeJarTask: TaskProvider<AnalyzeJarTask>,
     abiExclusions: Provider<String>
   ) = project.tasks.register<AbiAnalysisTask>("abiAnalysis$variantNameCapitalized") {
     javaCompileTask()?.let { javaClasses.from(it.get().outputs.files.asFileTree) }
     kotlinCompileTask()?.let { kotlinClasses.from(it.get().outputs.files.asFileTree) }
-    dependencies.set(findClassesTask.flatMap { it.allComponentsReport })
+    dependencies.set(analyzeJarTask.flatMap { it.allComponentsReport })
 
     output.set(outputPaths.abiAnalysisPath)
     abiDump.set(outputPaths.abiDumpPath)

--- a/src/main/kotlin/com/autonomousapps/internal/metaInf.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/metaInf.kt
@@ -1,0 +1,22 @@
+/*
+ * HIYA CONFIDENTIAL
+ * __________________
+ *
+ * (c) 2020 Hiya, Inc.
+ * All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Hiya, Inc. The intellectual and technical
+ * concepts contained herein are proprietary to Hiya, Inc.
+ * may be covered by U.S. and foreign patents, and are
+ * protected by trade secret or copyright law.  Dissemination
+ * of or reproduction of this material is strictly forbidden
+ * unless prior written permission is obtained from Hiya, Inc.
+ */
+
+package com.autonomousapps.internal
+
+internal const val MANIFEST_PATH = "META-INF/MANIFEST.MF"
+internal const val SERVICE_LOADER_PATH = "META-INF/services/"
+internal const val ANNOTATION_PROCESSOR_PATH = "META-INF/services/javax.annotation.processing.Processor"
+internal const val LINT_ISSUE_REGISTRY_PATH = "META-INF/services/com.android.tools.lint.client.api.IssueRegistry"

--- a/src/main/kotlin/com/autonomousapps/tasks/AnalyzeJarTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AnalyzeJarTask.kt
@@ -25,7 +25,7 @@ import org.gradle.api.tasks.*
  * TODO this is perhaps wrong/unnecessary. See TODO below.
  */
 @CacheableTask
-abstract class FindClassesTask : DefaultTask() {
+abstract class AnalyzeJarTask : DefaultTask() {
 
   init {
     group = TASK_GROUP_DEP_INTERNAL

--- a/src/main/kotlin/com/autonomousapps/tasks/FindAndroidLinters.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindAndroidLinters.kt
@@ -1,0 +1,85 @@
+package com.autonomousapps.tasks
+
+import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
+import com.autonomousapps.internal.AndroidLinterDependency
+import com.autonomousapps.internal.LINT_ISSUE_REGISTRY_PATH
+import com.autonomousapps.internal.Location
+import com.autonomousapps.internal.MANIFEST_PATH
+import com.autonomousapps.internal.utils.fromJsonSet
+import com.autonomousapps.internal.utils.getAndDelete
+import com.autonomousapps.internal.utils.toJson
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.artifacts.ArtifactCollection
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.*
+import java.io.BufferedReader
+import java.io.File
+import java.util.zip.ZipFile
+
+abstract class FindAndroidLinters : DefaultTask() {
+
+  init {
+    group = TASK_GROUP_DEP_INTERNAL
+    description = "Produces a report of dependencies that supply Android linters"
+  }
+
+  private lateinit var lintJars: ArtifactCollection
+
+  fun setLintJars(lintJars: ArtifactCollection) {
+    this.lintJars = lintJars
+  }
+
+  @PathSensitive(PathSensitivity.RELATIVE)
+  @InputFiles
+  fun getArtifactFiles(): FileCollection = lintJars.artifactFiles
+
+  @get:PathSensitive(PathSensitivity.NONE)
+  @get:InputFile
+  abstract val locations: RegularFileProperty
+
+  @get:OutputFile
+  abstract val output: RegularFileProperty
+
+  @TaskAction fun action() {
+    val outputFile = output.getAndDelete()
+
+    val candidates = locations.fromJsonSet<Location>()
+
+    val linters = lintJars.mapNotNull {
+      try {
+        AndroidLinterDependency(
+          componentIdentifier = it.id.componentIdentifier,
+          candidates = candidates,
+          lintRegistry = findLintRegistry(it.file)
+        )
+      } catch (e: GradleException) {
+        null
+      }
+    }
+
+    logger.debug("linters:\n${linters.joinToString(prefix = "- ", separator = "\n- ")}")
+    outputFile.writeText(linters.toJson())
+  }
+
+  private fun findLintRegistry(jar: File): String {
+    val zip = ZipFile(jar)
+
+    val manifestEntry: String? = zip.getEntry(MANIFEST_PATH)?.run {
+      zip.getInputStream(this).bufferedReader().use(BufferedReader::readLines)
+        .find { it.startsWith("Lint-Registry") }
+        ?.substringAfter(":")?.trim()
+    }
+    if (manifestEntry != null) return manifestEntry
+
+    val serviceEntry: String? = zip.getEntry(LINT_ISSUE_REGISTRY_PATH)?.run {
+      zip.getInputStream(this).bufferedReader().use(BufferedReader::readLines)
+        .first().trim()
+    }
+    if (serviceEntry != null) return serviceEntry
+
+    // One of the above should be non-null
+    throw GradleException("No linter issue registry for ${jar.path}")
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
@@ -1,6 +1,7 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
+import com.autonomousapps.internal.ANNOTATION_PROCESSOR_PATH
 import com.autonomousapps.internal.AnnotationProcessor
 import com.autonomousapps.internal.Location
 import com.autonomousapps.internal.utils.fromJsonSet
@@ -55,10 +56,6 @@ abstract class FindDeclaredProcsTask : DefaultTask() {
   init {
     group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of all supported annotation types and their annotation processors"
-  }
-
-  companion object {
-    internal const val ANNOTATION_PROCESSOR_PATH = "META-INF/services/javax.annotation.processing.Processor"
   }
 
   private var kaptArtifacts: ArtifactCollection? = null

--- a/src/main/kotlin/com/autonomousapps/tasks/FindNativeLibsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindNativeLibsTask.kt
@@ -34,7 +34,7 @@ abstract class FindNativeLibsTask : DefaultTask() {
 
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
-  abstract val dependencyConfigurations: RegularFileProperty
+  abstract val locations: RegularFileProperty
 
   @get:OutputFile
   abstract val output: RegularFileProperty
@@ -43,7 +43,7 @@ abstract class FindNativeLibsTask : DefaultTask() {
     val outputFile = output.getAndDelete()
 
     val nativeLibs = getArtifactFiles().asFileTree.files.mapToSet { it.name }
-    val candidates = dependencyConfigurations.fromJsonSet<Location>()
+    val candidates = locations.fromJsonSet<Location>()
 
     val artifacts = artifacts.mapNotNull {
       try {

--- a/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
@@ -1,10 +1,11 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
+import com.autonomousapps.internal.ANNOTATION_PROCESSOR_PATH
 import com.autonomousapps.internal.Location
+import com.autonomousapps.internal.SERVICE_LOADER_PATH
 import com.autonomousapps.internal.ServiceLoader
 import com.autonomousapps.internal.utils.*
-import com.autonomousapps.tasks.FindDeclaredProcsTask.Companion.ANNOTATION_PROCESSOR_PATH
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
@@ -26,10 +27,6 @@ abstract class FindServiceLoadersTask : DefaultTask() {
   init {
     group = TASK_GROUP_DEP_INTERNAL
     description = "Produces a report of all dependencies that include Java ServiceLoaders"
-  }
-
-  companion object {
-    private const val SERVICE_LOADER_PATH = "META-INF/services/"
   }
 
   @get:Internal
@@ -70,7 +67,8 @@ abstract class FindServiceLoadersTask : DefaultTask() {
       .filterNot { it.name.startsWith(ANNOTATION_PROCESSOR_PATH) }
       .filterNot { it.isDirectory }
       .mapToOrderedSet { serviceFile ->
-        val providerClasses = zip.getInputStream(serviceFile).bufferedReader().use(BufferedReader::readLines)
+        val providerClasses = zip.getInputStream(serviceFile)
+          .bufferedReader().use(BufferedReader::readLines)
           // remove whitespace
           .map { it.trim() }
           // Ignore comments

--- a/src/test/kotlin/com/autonomousapps/internal/JarAnalyzerTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/JarAnalyzerTest.kt
@@ -22,6 +22,7 @@ class JarAnalyzerTest {
     val transformer = JarAnalyzer(
       fixture.mockConfiguration,
       fixture.givenArtifacts,
+      emptySet(),
       mock(),
       StubInMemoryCache()
     )


### PR DESCRIPTION
Partially resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/303.

So far this PR only 
1. Finds android libraries that include lint jars
2. Includes this information in certain reports (including `reason`)

It does not yet use it for computing advice. To do that, I think I will need to also check if the library is either
1. being used in some other capacity (for example Timber, which is a library + a lint jar)
2. is _only_ a lint jar (such as the little robots RxLintRegistry)