### PR TITLE
Don't use an enforced platform for the Kotlin BOM.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Dependency Analysis Plugin Changelog
 
 # Version 0.69.0 (not released yet)
+* [Fixed] Don't use an enforced platform for the Kotlin BOM. This will permit use of the Kotlin
+compiler daemon for projects using Kotlin 1.4+.
+ ([#333](https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/333))
 * Now building with and testing against Gradle 6.7.1.
 * Update supported version of AGP 4.2.0 to beta01.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ val antlrVersion by extra("4.8")
 val internalAntlrVersion by extra("$antlrVersion.2")
 
 dependencies {
-  implementation(enforcedPlatform("org.jetbrains.kotlin:kotlin-bom"))
+  implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
 
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
   implementation("com.squareup.moshi:moshi:1.9.2") {


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/333