### PR TITLE
Added :ripples task and also fixed a few bugs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Dependency Analysis Plugin Changelog
 
+# Version 0.64.0 (unreleased)
+* [Fixed] Detect imports in Kotlin source even when @file:JvmName is used.
+* [Fixed] Filter out Java Platform modules when creating transitive-use relations.
+
 # Version 0.63.0
 * [New] Detect Android lint-only dependencies and do not suggest removing them.
 ([#303](https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/303))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Dependency Analysis Plugin Changelog
 
 # Version 0.64.0 (unreleased)
-* [Fixed] Detect imports in Kotlin source even when @file:JvmName is used.
+* [Fixed] Detect imports in Kotlin source even when @file:<Anything> is used.
 * [Fixed] Filter out Java Platform modules when creating transitive-use relations.
 
 # Version 0.63.0

--- a/antlr/src/main/antlr/com/autonomousapps/internal/grammar/Simple.g4
+++ b/antlr/src/main/antlr/com/autonomousapps/internal/grammar/Simple.g4
@@ -5,7 +5,7 @@ file
     ;
 
 fileAnnotation
-    :   '@file:JvmName("' Identifier+ '")'
+    :   '@file:' Identifier+ '("' Identifier+ '")'
     ;
 
 packageDeclaration

--- a/antlr/src/test/groovy/com/autonomousapps/SimpleSpec.groovy
+++ b/antlr/src/test/groovy/com/autonomousapps/SimpleSpec.groovy
@@ -16,7 +16,7 @@ class SimpleSpec extends Specification {
 
   @Rule TemporaryFolder temporaryFolder = new TemporaryFolder()
 
-  def "can find imports in Kotlin file without @JvmName annotation"() {
+  def "can find imports in Kotlin file without any file-level annotation"() {
     given:
     def sourceFile = temporaryFolder.newFile("temp.kt")
     sourceFile << """\
@@ -37,11 +37,34 @@ class SimpleSpec extends Specification {
     assertThat(imports).containsExactly("java.util.concurrent.atomic.AtomicBoolean")
   }
 
-  def "can find imports in Kotlin file with @JvmName annotation"() {
+  def "can find imports in Kotlin file with @file:JvmName annotation"() {
     given:
     def sourceFile = temporaryFolder.newFile("temp.kt")
     sourceFile << """\
     @file:JvmName("Hello")
+    
+    package com.hello
+    
+    import java.util.concurrent.atomic.AtomicBoolean
+    
+    fun method(): Boolean {
+      return AtomicBoolean().get()
+    }
+    """.stripMargin()
+
+    when:
+    def imports = parseSourceFileForImports(sourceFile)
+
+    then:
+    assertThat(imports.size()).isEqualTo(1)
+    assertThat(imports).containsExactly("java.util.concurrent.atomic.AtomicBoolean")
+  }
+
+  def "can find imports in Kotlin file with @file:Suppress annotation"() {
+    given:
+    def sourceFile = temporaryFolder.newFile("temp.kt")
+    sourceFile << """\
+    @file:Suppress("UnstableApiUsage")
     
     package com.hello
     

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ configurations.getByName("smokeTestImplementation")
 val asmVersion = "8.0.1.0"
 
 val antlrVersion by extra("4.8")
-val internalAntlrVersion by extra("$antlrVersion.1")
+val internalAntlrVersion by extra("$antlrVersion.2")
 
 dependencies {
   implementation(platform("org.jetbrains.kotlin:kotlin-bom"))

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -428,13 +428,18 @@ class DependencyAnalysisPlugin : Plugin<Project> {
 
       projectReport.set(outputPaths.adviceAggregatePath)
       projectReportPretty.set(outputPaths.adviceAggregatePrettyPath)
-      ripplePath.set(outputPaths.ripplePath)
+      rippleReport.set(outputPaths.ripplePath)
     }
 
-    // A lifecycle task
+    // A lifecycle task, always runs. Prints build health results to console
     tasks.register<BuildHealthTask>("buildHealth") {
       this@register.adviceReport.set(adviceReport.flatMap { it.projectReport })
       dependencyRenamingMap.set(getExtension().dependencyRenamingMap)
+    }
+
+    // A lifecycle task, always runs. Prints ripples to console
+    tasks.register<RipplesTask>("ripples") {
+      ripples.set(adviceReport.flatMap { it.rippleReport })
     }
   }
 

--- a/src/main/kotlin/com/autonomousapps/advice/Ripple.kt
+++ b/src/main/kotlin/com/autonomousapps/advice/Ripple.kt
@@ -1,6 +1,30 @@
 package com.autonomousapps.advice
 
-// TODO
 data class Ripple(
-  val foo: String
+  /** From the dependency project */
+  val upstreamRipple: UpstreamRipple,
+  /** On the dependent project */
+  val downstreamImpact: DownstreamImpact
+)
+
+data class UpstreamRipple(
+  /** The path of the project that may produce downstream impacts */
+  val projectPath: String,
+  /** The dependency implicated in the impact */
+  val providedDependency: Dependency,
+  /** The configuration that [providedDependency] is currently declared on in [projectPath] */
+  val fromConfiguration: String?,
+  /** The configuration on which the user should declare [providedDependency] on [projectPath] */
+  val toConfiguration: String?
+)
+
+data class DownstreamImpact(
+  /** The path of the project that may produce downstream impacts */
+  val parentProjectPath: String,
+  /** The path of the project that may be impacted by upstream changes */
+  val projectPath: String,
+  /** The dependency implicated in the impact */
+  val providedDependency: Dependency,
+  /** The configuration on which the user should declare [providedDependency] on [projectPath] */
+  val toConfiguration: String?
 )

--- a/src/main/kotlin/com/autonomousapps/internal/advice/RippleWriter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/RippleWriter.kt
@@ -1,0 +1,52 @@
+package com.autonomousapps.internal.advice
+
+import com.autonomousapps.advice.Ripple
+import com.autonomousapps.advice.UpstreamRipple
+import com.autonomousapps.internal.utils.colorize
+import org.gradle.kotlin.dsl.support.appendReproducibleNewLine
+
+internal class RippleWriter(
+  private val ripples: List<Ripple>
+) {
+
+  fun buildMessage(): String {
+    if (ripples.isEmpty()) {
+      return "Your project contains no potential ripples."
+    }
+
+    val msg = StringBuilder()
+    msg.appendReproducibleNewLine("Ripples:")
+    ripples.groupBy { it.upstreamRipple.projectPath }
+      .forEach { (dependencyProject, ripplesByProject) ->
+        msg.appendReproducibleNewLine("- You have been advised to make a change to ${dependencyProject.colorize()} that might impact dependent projects")
+
+        ripplesByProject.groupBy { it.upstreamRipple.providedDependency }
+          .forEach { (_, ripplesByDependency) ->
+            // subhead text
+            val changeText = ripplesByDependency.first().upstreamRipple.changeText()
+            msg.appendReproducibleNewLine("  - $changeText")
+
+            // downstream impacts
+            ripplesByDependency.forEach { r ->
+              val dependentProject = r.downstreamImpact.projectPath
+              val downstreamTo = r.downstreamImpact.toConfiguration
+              msg.appendReproducibleNewLine("    ${dependentProject.colorize()} uses this dependency transitively. You should add it to '$downstreamTo'")
+            }
+          }
+
+        // TODO remove once we have tests verifying the above works as expected
+//        ripplesByProject.forEach { r ->
+//          val dependentProject = r.downstreamImpact.projectPath
+//          val changeText = r.upstreamRipple.changeText()
+//          val downstreamTo = r.downstreamImpact.toConfiguration
+//          msg.appendReproducibleNewLine("  - $changeText") // TODO this line does not need to be repeated. Should do another grouping on ripple.upstreamRipple.providedDependency
+//            .appendReproducibleNewLine("    $dependentProject uses this dependency transitively. You should add it to '$downstreamTo'")
+//        }
+      }
+    return msg.toString()
+  }
+
+  private fun UpstreamRipple.changeText(): String =
+    if (toConfiguration == null) "Remove $providedDependency from '$fromConfiguration'"
+    else "Change $providedDependency from '$fromConfiguration' to '$toConfiguration'"
+}

--- a/src/main/kotlin/com/autonomousapps/internal/utils/colors.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/colors.kt
@@ -1,0 +1,15 @@
+package com.autonomousapps.internal.utils
+
+internal const val NORMAL = "\u001B[0m"
+internal const val GREEN_BOLD = "\u001B[1;32m"
+
+/**
+ * Colorizes string for console output. Default is [GREEN_BOLD].
+ *
+ * See also
+ * 1. [https://jakewharton.com/peeking-at-colorful-command-line-output/]
+ * 2. [https://en.wikipedia.org/wiki/ANSI_escape_code]
+ */
+internal fun String.colorize(style: String = GREEN_BOLD): String {
+  return "$style$this$NORMAL"
+}

--- a/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
@@ -1,11 +1,17 @@
 package com.autonomousapps.internal.utils
 
 import org.gradle.api.GradleException
-import org.gradle.api.artifacts.*
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.FileCollectionDependency
+import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.artifacts.SelfResolvingDependency
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Category
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier
 
@@ -60,12 +66,13 @@ internal fun Dependency.toIdentifier(
     identifier
   }
   is FileCollectionDependency -> {
-    with(files.files) {
-      // note that this will ignore any flat file dep beyond the first
-      if (isNotEmpty()) first().name else null
+    (files as? ConfigurableFileCollection)?.from?.let { from ->
+      from.firstOrNull() as? String
     }
   }
-  // Don't have enough information, so ignore it
+  // Don't have enough information, so ignore it. Please note that a `FileCollectionDependency` is
+  // also a `SelfResolvingDependency`, but not all `SelfResolvingDependency`s are
+  // `FileCollectionDependency`s.
   is SelfResolvingDependency -> null
   else -> throw GradleException("Unknown Dependency subtype: \n$this\n${javaClass.name}")
 }?.intern()

--- a/src/main/kotlin/com/autonomousapps/tasks/BuildHealthTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/BuildHealthTask.kt
@@ -14,6 +14,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.tasks.*
+import org.gradle.kotlin.dsl.support.appendReproducibleNewLine
 
 abstract class BuildHealthTask : DefaultTask() {
 
@@ -50,10 +51,8 @@ abstract class BuildHealthTask : DefaultTask() {
 
       val consoleText = advicePrinter.consoleText()
       buildHealthText
-        .append(projectHeaderText(projectAdvice.projectPath))
-        .append("\n")
-        .append(consoleText)
-        .append("\n")
+        .appendReproducibleNewLine(projectHeaderText(projectAdvice.projectPath))
+        .appendReproducibleNewLine(consoleText)
 
       // Only print to console if we're not configured to fail
       if (!shouldFail) {
@@ -79,7 +78,6 @@ abstract class BuildHealthTask : DefaultTask() {
     }
   }
 
-  // TODO if it's advice for root project and there IS no advice, emit nothing. There is often no source
   private fun projectHeaderText(projectPath: String): String =
     if (projectPath == ":") "Advice for root project"
     else "Advice for project $projectPath"

--- a/src/main/kotlin/com/autonomousapps/tasks/BuildHealthTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/BuildHealthTask.kt
@@ -79,6 +79,7 @@ abstract class BuildHealthTask : DefaultTask() {
     }
   }
 
+  // TODO if it's advice for root project and there IS no advice, emit nothing. There is often no source
   private fun projectHeaderText(projectPath: String): String =
     if (projectPath == ":") "Advice for root project"
     else "Advice for project $projectPath"

--- a/src/main/kotlin/com/autonomousapps/tasks/RipplesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/RipplesTask.kt
@@ -1,0 +1,52 @@
+package com.autonomousapps.tasks
+
+import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
+import com.autonomousapps.advice.Ripple
+import com.autonomousapps.advice.UpstreamRipple
+import com.autonomousapps.internal.utils.fromJsonList
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.support.appendReproducibleNewLine
+
+abstract class RipplesTask : DefaultTask() {
+
+  init {
+    group = TASK_GROUP_DEP_INTERNAL
+    description = "Emits to console all potential 'ripples' relating to dependency advice"
+  }
+
+  @get:PathSensitive(PathSensitivity.NONE)
+  @get:InputFile
+  abstract val ripples: RegularFileProperty
+
+  @TaskAction fun action() {
+    val ripples = ripples.fromJsonList<Ripple>()
+
+    if (ripples.isEmpty()) {
+      logger.quiet("Your project contains no potential ripples.")
+      return
+    }
+
+    logger.quiet("Ripples:")
+    ripples.groupBy { it.upstreamRipple.projectPath }.forEach { (dependencyProject, r) ->
+      val msg = StringBuilder("- You have been advised to make a change to $dependencyProject that might impact dependent projects\n")
+
+      r.forEach { ripple ->
+        val dependentProject = ripple.downstreamImpact.projectPath
+        val changeText = ripple.upstreamRipple.changeText()
+        val downstreamTo = ripple.downstreamImpact.toConfiguration
+        msg.appendReproducibleNewLine("  - $changeText") // TODO this line does not need to be repeated. Should do another grouping on ripple.upstreamRipple.providedDependency
+          .appendReproducibleNewLine("    $dependentProject uses this dependency transitively. You should add it to '$downstreamTo'")
+      }
+      logger.quiet(msg.toString())
+    }
+  }
+
+  private fun UpstreamRipple.changeText(): String =
+    if (toConfiguration == null) "Remove $providedDependency from '$fromConfiguration'"
+    else "Change $providedDependency from '$fromConfiguration' to '$toConfiguration'"
+}


### PR DESCRIPTION
* Run `./gradlew ripples` to see a report of expected downstream (dependent) impacts from upstream (dependency) changes.
* `LocateDependenciesTask` no longer resolves dependencies
* Updated Kotlin source parsing for imports
* First pass at colorizing console output