### PR TITLE
Don't report java-library plugin as redundant.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/JvmSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/JvmSpec.groovy
@@ -15,6 +15,7 @@ final class JvmSpec extends AbstractFunctionalSpec {
 
   private ProjectDirProvider javaLibraryProject = null
 
+  @SuppressWarnings('unused')
   def cleanup() {
     if (javaLibraryProject != null) {
       clean(javaLibraryProject)
@@ -22,34 +23,17 @@ final class JvmSpec extends AbstractFunctionalSpec {
   }
 
   @Unroll
-  def "reports redundant java-library and kapt plugins applied (#gradleVersion)"() {
+  def "reports redundant kotlin-jvm and kapt plugins applied (#gradleVersion)"() {
     given:
-    javaLibraryProject = new RedundantJavaLibraryAndKaptPluginsProject()
+    javaLibraryProject = new RedundantKotlinJvmAndKaptPluginsProject()
 
     when:
     build(gradleVersion, javaLibraryProject, 'buildHealth')
 
     then:
     Set<PluginAdvice> actualAdvice = javaLibraryProject.buildHealthFor(":").first().pluginAdvice
-    def expectedAdvice = RedundantJavaLibraryAndKaptPluginsProject.expectedAdvice().first().pluginAdvice
+    def expectedAdvice = RedundantKotlinJvmAndKaptPluginsProject.expectedAdvice().first().pluginAdvice
     assertThat(actualAdvice).containsExactlyElementsIn(expectedAdvice)
-
-    where:
-    gradleVersion << gradleVersions()
-  }
-
-  @Unroll
-  def "reports redundant java-library plugin applied (#gradleVersion)"() {
-    given:
-    javaLibraryProject = new RedundantJavaLibraryPluginProject()
-
-    when:
-    build(gradleVersion, javaLibraryProject, 'buildHealth')
-
-    then:
-    Set<PluginAdvice> actualAdvice = javaLibraryProject.buildHealthFor(":").first().pluginAdvice
-    assertThat(actualAdvice)
-      .containsExactlyElementsIn(RedundantJavaLibraryPluginProject.expectedAdvice().first().pluginAdvice)
 
     where:
     gradleVersion << gradleVersions()

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/RedundantPluginsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/RedundantPluginsSpec.groovy
@@ -9,7 +9,7 @@ import static com.google.common.truth.Truth.assertThat
 final class RedundantPluginsSpec extends AbstractJvmSpec {
 
   @Unroll
-  def "abi exclusion smoke test (#gradleVersion)"() {
+  def "kotlin-jvm plugin is redundant (#gradleVersion)"() {
     given:
     def project = new RedundantPluginsProject()
     gradleProject = project.gradleProject

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/RedundantPluginsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/RedundantPluginsProject.groovy
@@ -10,6 +10,7 @@ import com.autonomousapps.kit.Plugin
 import com.autonomousapps.kit.Source
 import com.autonomousapps.kit.SourceType
 
+import static com.autonomousapps.AdviceHelper.dependency
 import static com.autonomousapps.kit.Dependency.kotlinStdLib
 
 final class RedundantPluginsProject extends AbstractProject {
@@ -52,12 +53,12 @@ final class RedundantPluginsProject extends AbstractProject {
 
   def sources = [
     new Source(
-      SourceType.KOTLIN, "Main", "com/example",
+      SourceType.JAVA, "Main", "com/example",
       """\
-        package com.example
+        package com.example;
         
-        class Main {
-          fun magic() = 42
+        public class Main {
+          public int magic() { return 42; }
         }
       """.stripIndent()
     )
@@ -70,8 +71,8 @@ final class RedundantPluginsProject extends AbstractProject {
   final List<ComprehensiveAdvice> expectedBuildHealth = [
     new ComprehensiveAdvice(
       ':proj',
-      [] as Set<Advice>,
-      [PluginAdvice.redundantJavaLibrary()] as Set<PluginAdvice>,
+      [Advice.ofRemove(dependency(kotlinStdLib('api')))] as Set<Advice>,
+      [PluginAdvice.redundantKotlinJvm()] as Set<PluginAdvice>,
       true
     ),
     new ComprehensiveAdvice(':', [] as Set<Advice>, [] as Set<PluginAdvice>, false)

--- a/src/functionalTest/kotlin/com/autonomousapps/fixtures/RedundantJavaLibraryPluginProject.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/fixtures/RedundantJavaLibraryPluginProject.kt
@@ -4,54 +4,6 @@ import com.autonomousapps.advice.ComprehensiveAdvice
 import com.autonomousapps.advice.PluginAdvice
 import java.io.File
 
-class RedundantJavaLibraryPluginProject : ProjectDirProvider {
-
-  private val rootSpec = RootSpec(buildScript = buildScript())
-
-  private val rootProject = RootProject(rootSpec)
-
-  override val projectDir: File = rootProject.projectDir
-
-  override fun project(moduleName: String): Module {
-    if (moduleName == ":") {
-      return rootProject
-    } else {
-      error("No '$moduleName' project found!")
-    }
-  }
-
-  companion object {
-    // The point. This project has both kotlin-jvm and java-library applied, which is redundant.
-    private fun buildScript(): String {
-      return """
-        plugins {
-          id 'org.jetbrains.kotlin.jvm' version '1.4.21'
-          id 'java-library'
-          id 'com.autonomousapps.dependency-analysis' version '${System.getProperty("com.autonomousapps.pluginversion")}'
-        }
-        
-        repositories {
-          google()
-          mavenCentral()
-        }
-        
-        dependencies {
-          implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.21"
-        }
-    """.trimIndent()
-    }
-
-    @JvmStatic
-    fun expectedAdvice(): Set<ComprehensiveAdvice> {
-      return setOf(ComprehensiveAdvice(
-        projectPath = ":",
-        dependencyAdvice = emptySet(),
-        pluginAdvice = setOf(PluginAdvice.redundantJavaLibrary())
-      ))
-    }
-  }
-}
-
 class RedundantKotlinJvmPluginProject : ProjectDirProvider {
 
   private val rootSpec = RootSpec(
@@ -112,7 +64,7 @@ class RedundantKotlinJvmPluginProject : ProjectDirProvider {
   }
 }
 
-class RedundantJavaLibraryAndKaptPluginsProject : ProjectDirProvider {
+class RedundantKotlinJvmAndKaptPluginsProject : ProjectDirProvider {
 
   private val rootSpec = RootSpec(buildScript = buildScript())
 
@@ -155,7 +107,7 @@ class RedundantJavaLibraryAndKaptPluginsProject : ProjectDirProvider {
       return setOf(ComprehensiveAdvice(
         projectPath = ":",
         dependencyAdvice = emptySet(),
-        pluginAdvice = setOf(PluginAdvice.redundantJavaLibrary(), PluginAdvice.redundantKapt())
+        pluginAdvice = setOf(PluginAdvice.redundantKotlinJvm(), PluginAdvice.redundantKapt())
       ))
     }
   }

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -355,7 +355,11 @@ class DependencyAnalysisPlugin : Plugin<Project> {
   private fun Project.configureJavaLibProject() {
     if (configuredForKotlinJvmOrJavaLibrary.getAndSet(true)) {
       logger.info("(dependency analysis) $path was already configured for the kotlin-jvm plugin")
-      RedundantPluginSubPlugin(this, aggregateAdviceTask).configure()
+      RedundantPluginSubPlugin(
+        project = this,
+        aggregateAdviceTask = aggregateAdviceTask,
+        redundantPluginsBehavior = getExtension().issueHandler.redundantPluginsIssue()
+      ).configure()
       return
     }
     if (configuredForJavaProject.getAndSet(true)) {
@@ -403,7 +407,11 @@ class DependencyAnalysisPlugin : Plugin<Project> {
   private fun Project.configureKotlinJvmProject() {
     if (configuredForKotlinJvmOrJavaLibrary.getAndSet(true)) {
       logger.info("(dependency analysis) $path was already configured for the java-library plugin")
-      RedundantPluginSubPlugin(this, aggregateAdviceTask).configure()
+      RedundantPluginSubPlugin(
+        project = this,
+        aggregateAdviceTask = aggregateAdviceTask,
+        redundantPluginsBehavior = getExtension().issueHandler.redundantPluginsIssue()
+      ).configure()
       return
     }
 
@@ -711,6 +719,7 @@ class DependencyAnalysisPlugin : Plugin<Project> {
       kapt.set(providers.provider { plugins.hasPlugin("kotlin-kapt") })
       declaredProcs.set(declaredProcsTask.flatMap { it.output })
       unusedProcs.set(unusedProcsTask.flatMap { it.output })
+      redundantPluginsBehavior.set(getExtension().issueHandler.redundantPluginsIssueFor(this@analyzeDependencies.path))
 
       output.set(outputPaths.pluginKaptAdvicePath)
     }

--- a/src/main/kotlin/com/autonomousapps/RedundantPluginSubPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/RedundantPluginSubPlugin.kt
@@ -2,16 +2,19 @@
 
 package com.autonomousapps
 
+import com.autonomousapps.extension.Behavior
 import com.autonomousapps.internal.RedundantSubPluginOutputPaths
 import com.autonomousapps.tasks.AdviceSubprojectAggregationTask
 import com.autonomousapps.tasks.RedundantPluginAlertTask
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
 
 internal class RedundantPluginSubPlugin(
   private val project: Project,
-  private val aggregateAdviceTask: TaskProvider<AdviceSubprojectAggregationTask>
+  private val aggregateAdviceTask: TaskProvider<AdviceSubprojectAggregationTask>,
+  private val redundantPluginsBehavior: Provider<Behavior>
 ) {
 
   private val outputPaths = RedundantSubPluginOutputPaths(project)
@@ -28,6 +31,7 @@ internal class RedundantPluginSubPlugin(
       kotlinFiles.setFrom(project.fileTree(projectDir).matching {
         include("**/*.kt")
       })
+      redundantPluginsBehavior.set(this@RedundantPluginSubPlugin.redundantPluginsBehavior)
       output.set(outputPaths.pluginJvmAdvicePath)
     }
     aggregateAdviceTask.configure {

--- a/src/main/kotlin/com/autonomousapps/tasks/RedundantPluginAlertTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/RedundantPluginAlertTask.kt
@@ -2,17 +2,19 @@ package com.autonomousapps.tasks
 
 import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.advice.PluginAdvice
+import com.autonomousapps.extension.Behavior
+import com.autonomousapps.extension.Ignore
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.toJson
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 
 /**
  * Runs if both java-library and kotlin-jvm plugins have been applied. Checks for presence of java
- * and kotlin source. Suggests removing one or the other plugin as redundant, based on which kinds
- * of source are present.
+ * and kotlin source. Suggests removing kotlin-jvm if there is no Kotlin source.
  */
 @CacheableTask
 abstract class RedundantPluginAlertTask : DefaultTask() {
@@ -30,6 +32,9 @@ abstract class RedundantPluginAlertTask : DefaultTask() {
   @get:InputFiles
   abstract val kotlinFiles: ConfigurableFileCollection
 
+  @get:Input
+  abstract val redundantPluginsBehavior: Property<Behavior>
+
   @get:OutputFile
   abstract val output: RegularFileProperty
 
@@ -37,21 +42,14 @@ abstract class RedundantPluginAlertTask : DefaultTask() {
     // Outputs
     val outputFile = output.getAndDelete()
 
-    val hasJava = javaFiles.files.isNotEmpty()
     val hasKotlin = kotlinFiles.files.isNotEmpty()
+    val shouldIgnore = redundantPluginsBehavior.get() is Ignore
 
-    val pluginAdvice = if (hasJava && hasKotlin) {
-      // Project has both java and kotlin, prefer kotlin
-      PluginAdvice.redundantJavaLibrary()
-    } else if (hasJava) {
-      // Project has only java, so why was kotlin applied?
-      PluginAdvice.redundantKotlinJvm()
-    } else {
-      // Project has only kotlin, or nothing (!), prefer kotlin
-      PluginAdvice.redundantJavaLibrary()
-    }
-
-    val pluginAdvices = listOf(pluginAdvice)
+    // TODO Issue 427: use plugin excludes
+    // https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/427
+    val pluginAdvices =
+      if (!hasKotlin && !shouldIgnore) setOf(PluginAdvice.redundantKotlinJvm())
+      else emptySet()
 
     if (pluginAdvices.isNotEmpty()) {
       val adviceString = pluginAdvices.joinToString(prefix = "- ", separator = "\n- ") {


### PR DESCRIPTION
Don't emit warning about redundant plugins when behavior is set to ignore.