### PR TITLE
Changed path-sensitivity to ABSOLUTE to account for artifacts in a transform directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Dependency Analysis Plugin Changelog
 * [Fixed] Assume dependencies on some variant (e.g. `debugImplementation` vs `implementation`) are 
 correctly on that variant.
 ([#340](https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/340))
+* [Fixed] Use absolute-path sensitivity for artifact file paths.
+([#350](https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/350))
 * [Fixed] File dependencies now trim the prefix path in order to provide a unique identification.
 * [Fixed] Exclusively use the compile classpath for resolving dependencies, filtering out 
   constraints.

--- a/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
@@ -41,12 +41,12 @@ abstract class ArtifactsReportTask : DefaultTask() {
 
   /**
    * This is the "official" input for wiring task dependencies correctly, but is otherwise
-   * unused. This needs to use [InputFiles] and [PathSensitivity.RELATIVE] because the path to the
+   * unused. This needs to use [InputFiles] and [PathSensitivity.ABSOLUTE] because the path to the
    * jars really does matter here. Using [Classpath] is an error, as it looks only at content and
    * not name or path, and we really do need to know the actual path to the artifact, even if its
    * contents haven't changed.
    */
-  @PathSensitive(PathSensitivity.RELATIVE)
+  @PathSensitive(PathSensitivity.ABSOLUTE)
   @InputFiles
   fun getArtifactFiles(): FileCollection = artifacts.artifactFiles
 


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/350.