### PR TITLE
Add system property to configure enabling of test-related code analysis.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -256,7 +256,12 @@ class DependencyAnalysisPlugin : Plugin<Project> {
     androidUnitTestSourceSets: List<SourceProvider>?,
     kotlinSourceSets: NamedDomainObjectContainer<KotlinSourceSet>?
   ): VariantSourceSet {
-    val allAndroid = androidSourceSets + (androidUnitTestSourceSets ?: emptyList())
+
+    val testSource =
+      if (shouldAnalyzeTests() && androidUnitTestSourceSets != null) androidUnitTestSourceSets
+      else emptyList()
+
+    val allAndroid = androidSourceSets + testSource
     return VariantSourceSet(
       androidSourceSets = allAndroid.toSortedSet(JAVA_COMPARATOR),
       kotlinSourceSets = kotlinSourceSets?.filterToOrderedSet(KOTLIN_COMPARATOR) { k ->
@@ -342,7 +347,9 @@ class DependencyAnalysisPlugin : Plugin<Project> {
     afterEvaluate {
       val java = the<JavaPluginConvention>()
       val testSource = java.sourceSets.findByName("test")
-      val mainSource = java.sourceSets.findByName("main")
+      val mainSource =
+        if (shouldAnalyzeTests()) java.sourceSets.findByName("main")
+        else null
       mainSource?.let { sourceSet ->
         try {
           // Regardless of the fact that this is a "java-library" project, the presence of Spring

--- a/src/main/kotlin/com/autonomousapps/Flags.kt
+++ b/src/main/kotlin/com/autonomousapps/Flags.kt
@@ -3,13 +3,12 @@ package com.autonomousapps
 const val FLAG_SILENT = "dependency.analysis.silent"
 const val FLAG_MAX_CACHE_SIZE = "dependency.analysis.cache.max"
 const val FLAG_FAIL = "dependency.analysis.fail"
+const val FLAG_TEST_ANALYSIS = "dependency.analysis.test.analysis"
 
-internal fun shouldNotBeSilent(): Boolean {
-  val silent = System.getProperty(FLAG_SILENT, "false")
-  return !silent!!.toBoolean()
-}
+internal fun shouldNotBeSilent() = getSysProp(FLAG_SILENT, false)
+internal fun shouldFail() = getSysProp(FLAG_FAIL, false)
+internal fun shouldAnalyzeTests() = getSysProp(FLAG_TEST_ANALYSIS, true)
 
-internal fun shouldFail(): Boolean {
-  val shouldFail = System.getProperty(FLAG_FAIL, "false")
-  return shouldFail!!.toBoolean()
+private fun getSysProp(name: String, default: Boolean): Boolean {
+  return System.getProperty(name, default.toString())!!.toBoolean()
 }

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
@@ -9,6 +9,7 @@ import com.autonomousapps.internal.artifactViewFor
 import com.autonomousapps.internal.utils.capitalizeSafely
 import com.autonomousapps.internal.utils.namedOrNull
 import com.autonomousapps.services.InMemoryCache
+import com.autonomousapps.shouldAnalyzeTests
 import com.autonomousapps.tasks.*
 import org.gradle.api.Project
 import org.gradle.api.UnknownDomainObjectException
@@ -249,11 +250,14 @@ internal class AndroidAppAnalyzer(
       kotlinCompileTask()?.let { kotlinClasses.from(it.get().outputs.files.asFileTree) }
       javaClasses.from(javaCompileTask().get().outputs.files.asFileTree)
       variantFiles.set(createVariantFiles.flatMap { it.output })
-      testJavaCompile?.let { javaCompile ->
-        testJavaClassesDir.set(javaCompile.flatMap { it.destinationDirectory })
-      }
-      testKotlinCompile?.let { kotlinCompile ->
-        testKotlinClassesDir.set(kotlinCompile.flatMap { it.destinationDirectory })
+
+      if (shouldAnalyzeTests()) {
+        testJavaCompile?.let { javaCompile ->
+          testJavaClassesDir.set(javaCompile.flatMap { it.destinationDirectory })
+        }
+        testKotlinCompile?.let { kotlinCompile ->
+          testKotlinClassesDir.set(kotlinCompile.flatMap { it.destinationDirectory })
+        }
       }
       layouts(variant.sourceSets.flatMap { it.resDirectories })
 
@@ -301,12 +305,16 @@ internal class AndroidLibAnalyzer(
     project.tasks.register<JarAnalysisTask>("analyzeClassUsage$variantNameCapitalized") {
       variantFiles.set(createVariantFiles.flatMap { it.output })
       jar.set(getBundleTaskOutput())
-      testJavaCompile?.let { javaCompile ->
-        testJavaClassesDir.set(javaCompile.flatMap { it.destinationDirectory })
+
+      if (shouldAnalyzeTests()) {
+        testJavaCompile?.let { javaCompile ->
+          testJavaClassesDir.set(javaCompile.flatMap { it.destinationDirectory })
+        }
+        testKotlinCompile?.let { kotlinCompile ->
+          testKotlinClassesDir.set(kotlinCompile.flatMap { it.destinationDirectory })
+        }
       }
-      testKotlinCompile?.let { kotlinCompile ->
-        testKotlinClassesDir.set(kotlinCompile.flatMap { it.destinationDirectory })
-      }
+
       layouts(variant.sourceSets.flatMap { it.resDirectories })
 
       output.set(outputPaths.allUsedClassesPath)

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -6,6 +6,7 @@ import com.autonomousapps.internal.OutputPaths
 import com.autonomousapps.internal.utils.capitalizeSafely
 import com.autonomousapps.internal.utils.namedOrNull
 import com.autonomousapps.services.InMemoryCache
+import com.autonomousapps.shouldAnalyzeTests
 import com.autonomousapps.tasks.*
 import org.gradle.api.Project
 import org.gradle.api.UnknownDomainObjectException
@@ -64,11 +65,14 @@ internal abstract class JvmAnalyzer(
       javaCompileTask()?.let { javaClasses.from(it.get().outputs.files.asFileTree) }
       kotlinCompileTask()?.let { kotlinClasses.from(it.get().outputs.files.asFileTree) }
       variantFiles.set(createVariantFiles.flatMap { it.output })
-      testJavaCompile?.let { javaCompile ->
-        testJavaClassesDir.set(javaCompile.flatMap { it.destinationDirectory })
-      }
-      testKotlinCompile?.let { kotlinCompile ->
-        testKotlinClassesDir.set(kotlinCompile.flatMap { it.destinationDirectory })
+
+      if (shouldAnalyzeTests()) {
+        testJavaCompile?.let { javaCompile ->
+          testJavaClassesDir.set(javaCompile.flatMap { it.destinationDirectory })
+        }
+        testKotlinCompile?.let { kotlinCompile ->
+          testKotlinClassesDir.set(kotlinCompile.flatMap { it.destinationDirectory })
+        }
       }
 
       output.set(outputPaths.allUsedClassesPath)


### PR DESCRIPTION
Use like
```
./gradlew buildHealth -Ddependency.analysis.test.analysis=false
```
or
```
# gradle.properties
systemProp.dependency.analysis.test.analysis=false
```

The default value is `true`.