### PR TITLE
Java bytecode analysis will filter to analyze only jar files

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/JarAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/JarAnalyzer.kt
@@ -12,6 +12,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.DependencyResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.logging.Logger
+import java.util.zip.ZipException
 import java.util.zip.ZipFile
 
 /**
@@ -28,7 +29,9 @@ internal class JarAnalyzer(
 
   fun components(): List<Component> {
     computeTransitivity()
-    return artifacts.asComponents()
+    return artifacts
+      .filter { it.file.name.endsWith(".jar") }
+      .asComponents()
   }
 
   private fun computeTransitivity() {

--- a/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindServiceLoadersTask.kt
@@ -49,9 +49,9 @@ abstract class FindServiceLoadersTask : DefaultTask() {
 
   @TaskAction fun action() {
     val outputFile = output.getAndDelete()
-    val serviceLoaders: Set<ServiceLoader> = artifacts.flatMapToSet {
-      findServiceLoaders(it)
-    }
+    val serviceLoaders: Set<ServiceLoader> = artifacts
+      .filter { it.file.name.endsWith(".jar") }
+      .flatMapToSet { findServiceLoaders(it) }
 
     outputFile.writeText(serviceLoaders.toJson())
   }

--- a/src/main/kotlin/com/autonomousapps/tasks/InlineMemberExtractionTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/InlineMemberExtractionTask.kt
@@ -127,8 +127,9 @@ internal class InlineDependenciesFinder(
 
   // from the upstream bytecode. Therefore "candidates" (not necessarily used)
   private fun findInlineImportCandidates(): Set<ComponentWithInlineMembers> {
-    return artifacts
-      .map { artifact ->
+    return artifacts.filter {
+        it.file.name.endsWith(".jar")
+      }.map { artifact ->
         artifact to InlineMemberFinder(inMemoryCacheProvider, logger, ZipFile(artifact.file)).find().toSortedSet()
       }.filterNot { (_, imports) ->
         imports.isEmpty()


### PR DESCRIPTION
I'm currently working in a repo that leaks non-jar file types (i.e. xml) onto
the classpath. The other filetypes causes the dependency analysis tool to
throw ZipExceptions since the tool tries to open each file as a ZipFile.

Test:
1. Import dependency analysis into my repo
2. Run "./gradlew buildHealth" -> fails
3. Build dependency analysis tool with these changes (make snapshot)
4. Import snapshot of dependency analysis into my repo
5. Run "./gradlew buildHealth" -> passes and shows valid results