### PR TITLE
Fix: don't fail in configuration when an Android unit test variant is disabled.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AndroidTestDependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AndroidTestDependenciesSpec.groovy
@@ -1,0 +1,29 @@
+package com.autonomousapps.android
+
+import com.autonomousapps.android.projects.AndroidTestDependenciesProject
+import com.autonomousapps.internal.android.AgpVersion
+import org.gradle.util.GradleVersion
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+@SuppressWarnings("GroovyAssignabilityCheck")
+final class AndroidTestDependenciesSpec extends AbstractAndroidSpec {
+
+  def "configuration succeeds when a unit test variant is disabled (#gradleVersion)"() {
+    given:
+    def project = new AndroidTestDependenciesProject(agpVersion)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, ':buildHealth')
+
+    then:
+    assertThat(actualAdvice()).containsExactlyElementsIn(project.expectedAdvice)
+
+    where:
+    gradleVersion << [GradleVersion.version('7.1')]
+    agpVersion << [AgpVersion.version('4.2.1').version]
+//    [gradleVersion, agpVersion] << gradleAgpMatrix()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/AndroidTestDependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AndroidTestDependenciesSpec.groovy
@@ -12,9 +12,28 @@ final class AndroidTestDependenciesSpec extends AbstractAndroidSpec {
 
   def "configuration succeeds when a unit test variant is disabled (#gradleVersion)"() {
     given:
-    def project = new AndroidTestDependenciesProject(agpVersion)
+    def project = new AndroidTestDependenciesProject.Configurable(agpVersion)
     gradleProject = project.gradleProject
 
+    // TODO even "help" should fail, right?
+    when:
+    build(gradleVersion, gradleProject.rootDir, ':buildHealth')
+
+    then:
+    assertThat(actualAdvice()).containsExactlyElementsIn(project.expectedAdvice)
+
+    where:
+    gradleVersion << [GradleVersion.version('7.1')]
+    agpVersion << [AgpVersion.version('4.2.1').version]
+//    [gradleVersion, agpVersion] << gradleAgpMatrix()
+  }
+
+  def "transitive test dependencies should be declared on testImplementation (#gradleVersion)"() {
+    given:
+    def project = new AndroidTestDependenciesProject.UsedTransitive(agpVersion)
+    gradleProject = project.gradleProject
+
+    // TODO even "help" should fail, right?
     when:
     build(gradleVersion, gradleProject.rootDir, ':buildHealth')
 

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestDependenciesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestDependenciesProject.groovy
@@ -5,62 +5,71 @@ import com.autonomousapps.advice.Advice
 import com.autonomousapps.kit.*
 
 import static com.autonomousapps.AdviceHelper.dependency
+import static com.autonomousapps.AdviceHelper.transitiveDependency
 import static com.autonomousapps.kit.Dependency.*
 
-/**
- * TODO which version of AGP is required for the "androidComponents" DSL block?
- */
-final class AndroidTestDependenciesProject extends AbstractProject {
+abstract class AndroidTestDependenciesProject extends AbstractProject {
 
-  // TODO we need the implementation dependency to workaround a bug in the graphing algo: it crashes when there's only one node
-  /** Should be removed */
-  private static final commonsIO = commonsIO('implementation')
-  /** Should be removed */
-  private static final commonsMath = commonsMath('testImplementation')
-  /** Should be `testImplementation` */
-  private static final commonsCollections = commonsCollections('implementation')
+  protected static final junit = junit('testImplementation')
 
-  private final String agpVersion
-  final GradleProject gradleProject
+  protected final String agpVersion
+  abstract GradleProject gradleProject
 
   AndroidTestDependenciesProject(agpVersion) {
     this.agpVersion = agpVersion
-    this.gradleProject = build()
   }
 
-  private GradleProject build() {
-    def builder = newGradleProjectBuilder()
-    builder.withRootProject { r ->
-      r.gradleProperties = GradleProperties.minimalAndroidProperties()
-      r.withBuildScript { bs ->
-        bs.buildscript = BuildscriptBlock.defaultAndroidBuildscriptBlock(agpVersion)
-      }
+  /**
+   * TODO which version of AGP is required for the "androidComponents" DSL block?
+   */
+  static final class Configurable extends AndroidTestDependenciesProject {
+
+    // TODO we need the implementation dependency to workaround a bug in the graphing algo: it crashes when there's only one node
+    /** Should be removed */
+    private static final commonsIO = commonsIO('implementation')
+    /** Should be removed */
+    private static final commonsMath = commonsMath('testImplementation')
+    /** Should be `testImplementation` */
+    private static final commonsCollections = commonsCollections('implementation')
+
+    Configurable(agpVersion) {
+      super(agpVersion)
+      this.gradleProject = build()
     }
-    builder.withAndroidSubproject('proj') { s ->
-      s.sources = sources
-      s.withBuildScript { bs ->
-        bs.plugins = [Plugin.androidLibPlugin]
-        bs.android = AndroidBlock.defaultAndroidLibBlock(false)
-        bs.dependencies = [commonsIO, commonsCollections, commonsMath, junit('testImplementation')]
-        bs.additions = """\
+
+    private GradleProject build() {
+      def builder = newGradleProjectBuilder()
+      builder.withRootProject { r ->
+        r.gradleProperties = GradleProperties.minimalAndroidProperties()
+        r.withBuildScript { bs ->
+          bs.buildscript = BuildscriptBlock.defaultAndroidBuildscriptBlock(agpVersion)
+        }
+      }
+      builder.withAndroidSubproject('proj') { s ->
+        s.sources = sources
+        s.withBuildScript { bs ->
+          bs.plugins = [Plugin.androidLibPlugin]
+          bs.android = AndroidBlock.defaultAndroidLibBlock(false)
+          bs.dependencies = [commonsIO, commonsCollections, commonsMath, junit]
+          bs.additions = """\
           androidComponents {
             beforeUnitTests(selector().withBuildType("release")) {
               enabled = false
             }
           }
         """.stripIndent()
+        }
       }
+
+      def project = builder.build()
+      project.writer().write()
+      return project
     }
 
-    def project = builder.build()
-    project.writer().write()
-    return project
-  }
-
-  private List<Source> sources = [
-    new Source(
-      SourceType.JAVA, "Main", "com/example",
-      """\
+    private List<Source> sources = [
+      new Source(
+        SourceType.JAVA, "Main", "com/example",
+        """\
         package com.example;
 
         public class Main {
@@ -69,10 +78,10 @@ final class AndroidTestDependenciesProject extends AbstractProject {
           }
         }
       """.stripIndent()
-    ),
-    new Source(
-      SourceType.JAVA, "Spec", "com/example",
-      """\
+      ),
+      new Source(
+        SourceType.JAVA, "Spec", "com/example",
+        """\
         package com.example;
         
         import org.apache.commons.collections4.Bag;
@@ -86,13 +95,88 @@ final class AndroidTestDependenciesProject extends AbstractProject {
           }
         }
       """.stripIndent(),
-      'test'
-    )
-  ]
+        'test'
+      )
+    ]
 
-  final List<Advice> expectedAdvice = [
-    Advice.ofRemove(dependency(commonsMath)),
-    Advice.ofRemove(dependency(commonsIO)),
-    Advice.ofChange(dependency(commonsCollections), 'testImplementation')
-  ]
+    final List<Advice> expectedAdvice = [
+      Advice.ofRemove(dependency(commonsMath)),
+      Advice.ofRemove(dependency(commonsIO)),
+      Advice.ofChange(dependency(commonsCollections), 'testImplementation')
+    ]
+  }
+
+  static final class UsedTransitive extends AndroidTestDependenciesProject {
+
+    /** Unused. Brings along Okio, which is used. */
+    private static final okHttp = okHttp('testImplementation')
+
+    UsedTransitive(agpVersion) {
+      super(agpVersion)
+      this.gradleProject = build()
+    }
+
+    private GradleProject build() {
+      def builder = newGradleProjectBuilder()
+      builder.withRootProject { r ->
+        r.gradleProperties = GradleProperties.minimalAndroidProperties()
+        r.withBuildScript { bs ->
+          bs.buildscript = BuildscriptBlock.defaultAndroidBuildscriptBlock(agpVersion)
+        }
+      }
+      builder.withAndroidSubproject('proj') { s ->
+        s.sources = sources
+        s.withBuildScript { bs ->
+          bs.plugins = [Plugin.androidLibPlugin]
+          bs.android = AndroidBlock.defaultAndroidLibBlock(false)
+          bs.dependencies = [okHttp, junit]
+
+        }
+      }
+
+      def project = builder.build()
+      project.writer().write()
+      return project
+    }
+
+    private List<Source> sources = [
+      new Source(
+        SourceType.JAVA, "Main", "com/example",
+        """\
+        package com.example;
+
+        public class Main {
+          public int magic() {
+            return 42;
+          }
+        }
+      """.stripIndent()
+      ),
+      new Source(
+        SourceType.JAVA, "Spec", "com/example",
+        """\
+        package com.example;
+        
+        import okio.Buffer;
+        import org.junit.Test;
+        
+        public class Spec {
+          @Test
+          public void test() {
+            Buffer buffer = new Buffer();
+          }
+        }
+      """.stripIndent(),
+        'test'
+      )
+    ]
+
+    final List<Advice> expectedAdvice = [
+      Advice.ofRemove(dependency(okHttp)),
+      Advice.ofAdd(transitiveDependency(
+        dependency: dependency(identifier: 'com.squareup.okio:okio'),
+        parents: [dependency(identifier: 'com.squareup.okhttp3:okhttp')]
+      ), 'testImplementation')
+    ]
+  }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestDependenciesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestDependenciesProject.groovy
@@ -1,0 +1,98 @@
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.advice.Advice
+import com.autonomousapps.kit.*
+
+import static com.autonomousapps.AdviceHelper.dependency
+import static com.autonomousapps.kit.Dependency.*
+
+/**
+ * TODO which version of AGP is required for the "androidComponents" DSL block?
+ */
+final class AndroidTestDependenciesProject extends AbstractProject {
+
+  // TODO we need the implementation dependency to workaround a bug in the graphing algo: it crashes when there's only one node
+  /** Should be removed */
+  private static final commonsIO = commonsIO('implementation')
+  /** Should be removed */
+  private static final commonsMath = commonsMath('testImplementation')
+  /** Should be `testImplementation` */
+  private static final commonsCollections = commonsCollections('implementation')
+
+  private final String agpVersion
+  final GradleProject gradleProject
+
+  AndroidTestDependenciesProject(agpVersion) {
+    this.agpVersion = agpVersion
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withRootProject { r ->
+      r.gradleProperties = GradleProperties.minimalAndroidProperties()
+      r.withBuildScript { bs ->
+        bs.buildscript = BuildscriptBlock.defaultAndroidBuildscriptBlock(agpVersion)
+      }
+    }
+    builder.withAndroidSubproject('proj') { s ->
+      s.sources = sources
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.androidLibPlugin]
+        bs.android = AndroidBlock.defaultAndroidLibBlock(false)
+        bs.dependencies = [commonsIO, commonsCollections, commonsMath, junit('testImplementation')]
+        bs.additions = """\
+          androidComponents {
+            beforeUnitTests(selector().withBuildType("release")) {
+              enabled = false
+            }
+          }
+        """.stripIndent()
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private List<Source> sources = [
+    new Source(
+      SourceType.JAVA, "Main", "com/example",
+      """\
+        package com.example;
+
+        public class Main {
+          public int magic() {
+            return 42;
+          }
+        }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.JAVA, "Spec", "com/example",
+      """\
+        package com.example;
+        
+        import org.apache.commons.collections4.Bag;
+        import org.apache.commons.collections4.bag.HashBag;
+        import org.junit.Test;
+        
+        public class Spec {
+          @Test
+          public void test() {
+            Bag<String> bag = new HashBag<>();
+          }
+        }
+      """.stripIndent(),
+      'test'
+    )
+  ]
+
+  final List<Advice> expectedAdvice = [
+    Advice.ofRemove(dependency(commonsMath)),
+    Advice.ofRemove(dependency(commonsIO)),
+    Advice.ofChange(dependency(commonsCollections), 'testImplementation')
+  ]
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/TestDependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/TestDependenciesSpec.groovy
@@ -1,7 +1,6 @@
 package com.autonomousapps.jvm
 
 import com.autonomousapps.jvm.projects.TestDependenciesProject
-import org.gradle.util.GradleVersion
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
@@ -19,7 +18,7 @@ final class TestDependenciesSpec extends AbstractJvmSpec {
     then:
     assertThat(actualAdvice()).containsExactlyElementsIn(project.expectedAdvice)
 
-    where: 'Spring Boot requires Gradle 6.3+'
-    gradleVersion << [GradleVersion.current()]//gradleVersions()
+    where:
+    gradleVersion << gradleVersions()
   }
 }

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -571,10 +571,10 @@ class DependencyAnalysisPlugin : Plugin<Project> {
             .artifacts
 
         val testArtifactCollection =
-          configurations[dependencyAnalyzer.testCompileConfigurationName]
-            .incoming
-            .artifactViewFor(dependencyAnalyzer.attributeValueJar)
-            .artifacts
+          configurations.findByName(dependencyAnalyzer.testCompileConfigurationName)
+            ?.incoming
+            ?.artifactViewFor(dependencyAnalyzer.attributeValueJar)
+            ?.artifacts
 
         setArtifacts(artifactCollection)
         setTestArtifacts(testArtifactCollection)
@@ -599,13 +599,13 @@ class DependencyAnalysisPlugin : Plugin<Project> {
           .artifacts
           .artifactFiles
         )
-        val testCompileClasspath = configurations.getByName(dependencyAnalyzer.testCompileConfigurationName)
+        val testCompileClasspath = configurations.findByName(dependencyAnalyzer.testCompileConfigurationName)
         this.testCompileClasspath = testCompileClasspath
         testArtifactFiles.setFrom(testCompileClasspath
-          .incoming
-          .artifactViewFor(dependencyAnalyzer.attributeValueJar)
-          .artifacts
-          .artifactFiles
+          ?.incoming
+          ?.artifactViewFor(dependencyAnalyzer.attributeValueJar)
+          ?.artifacts
+          ?.artifactFiles
         )
 
         allArtifacts.set(artifactsReportTask.flatMap { it.output })

--- a/src/main/kotlin/com/autonomousapps/internal/JarAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/JarAnalyzer.kt
@@ -19,7 +19,7 @@ import java.util.zip.ZipFile
  */
 internal class JarAnalyzer(
   private val compileClasspath: Configuration,
-  private val testCompileClasspath: Configuration,
+  private val testCompileClasspath: Configuration?,
   private val artifacts: List<Artifact>,
   private val androidLinters: Set<AndroidLinterDependency>,
   private val logger: Logger,
@@ -33,7 +33,7 @@ internal class JarAnalyzer(
 
   private fun computeTransitivity() {
     val directDependencies = compileClasspath.directDependencies()
-    val testDirectDependencies = testCompileClasspath.directDependencies()
+    val testDirectDependencies = testCompileClasspath?.directDependencies().orEmpty()
 
     // "Artifacts" are everything used to compile the project. If there is a direct artifact with a
     // matching identifier, then that artifact is NOT transitive. Otherwise, it IS transitive.

--- a/src/main/kotlin/com/autonomousapps/tasks/AnalyzeJarTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AnalyzeJarTask.kt
@@ -31,7 +31,7 @@ abstract class AnalyzeJarTask : DefaultTask() {
 
   /**
    * This is the "official" input for wiring task dependencies correctly, but is otherwise unused.
-   * It is the result of resolving `compileClasspath`. cf. [compileClasspath]
+   * It is the result of resolving `compileClasspath`. cf. [compileClasspath].
    */
   @get:Classpath
   abstract val artifactFiles: ConfigurableFileCollection
@@ -43,11 +43,18 @@ abstract class AnalyzeJarTask : DefaultTask() {
   @get:Internal
   lateinit var compileClasspath: Configuration
 
+  /**
+   * This is the "official" input for wiring task dependencies correctly, but is otherwise unused.
+   * It is the result of resolving `testCompileClasspath`. cf. [testCompileClasspath].
+   *
+   * May be absent if, e.g., Android unit tests are disabled for some variant.
+   */
+  @get:Optional
   @get:Classpath
   abstract val testArtifactFiles: ConfigurableFileCollection
 
   @get:Internal
-  lateinit var testCompileClasspath: Configuration
+  var testCompileClasspath: Configuration? = null
 
   /**
    * A [`Set<Artifact>`][Artifact].

--- a/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
@@ -48,15 +48,17 @@ abstract class ArtifactsReportTask : DefaultTask() {
   @InputFiles
   fun getArtifactFiles(): FileCollection = artifacts.artifactFiles
 
-  private lateinit var testArtifacts: ArtifactCollection
+  private var testArtifacts: ArtifactCollection? = null
 
-  fun setTestArtifacts(testArtifacts: ArtifactCollection) {
+  fun setTestArtifacts(testArtifacts: ArtifactCollection?) {
     this.testArtifacts = testArtifacts
   }
 
+  /** May be absent if, e.g., Android unit tests are disabled for some variant. */
+  @Optional
   @PathSensitive(PathSensitivity.ABSOLUTE)
   @InputFiles
-  fun getTestArtifactFiles(): FileCollection = testArtifacts.artifactFiles
+  fun getTestArtifactFiles(): FileCollection? = testArtifacts?.artifactFiles
 
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
@@ -93,7 +95,7 @@ abstract class ArtifactsReportTask : DefaultTask() {
     }
 
     val artifacts = artifacts.asArtifacts()
-    val testArtifacts = testArtifacts.asArtifacts()
+    val testArtifacts = testArtifacts?.asArtifacts().orEmpty()
     val allArtifacts = artifacts + testArtifacts
 
     reportFile.writeText(allArtifacts.toJson())


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/423.