### PR TITLE
Add tasks to view project dependency graphs.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/graph/DependencyGraph.kt
+++ b/src/main/kotlin/com/autonomousapps/graph/DependencyGraph.kt
@@ -83,8 +83,24 @@ internal class DependencyGraph {
 
   fun hasNode(node: Node): Boolean = hasNode(node.identifier)
   fun hasNode(node: String): Boolean = nodes[node] != null
+
+  fun reversed(): DependencyGraph {
+    val reversed = DependencyGraph()
+    edges().forEach {
+      reversed.addEdge(Edge(it.to, it.from, it.weight))
+    }
+    return reversed
+  }
 }
 
 internal fun missingNode(node: Node): Nothing = missingNode(node.identifier)
 internal fun missingNode(node: String): Nothing =
   throw IllegalArgumentException("Node $node is not in the graph")
+
+internal operator fun DependencyGraph.plus(other: DependencyGraph): DependencyGraph = apply {
+  other.edges().forEach { addEdge(it) }
+}
+
+internal fun Iterable<DependencyGraph>.merge(): DependencyGraph = reduce { acc, dependencyGraph ->
+  acc + dependencyGraph
+}

--- a/src/main/kotlin/com/autonomousapps/graph/DepthFirstSearch.kt
+++ b/src/main/kotlin/com/autonomousapps/graph/DepthFirstSearch.kt
@@ -1,0 +1,40 @@
+package com.autonomousapps.graph
+
+/**
+ * This class is used to generate subgraphs from a larger graph, [graph], which are reachable from
+ * the given source node.
+ */
+internal class DepthFirstSearch(
+  private val graph: DependencyGraph,
+  source: Node
+) {
+
+  private val marked = linkedMapOf<String, Boolean>()
+
+  init {
+    dfs(source)
+  }
+
+  private fun dfs(source: Node) {
+    marked[source.identifier] = true
+    graph.adj(source).forEach { (_, to) ->
+      if (!isMarked(to)) {
+        dfs(to)
+      }
+    }
+  }
+
+  val subgraph: DependencyGraph by lazy {
+    val sub = DependencyGraph()
+    graph.edges().forEach {
+      // if both nodes on the edge are marked, add this edge to the subgraph
+      if (isMarked(it.from) && isMarked(it.to)) {
+        sub.addEdge(it)
+      }
+    }
+    sub
+  }
+
+  private fun isMarked(node: Node): Boolean = isMarked(node.identifier)
+  private fun isMarked(identifier: String): Boolean = marked.getOrDefault(identifier, false)
+}

--- a/src/main/kotlin/com/autonomousapps/internal/ConfigurationsToDependenciesTransformer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/ConfigurationsToDependenciesTransformer.kt
@@ -6,6 +6,7 @@ import org.gradle.api.artifacts.ConfigurationContainer
 
 internal class ConfigurationsToDependenciesTransformer(
   private val flavorName: String?,
+  private val buildType: String?,
   private val variantName: String,
   private val configurations: ConfigurationContainer
 ) {
@@ -71,7 +72,7 @@ internal class ConfigurationsToDependenciesTransformer(
           logger.warn("Dependency $identifier has been declared multiple times: $configurations")
         }
 
-        // one of the declarations is for an api configuration. Prefer that one
+        // if one of the declarations is for an api configuration. Prefer that one
         if (configurations.any { it.endsWith("api", true) }) {
           interestingLocations.removeIf {
             it.identifier == identifier && !it.configurationName.endsWith("api", true)
@@ -88,12 +89,21 @@ internal class ConfigurationsToDependenciesTransformer(
       // so, flavorDebugApi, etc.
       "${variantName}${it.capitalizeSafely()}"
     }).toMutableSet()
+
     if (flavorName != null) {
       confNames.addAll(DEFAULT_CONFS.map {
         // so, flavorApi, etc.
         "${flavorName}${it.capitalizeSafely()}"
       })
     }
+
+    if (buildType != null) {
+      confNames.addAll(DEFAULT_CONFS.map {
+        // so, buildTypeApi, etc.
+        "${buildType}${it.capitalizeSafely()}"
+      })
+    }
+
     return confNames
   }
 

--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -83,6 +83,9 @@ internal class NoVariantOutputPaths(private val project: Project) {
   val aggregateGraphDotPath = layout("$ROOT_DIR/graph-all-variants.gv")
   val graphReasonPath = layout("$ROOT_DIR/graph-reason.gv")
 
+  val aggregateProjectGraphPath = layout("$ROOT_DIR/project-graph.json")
+  val aggregateProjectGraphDotPath = layout("$ROOT_DIR/project-graph.gv")
+
   @Suppress("SameParameterValue")
   private fun layout(path: String) = project.layout.buildDirectory.file(path)
 }
@@ -97,6 +100,9 @@ internal class RootOutputPaths(private val project: Project) {
   val adviceAggregatePath = layout("$ROOT_DIR/advice-holistic.json")
   val adviceAggregatePrettyPath = layout("$ROOT_DIR/advice-holistic-pretty.json")
   val ripplePath = layout("$ROOT_DIR/ripples.json")
+  val projectGraphPath = layout("$ROOT_DIR/project-graph.gv")
+  val projectGraphRevPath = layout("$ROOT_DIR/project-graph-rev.gv")
+  val projectGraphRevSubPath = layout("$ROOT_DIR/project-graph-rev-sub.gv")
 }
 
 internal class RedundantSubPluginOutputPaths(

--- a/src/main/kotlin/com/autonomousapps/internal/advice/RippleWriter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/RippleWriter.kt
@@ -33,15 +33,6 @@ internal class RippleWriter(
               msg.appendReproducibleNewLine("    ${dependentProject.colorize()} uses this dependency transitively. You should add it to '$downstreamTo'")
             }
           }
-
-        // TODO remove once we have tests verifying the above works as expected
-//        ripplesByProject.forEach { r ->
-//          val dependentProject = r.downstreamImpact.projectPath
-//          val changeText = r.upstreamRipple.changeText()
-//          val downstreamTo = r.downstreamImpact.toConfiguration
-//          msg.appendReproducibleNewLine("  - $changeText") // TODO this line does not need to be repeated. Should do another grouping on ripple.upstreamRipple.providedDependency
-//            .appendReproducibleNewLine("    $dependentProject uses this dependency transitively. You should add it to '$downstreamTo'")
-//        }
       }
     return msg.toString()
   }

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
@@ -39,6 +39,7 @@ internal abstract class AndroidAnalyzer<T : ClassAnalysisTask>(
 
   final override val flavorName: String = variant.flavorName
   final override val variantName: String = variant.name
+  final override val buildType: String = variant.buildType.name
   final override val variantNameCapitalized: String = variantName.capitalizeSafely()
   final override val compileConfigurationName = "${variantName}CompileClasspath"
   final override val runtimeConfigurationName = "${variantName}RuntimeClasspath"

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
@@ -28,6 +28,11 @@ internal interface DependencyAnalyzer<T : ClassAnalysisTask> {
   val flavorName: String?
 
   /**
+   * E.g., 'debug'
+   */
+  val buildType: String?
+
+  /**
    * E.g., `FlavorDebug`
    */
   val variantNameCapitalized: String

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -27,6 +27,7 @@ internal abstract class JvmAnalyzer(
 ) : AbstractDependencyAnalyzer<ClassListAnalysisTask>(project) {
 
   final override val flavorName: String? = null
+  final override val buildType: String? = null
   final override val variantName: String = mainSourceSet.name
   final override val variantNameCapitalized = variantName.capitalizeSafely()
 

--- a/src/main/kotlin/com/autonomousapps/internal/utils/utils.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/utils.kt
@@ -25,8 +25,21 @@ internal inline fun <reified T> RegularFileProperty.fromJsonList(): List<T> {
   return get().asFile.readText().fromJsonList()
 }
 
+internal inline fun <reified K, reified V> RegularFileProperty.fromJsonMapList(): Map<K, List<V>> {
+  return get().fromJsonMapList()
+}
+
+internal inline fun <reified K, reified V> RegularFile.fromJsonMapList(): Map<K, List<V>> {
+  return asFile.fromJsonMapList()
+}
+
+internal inline fun <reified K, reified V> File.fromJsonMapList(): Map<K, List<V>> {
+  return readText().fromJsonMapList()
+}
+
 internal inline fun <reified T> RegularFileProperty.fromJson(): T = get().fromJson()
-internal inline fun <reified T> RegularFile.fromJson(): T = asFile.readText().fromJson()
+internal inline fun <reified T> RegularFile.fromJson(): T = asFile.fromJson()
+internal inline fun <reified T> File.fromJson(): T = readText().fromJson()
 
 internal inline fun <reified T> RegularFileProperty.fromNullableJsonSet(): Set<T>? {
   return orNull?.asFile?.readText()?.fromJsonSet()

--- a/src/main/kotlin/com/autonomousapps/tasks/DependencyGraphAggregationTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DependencyGraphAggregationTask.kt
@@ -3,9 +3,9 @@ package com.autonomousapps.tasks
 import com.autonomousapps.TASK_GROUP_DEP
 import com.autonomousapps.graph.DependencyGraph
 import com.autonomousapps.graph.GraphWriter
+import com.autonomousapps.graph.merge
 import com.autonomousapps.internal.utils.fromJson
 import com.autonomousapps.internal.utils.getAndDelete
-import com.autonomousapps.internal.utils.mapToSet
 import com.autonomousapps.internal.utils.toJson
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFile
@@ -35,14 +35,7 @@ abstract class DependencyGraphAggregationTask : DefaultTask() {
     val outputJsonFile = outputJson.getAndDelete()
     val outputDotFile = outputDot.getAndDelete()
 
-    val graph: DependencyGraph = graphs.get().mapToSet { it.fromJson<DependencyGraph>() }
-      .reduce { acc, dependencyGraph ->
-        acc.apply {
-          dependencyGraph.edges().forEach {
-            addEdge(it)
-          }
-        }
-      }
+    val graph = graphs.get().map { it.fromJson<DependencyGraph>() }.merge()
 
     logger.quiet("Graph JSON at ${outputJsonFile.path}")
     outputJsonFile.writeText(graph.toJson())

--- a/src/main/kotlin/com/autonomousapps/tasks/LocateDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/LocateDependenciesTask.kt
@@ -27,6 +27,10 @@ abstract class LocateDependenciesTask : DefaultTask() {
   @get:Input
   abstract val flavorName: Property<String>
 
+  @get:Optional
+  @get:Input
+  abstract val buildType: Property<String>
+
   @get:Input
   abstract val variantName: Property<String>
 
@@ -38,6 +42,7 @@ abstract class LocateDependenciesTask : DefaultTask() {
 
     val locations = ConfigurationsToDependenciesTransformer(
       flavorName = flavorName.orNull,
+      buildType = buildType.orNull,
       variantName = variantName.get(),
       configurations = project.configurations
     ).locations()

--- a/src/main/kotlin/com/autonomousapps/tasks/ProjectGraphAggregationTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ProjectGraphAggregationTask.kt
@@ -1,0 +1,85 @@
+package com.autonomousapps.tasks
+
+import com.autonomousapps.TASK_GROUP_DEP
+import com.autonomousapps.graph.*
+import com.autonomousapps.internal.utils.fromJson
+import com.autonomousapps.internal.utils.getAndDelete
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.*
+import org.gradle.api.tasks.options.Option
+
+/**
+ * This task generates a complete project-dependencies graph for every subproject in a build, as
+ * well as a reverse-dependencies graph which shows which projects might be impacted by a change in
+ * another project.
+ */
+@CacheableTask
+abstract class ProjectGraphAggregationTask : DefaultTask() {
+
+  init {
+    group = TASK_GROUP_DEP
+    description = "Produces a graph of all inter-project dependencies"
+  }
+
+  private var query: String = ""
+
+  @Option(option = "id", description = "The project dependency for which to generate a reverse graph")
+  fun query(identifier: String) {
+    this.query = identifier
+  }
+
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  @get:InputFiles
+  lateinit var graphs: Configuration
+
+  @get:OutputFile
+  abstract val output: RegularFileProperty
+
+  @get:OutputFile
+  abstract val outputRev: RegularFileProperty
+
+  @get:OutputFile
+  abstract val outputRevSub: RegularFileProperty
+
+  @TaskAction fun action() {
+    val outputFile = output.getAndDelete()
+    val outputRevFile = outputRev.getAndDelete()
+    val outputRevSubFile = outputRevSub.getAndDelete()
+
+    val graph = graphs.dependencies
+      .filterIsInstance<ProjectDependency>()
+      .flatMap { dep ->
+        graphs.fileCollection(dep)
+          .filter { it.exists() }
+          .map { it.fromJson<DependencyGraph>() }
+      }.merge()
+
+    val reversed = graph.reversed()
+
+    logger.quiet("Graph DOT at ${outputFile.path}")
+    outputFile.writeText(GraphWriter.toDot(graph))
+
+    logger.quiet("Graph rev DOT at ${outputRevFile.path}")
+    outputRevFile.writeText(GraphWriter.toDot(reversed))
+
+    if (query.isNotEmpty()) {
+      val node = getQueryNode()
+      val subgraph = DepthFirstSearch(reversed, node).subgraph
+
+      logger.quiet("Subgraph rooted on $query at ${outputRevSubFile.path}")
+      outputRevSubFile.writeText(GraphWriter.toDot(subgraph))
+    }
+  }
+
+  private fun getQueryNode(): Node {
+    if (!query.startsWith(":")) {
+      throw GradleException("You cannot query for a non-project dependency.")
+    }
+
+    return ProducerNode(query)
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/ProjectGraphTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ProjectGraphTask.kt
@@ -1,0 +1,84 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.autonomousapps.tasks
+
+import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
+import com.autonomousapps.graph.*
+import com.autonomousapps.internal.Location
+import com.autonomousapps.internal.utils.*
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.*
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * This task generates a very simple project-dependencies graph that describes the direct
+ * dependencies of the subproject in question.
+ */
+@CacheableTask
+abstract class ProjectGraphTask @Inject constructor(
+  private val workerExecutor: WorkerExecutor
+) : DefaultTask() {
+
+  init {
+    group = TASK_GROUP_DEP_INTERNAL
+    description = "Produces a graph of all inter-project dependencies"
+  }
+
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  @get:InputFiles
+  abstract val locations: ListProperty<RegularFile>
+
+  @get:OutputFile
+  abstract val outputJson: RegularFileProperty
+
+  @get:OutputFile
+  abstract val outputDot: RegularFileProperty
+
+  @TaskAction fun action() {
+    workerExecutor.noIsolation().submit(Action::class.java) {
+      locations.set(this@ProjectGraphTask.locations)
+      outputJson.set(this@ProjectGraphTask.outputJson)
+      outputDot.set(this@ProjectGraphTask.outputDot)
+      projectPath.set(project.path)
+    }
+  }
+
+  interface Parameters : WorkParameters {
+    val locations: ListProperty<RegularFile>
+    val outputJson: RegularFileProperty
+    val outputDot: RegularFileProperty
+    val projectPath: Property<String>
+  }
+
+  abstract class Action : WorkAction<Parameters> {
+
+    private val logger = getLogger<ProjectGraphTask>()
+
+    override fun execute() {
+      val outputJsonFile = parameters.outputJson.getAndDelete()
+      val outputDotFile = parameters.outputDot.getAndDelete()
+
+      val graph = DependencyGraph()
+      parameters.locations.get().flatMap {
+        it.fromJsonSet<Location>()
+      }.filterToSet {
+        it.isInteresting && it.identifier.startsWith(":")
+      }.forEach {
+        graph.addEdge(Edge(ProducerNode(parameters.projectPath.get()), ConsumerNode(it.identifier)))
+      }
+
+      logger.quiet("Graph JSON at ${outputJsonFile.path}")
+      outputJsonFile.writeText(graph.toJson())
+
+      logger.quiet("Graph DOT at ${outputDotFile.path}")
+      outputDotFile.writeText(GraphWriter.toDot(graph))
+    }
+  }
+}


### PR DESCRIPTION
Adds a couple new features, similar to `:ripples`, to enable the user to see potential downstream impacts from upstream changes.
```
./gradlew :projectGraphReport
```
will generate two graphviz DOT files
1. The project dependency graph (not including any external dependencies)
2. The reverse project dependency graph ("A depends on B, so if I change B, A might be impacted")

and
```
./gradlew :projectGraphReport --id :my-project
```
will generate three graphviz DOT files. The two above, and additionally
3. The reverse project dependency graph anchored on `:my-project` (i.e. a subgraph showing potential impacts from changing `:my-project`)