### PR TITLE
Test against AGP 7.0.0-alpha05.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: Execute tests
         id: gradle
         uses: eskatos/gradle-command-action@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: Execute tests
         uses: eskatos/gradle-command-action@v1
         with:

--- a/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
@@ -20,6 +20,7 @@ abstract class AbstractFunctionalSpec extends Specification {
 //    GradleVersion.version('6.4.1'),
 //    GradleVersion.version('6.5.1'),
 //    GradleVersion.version('6.6.1'),
+//    GradleVersion.version('6.7.1'),
     GradleVersion.version('6.8.2')
   ]
 
@@ -58,10 +59,13 @@ abstract class AbstractFunctionalSpec extends Specification {
   }
 
   protected static boolean isCompatible(GradleVersion gradleVersion, AgpVersion agpVersion) {
-    if (agpVersion >= AgpVersion.version('4.1.0')) {
-      return gradleVersion >= GradleVersion.version('6.5')
+    if (agpVersion >= AgpVersion.version('7.0.0')) {
+      // TODO can't find docs on min Gradle version.
+      return gradleVersion >= GradleVersion.version('6.8.0')
     } else if (agpVersion >= AgpVersion.version('4.2.0')) {
       return gradleVersion >= GradleVersion.version('6.7')
+    } else if (agpVersion >= AgpVersion.version('4.1.0')) {
+      return gradleVersion >= GradleVersion.version('6.5')
     } else {
       return true
     }

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -23,7 +23,8 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
     AgpVersion.version('3.6.4'),
     AgpVersion.version('4.0.1'),
     AgpVersion.version('4.1.2'),
-    AgpVersion.version('4.2.0-beta04')
+    AgpVersion.version('4.2.0-beta04'),
+    AgpVersion.version('7.0.0-alpha05')
   ]
 
   protected static List<AgpVersion> agpVersions(AgpVersion minAgpVersion = AgpVersion.AGP_MIN) {
@@ -40,9 +41,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   }
 
   @SuppressWarnings(["GroovyAssignabilityCheck", "GrUnresolvedAccess"])
-  protected static List<List<Object>> gradleAgpMatrix(
-    AgpVersion minAgpVersion = AgpVersion.AGP_MIN
-  ) {
+  protected static List<List<Object>> gradleAgpMatrix(AgpVersion minAgpVersion = AgpVersion.AGP_MIN) {
     // Cartesian product
     def matrix = Arrays.asList(gradleVersions(), agpVersions(minAgpVersion)).combinations()
 

--- a/src/functionalTest/groovy/com/autonomousapps/android/DataBindingSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/DataBindingSpec.groovy
@@ -1,6 +1,7 @@
 package com.autonomousapps.android
 
 import com.autonomousapps.fixtures.DataBindingProject
+import com.autonomousapps.internal.android.AgpVersion
 import spock.lang.Unroll
 
 import static com.autonomousapps.utils.Runner.build
@@ -24,6 +25,8 @@ final class DataBindingSpec extends AbstractAndroidSpec {
     assertThat(actualAdviceForApp).containsExactlyElementsIn(expectedAdviceForApp)
 
     where:
-    [gradleVersion, agpVersion] << gradleAgpMatrix()
+    // AGP versions before 4.x will throw java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException
+    // when compiled and run with Java 11. So just don't bother running those tests.
+    [gradleVersion, agpVersion] << gradleAgpMatrix(AgpVersion.version('4.0.0'))
   }
 }

--- a/src/main/kotlin/com/autonomousapps/internal/advice/filter/DataBindingFilter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/filter/DataBindingFilter.kt
@@ -7,6 +7,9 @@ import com.autonomousapps.advice.HasDependency
  * * androidx.databinding:databinding-adapters
  * * androidx.databinding:databinding-runtime
  * * androidx.databinding:databinding-common
+ *
+ * For AGP 7+
+ * * androidx.databinding:databinding-ktx
  */
 internal class DataBindingFilter : DependencyFilter {
 
@@ -14,7 +17,8 @@ internal class DataBindingFilter : DependencyFilter {
     private val databindingDependencies = listOf(
       "androidx.databinding:databinding-adapters",
       "androidx.databinding:databinding-runtime",
-      "androidx.databinding:databinding-common"
+      "androidx.databinding:databinding-common",
+      "androidx.databinding:databinding-ktx"
     )
   }
 

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -12,7 +12,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
   companion object {
 
     @JvmStatic val AGP_MIN = version("3.5.4")
-    @JvmStatic val AGP_MAX = version("4.2.0-beta04")
+    @JvmStatic val AGP_MAX = version("7.0.0-alpha05")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)


### PR DESCRIPTION
Getting a weird failure locally (maybe related to building with Java 11?). https://scans.gradle.com/s/wlyny2evw26uk/tests

Maybe this fixes it? https://stackoverflow.com/questions/43574426/java-how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexceptio

Looking at the failures, I only see it with AGP 3.x. The AGP 7.x failure is a legit failure due to a new databinding-related dependency.