### PR TITLE
Fix inputs for Option arguments

### DIFF
--- a/src/main/kotlin/com/autonomousapps/tasks/DependencyGraphAllProjects.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DependencyGraphAllProjects.kt
@@ -38,6 +38,11 @@ abstract class DependencyGraphAllProjects : DefaultTask() {
     this.query = identifier
   }
 
+  @Input
+  fun getQuery(): String {
+    return query
+  }
+
   @get:PathSensitive(PathSensitivity.RELATIVE)
   @get:InputFiles
   lateinit var graphs: Configuration

--- a/src/main/kotlin/com/autonomousapps/tasks/ReasonAggregationTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ReasonAggregationTask.kt
@@ -37,6 +37,11 @@ abstract class ReasonAggregationTask : DefaultTask() {
     this.query = identifier
   }
 
+  @Input
+  fun getQuery(): String {
+    return query
+  }
+
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
   abstract val graph: RegularFileProperty

--- a/src/main/kotlin/com/autonomousapps/tasks/ReasonTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ReasonTask.kt
@@ -34,6 +34,11 @@ abstract class ReasonTask : DefaultTask() {
     this.query = identifier
   }
 
+  @Input
+  fun getQuery(): String {
+    return query
+  }
+
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
   abstract val graph: RegularFileProperty


### PR DESCRIPTION
`@Option` arguments weren't considered as inputs for tasks. This resulted in wrong up-to-date or cache results.