### PR TITLE
Improved parsing of Kotlin source. Don't include Java Platforms in transitive relations.

### DIFF
--- a/antlr/build.gradle.kts
+++ b/antlr/build.gradle.kts
@@ -3,14 +3,15 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 
 plugins {
-    `java-library`
-    antlr
-    id("com.github.johnrengelman.shadow") version "5.2.0"
-    `maven-publish`
+  `java-library`
+  antlr
+  id("com.github.johnrengelman.shadow") version "5.2.0"
+  `maven-publish`
+  groovy
 }
 
 repositories {
-    jcenter()
+  jcenter()
 }
 
 group = "com.autonomousapps"
@@ -18,64 +19,72 @@ val antlrVersion: String by rootProject.extra // e.g., 4.8
 val internalAntlrVersion: String by rootProject.extra // e.g., 4.8.0
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 
-    withJavadocJar()
-    withSourcesJar()
+  withJavadocJar()
+  withSourcesJar()
 }
 
 // https://docs.gradle.org/current/userguide/antlr_plugin.html
 // https://discuss.gradle.org/t/using-gradle-2-10s-antlr-plugin-to-import-an-antlr-4-lexer-grammar-into-another-grammar/14970/6
 tasks.generateGrammarSource {
-    /*
-     * Ignore implied package structure for .g4 files and instead use this for all generated source.
-     */
-    val pkg = "com.autonomousapps.internal.grammar"
-    val dir = pkg.replace(".", "/")
-    outputDirectory = file("$buildDir/generated-src/antlr/main/$dir")
-    arguments = arguments + listOf(
-        // Specify the package declaration for generated Java source
-        "-package", pkg,
-        // Specify that generated Java source should go into the outputDirectory, regardless of package structure
-        "-Xexact-output-dir",
-        // Specify the location of "libs"; i.e., for grammars composed of multiple files
-        "-lib", "src/main/antlr/$dir"
-    )
+  /*
+   * Ignore implied package structure for .g4 files and instead use this for all generated source.
+   */
+  val pkg = "com.autonomousapps.internal.grammar"
+  val dir = pkg.replace(".", "/")
+  outputDirectory = file("$buildDir/generated-src/antlr/main/$dir")
+  arguments = arguments + listOf(
+    // Specify the package declaration for generated Java source
+    "-package", pkg,
+    // Specify that generated Java source should go into the outputDirectory, regardless of package structure
+    "-Xexact-output-dir",
+    // Specify the location of "libs"; i.e., for grammars composed of multiple files
+    "-lib", "src/main/antlr/$dir"
+  )
 }
 
 // Publish with `./gradlew antlr:publishShadowPublicationToMavenRepository`
 publishing {
-    publications {
-        create<MavenPublication>("shadow") {
-            groupId = "autonomousapps"
-            artifactId = "antlr"
-            version = internalAntlrVersion
+  publications {
+    create<MavenPublication>("shadow") {
+      groupId = "autonomousapps"
+      artifactId = "antlr"
+      version = internalAntlrVersion
 
-            //from components.java
-            project.shadow.component(this)
-        }
+      //from components.java
+      project.shadow.component(this)
     }
-    repositories {
-        maven {
-            url = uri("$buildDir/repo")
-        }
+  }
+  repositories {
+    maven {
+      url = uri("$buildDir/repo")
     }
+  }
 }
 
 dependencies {
-    antlr("org.antlr:antlr4:$antlrVersion")
-    implementation("org.antlr:antlr4-runtime:$antlrVersion")
+  antlr("org.antlr:antlr4:$antlrVersion")
+  implementation("org.antlr:antlr4-runtime:$antlrVersion")
+
+  testImplementation("org.spockframework:spock-core:1.3-groovy-2.5") {
+    exclude(module = "groovy-all")
+    because("For Spock tests")
+  }
+  testImplementation("com.google.truth:truth:1.0.1") {
+    because("Groovy's == behavior on Comparable classes is beyond stupid")
+  }
 }
 
 //jar.enabled = false
 
 tasks.register<ConfigureShadowRelocation>("relocateShadowJar") {
-    target = tasks.shadowJar.get()
+  target = tasks.shadowJar.get()
 }
 
 tasks.shadowJar {
-    dependsOn(tasks.getByName("relocateShadowJar"))
-    archiveClassifier.set("")
-    relocate("org.antlr", "com.autonomousapps.internal.antlr")
+  dependsOn(tasks.getByName("relocateShadowJar"))
+  archiveClassifier.set("")
+  relocate("org.antlr", "com.autonomousapps.internal.antlr")
 }

--- a/antlr/src/main/antlr/com/autonomousapps/internal/grammar/Simple.g4
+++ b/antlr/src/main/antlr/com/autonomousapps/internal/grammar/Simple.g4
@@ -1,7 +1,11 @@
 grammar Simple;
 
 file
-    :   packageDeclaration? importList .* EOF
+    :   fileAnnotation? .*? packageDeclaration? importList .*? EOF
+    ;
+
+fileAnnotation
+    :   '@file:JvmName("' Identifier+ '")'
     ;
 
 packageDeclaration

--- a/antlr/src/test/groovy/com/autonomousapps/SimpleSpec.groovy
+++ b/antlr/src/test/groovy/com/autonomousapps/SimpleSpec.groovy
@@ -1,0 +1,102 @@
+package com.autonomousapps
+
+import com.autonomousapps.internal.grammar.SimpleBaseListener
+import com.autonomousapps.internal.grammar.SimpleLexer
+import com.autonomousapps.internal.grammar.SimpleParser
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.tree.ParseTreeWalker
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static com.google.common.truth.Truth.assertThat
+
+class SimpleSpec extends Specification {
+
+  @Rule TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+  def "can find imports in Kotlin file without @JvmName annotation"() {
+    given:
+    def sourceFile = temporaryFolder.newFile("temp.kt")
+    sourceFile << """\
+    package com.hello
+    
+    import java.util.concurrent.atomic.AtomicBoolean
+    
+    fun method(): Boolean {
+      return AtomicBoolean().get()
+    }
+    """.stripMargin()
+
+    when:
+    def imports = parseSourceFileForImports(sourceFile)
+
+    then:
+    assertThat(imports.size()).isEqualTo(1)
+    assertThat(imports).containsExactly("java.util.concurrent.atomic.AtomicBoolean")
+  }
+
+  def "can find imports in Kotlin file with @JvmName annotation"() {
+    given:
+    def sourceFile = temporaryFolder.newFile("temp.kt")
+    sourceFile << """\
+    @file:JvmName("Hello")
+    
+    package com.hello
+    
+    import java.util.concurrent.atomic.AtomicBoolean
+    
+    fun method(): Boolean {
+      return AtomicBoolean().get()
+    }
+    """.stripMargin()
+
+    when:
+    def imports = parseSourceFileForImports(sourceFile)
+
+    then:
+    assertThat(imports.size()).isEqualTo(1)
+    assertThat(imports).containsExactly("java.util.concurrent.atomic.AtomicBoolean")
+  }
+
+  private static Set<String> parseSourceFileForImports(File file) {
+    def parser = newSimpleParser(file)
+    def importListener = walkTree(parser)
+    return importListener.imports()
+  }
+
+  private static SimpleParser newSimpleParser(File file) {
+    def input = new FileInputStream(file).withCloseable { CharStreams.fromStream(it) }
+    def lexer = new SimpleLexer(input)
+    def tokens = new CommonTokenStream(lexer)
+    return new SimpleParser(tokens)
+  }
+
+  private static SimpleImportListener walkTree(SimpleParser parser) {
+    def tree = parser.file()
+    def walker = new ParseTreeWalker()
+    def importListener = new SimpleImportListener()
+    walker.walk(importListener, tree)
+    return importListener
+  }
+
+  private static class SimpleImportListener extends SimpleBaseListener {
+
+    private def imports = [] as Set<String>
+
+    Set<String> imports() {
+      return imports
+    }
+
+    @Override
+    void enterImportDeclaration(SimpleParser.ImportDeclarationContext ctx) {
+      def qualifiedName = ctx.qualifiedName().text
+      if (ctx.children.any { it.text == "*" }) {
+        imports.add("$qualifiedName.*")
+      } else {
+        imports.add(qualifiedName)
+      }
+    }
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ configurations.getByName("smokeTestImplementation")
 val asmVersion = "8.0.1.0"
 
 val antlrVersion by extra("4.8")
-val internalAntlrVersion by extra("$antlrVersion.0")
+val internalAntlrVersion by extra("$antlrVersion.1")
 
 dependencies {
   implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
@@ -104,8 +104,7 @@ dependencies {
   testImplementation("com.squareup.okio:okio:2.6.0") {
     because("Easy IO APIs")
   }
-  val truthVersion = "1.0.1"
-  testImplementation("com.google.truth:truth:$truthVersion") {
+  testImplementation("com.google.truth:truth:1.0.1") {
     because("Groovy's == behavior on Comparable classes is beyond stupid")
   }
 

--- a/src/main/kotlin/com/autonomousapps/AbstractAbiPostProcessingTask.kt
+++ b/src/main/kotlin/com/autonomousapps/AbstractAbiPostProcessingTask.kt
@@ -1,5 +1,6 @@
 package com.autonomousapps
 
+import com.autonomousapps.internal.utils.readText
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
@@ -17,6 +18,6 @@ abstract class AbstractAbiPostProcessingTask : DefaultTask() {
   abstract val input: RegularFileProperty
 
   fun abiDump(): String {
-    return input.get().asFile.readText()
+    return input.readText()
   }
 }

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -428,6 +428,7 @@ class DependencyAnalysisPlugin : Plugin<Project> {
 
       projectReport.set(outputPaths.adviceAggregatePath)
       projectReportPretty.set(outputPaths.adviceAggregatePrettyPath)
+      ripplePath.set(outputPaths.ripplePath)
     }
 
     // A lifecycle task

--- a/src/main/kotlin/com/autonomousapps/advice/Ripple.kt
+++ b/src/main/kotlin/com/autonomousapps/advice/Ripple.kt
@@ -1,0 +1,6 @@
+package com.autonomousapps.advice
+
+// TODO
+data class Ripple(
+  val foo: String
+)

--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -96,6 +96,7 @@ internal class RootOutputPaths(private val project: Project) {
 
   val adviceAggregatePath = layout("$ROOT_DIR/advice-holistic.json")
   val adviceAggregatePrettyPath = layout("$ROOT_DIR/advice-holistic-pretty.json")
+  val ripplePath = layout("$ROOT_DIR/ripples.json")
 }
 
 internal class RedundantSubPluginOutputPaths(

--- a/src/main/kotlin/com/autonomousapps/internal/classReferenceParsers.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/classReferenceParsers.kt
@@ -2,7 +2,13 @@ package com.autonomousapps.internal
 
 import com.autonomousapps.advice.VariantFile
 import com.autonomousapps.internal.asm.ClassReader
-import com.autonomousapps.internal.utils.*
+import com.autonomousapps.internal.utils.JAVA_FQCN_REGEX_SLASHY
+import com.autonomousapps.internal.utils.asClassFiles
+import com.autonomousapps.internal.utils.buildDocument
+import com.autonomousapps.internal.utils.getLogger
+import com.autonomousapps.internal.utils.map
+import com.autonomousapps.internal.utils.mapToOrderedSet
+import com.autonomousapps.internal.utils.mapToSet
 import org.gradle.api.logging.Logger
 import java.io.File
 import java.util.zip.ZipFile

--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -158,17 +158,15 @@ internal inline fun <T> Collection<T>.reallyAll(predicate: (T) -> Boolean): Bool
   return true
 }
 
-internal fun <T> Set<T>.efficient(): Set<T> {
-  return when {
-    isEmpty() -> emptySet()
-    size == 1 -> Collections.singleton(first())
-    else -> this
-  }
+internal fun <T> Set<T>.efficient(): Set<T> = when {
+  isEmpty() -> emptySet()
+  size == 1 -> Collections.singleton(first())
+  else -> this
 }
 
 /**
- * Given a list of pairs, where the pairs are key -> value pairs, merge into a map (not losing any
- * keys).
+ * Given a list of pairs, where the pairs are key -> (value as Set) pairs, merge into a map (not
+ * losing any values).
  */
 internal fun <T, U> List<Pair<T, MutableSet<U>>>.mergedMap(): Map<T, Set<U>> {
   return foldRight(linkedMapOf<T, MutableSet<U>>()) { (key, values), map ->

--- a/src/main/kotlin/com/autonomousapps/internal/utils/utils.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/utils.kt
@@ -36,6 +36,8 @@ internal fun RegularFileProperty.readLines(): List<String> {
   return get().asFile.readLines()
 }
 
+internal fun RegularFileProperty.readText(): String = get().asFile.readText()
+
 // Print dependency tree (like running the `dependencies` task).
 @Suppress("unused")
 internal fun printDependencyTree(dependencies: Set<DependencyResult>, level: Int = 0) {

--- a/src/main/kotlin/com/autonomousapps/tasks/AdviceAggregateReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AdviceAggregateReportTask.kt
@@ -29,6 +29,9 @@ abstract class AdviceAggregateReportTask : DefaultTask() {
   @get:OutputFile
   abstract val projectReportPretty: RegularFileProperty
 
+  @get:OutputFile
+  abstract val ripplePath: RegularFileProperty
+
   @TaskAction
   fun action() {
     val projectReportFile = projectReport.getAndDelete()

--- a/src/main/kotlin/com/autonomousapps/tasks/AdviceSubprojectAggregationTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AdviceSubprojectAggregationTask.kt
@@ -24,6 +24,10 @@ abstract class AdviceSubprojectAggregationTask : DefaultTask() {
 
   private val projectPath = project.path
 
+  /*
+   * Inputs
+   */
+
   @get:PathSensitive(PathSensitivity.RELATIVE)
   @get:InputFiles
   abstract val dependencyAdvice: ListProperty<RegularFile>

--- a/src/main/kotlin/com/autonomousapps/tasks/GeneralUsageDetectionTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GeneralUsageDetectionTask.kt
@@ -6,10 +6,20 @@ import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.advice.Dependency
 import com.autonomousapps.internal.Component
 import com.autonomousapps.internal.Imports
-import com.autonomousapps.internal.utils.*
+import com.autonomousapps.internal.utils.flatMapToOrderedSet
+import com.autonomousapps.internal.utils.fromJsonList
+import com.autonomousapps.internal.utils.getAndDelete
+import com.autonomousapps.internal.utils.getLogger
+import com.autonomousapps.internal.utils.mapToSet
+import com.autonomousapps.internal.utils.toJson
+import com.autonomousapps.internal.utils.toPrettyString
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
@@ -74,8 +84,8 @@ abstract class GeneralUsageDetectionWorkAction : WorkAction<GeneralUsageDetectio
     val constantUsageReportFile = parameters.output.getAndDelete()
 
     // Inputs
-    val components = parameters.components.get().asFile.readText().fromJsonList<Component>()
-    val imports = parameters.importsFile.get().asFile.readText().fromJsonList<Imports>().flatten()
+    val components = parameters.components.fromJsonList<Component>()
+    val imports = parameters.importsFile.fromJsonList<Imports>().flatten()
 
     val usedDependencies = findUsedDependencies(components, imports)
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ImportFinderTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ImportFinderTask.kt
@@ -12,12 +12,18 @@ import com.autonomousapps.internal.grammar.SimpleBaseListener
 import com.autonomousapps.internal.grammar.SimpleLexer
 import com.autonomousapps.internal.grammar.SimpleParser
 import com.autonomousapps.internal.utils.flatMapToOrderedSet
+import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.getLogger
 import com.autonomousapps.internal.utils.toJson
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
@@ -78,8 +84,7 @@ abstract class ImportFinderWorkAction : WorkAction<ImportFinderParameters> {
 
   override fun execute() {
     // Output
-    val reportFile = parameters.constantUsageReport.get().asFile
-    reportFile.delete()
+    val reportFile = parameters.constantUsageReport.getAndDelete()
 
     val imports = ImportFinder(
       javaSourceFiles = parameters.javaSourceFiles,


### PR DESCRIPTION
Fixes two bugs:
1. Failed parsing of Kotlin source for import statements when that file includes `@file:JvmName("...")`
2. linking of dependencies to their used-transitive dependencies was over-zealous thanks to the inclusion of java platforms.