### PR TITLE
Fix Android manifest parsing in case of queries node

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/ManifestParser.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/ManifestParser.kt
@@ -1,0 +1,72 @@
+package com.autonomousapps.internal
+
+import com.autonomousapps.internal.utils.buildDocument
+import com.autonomousapps.internal.utils.mapToSet
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import java.io.File
+
+internal class ManifestParser {
+
+  class ParseResult(
+    val packageName: String,
+    val components: Map<String, Set<String>>
+  )
+
+  fun parse(manifest: File): ParseResult {
+    val document = buildDocument(manifest)
+
+    val packageName = packageName(document)
+    val application = application(document)
+    // "service" is enough to catch LeakCanary, and "provider" makes sense in principle. Trying not to be too aggressive.
+    val services = application?.componentNames(Manifest.Component.SERVICE, packageName) ?: emptySet()
+    val providers = application?.componentNames(Manifest.Component.PROVIDER, packageName) ?: emptySet()
+
+    val componentsMapping = mutableMapOf<String, Set<String>>()
+    if (services.isNotEmpty()) componentsMapping[Manifest.Component.SERVICE.mapKey] = services
+    if (providers.isNotEmpty()) componentsMapping[Manifest.Component.PROVIDER.mapKey] = providers
+
+    return ParseResult(
+      packageName = packageName,
+      components = componentsMapping
+    )
+  }
+
+  private fun application(document: Document): Element? {
+    val elements = document.getElementsByTagName("application")
+    return if (elements.length > 0) {
+      elements.item(0) as Element
+    } else {
+      null
+    }
+  }
+
+  private fun packageName(document: Document): String {
+    return document.getElementsByTagName("manifest").item(0)
+      .attributes
+      .getNamedItem("package")
+      .nodeValue
+  }
+
+  private fun Element.componentNames(
+    component: Manifest.Component,
+    packageName: String
+  ): Set<String> {
+    return getElementsByTagName(component.tagName)
+      .mapToSet {
+        it.attributes.getNamedItem(component.attrName).nodeValue.withPackageName(
+          packageName
+        )
+      }
+  }
+
+  private fun String.withPackageName(packageName: String): String {
+    return if (startsWith(".")) {
+      // item name is relative, so prefix with the package name
+      "$packageName$this"
+    } else {
+      // item name is absolute, so use it as-is
+      this
+    }
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/ManifestPackageExtractionTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ManifestPackageExtractionTask.kt
@@ -4,6 +4,7 @@ package com.autonomousapps.tasks
 
 import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.Manifest
+import com.autonomousapps.internal.ManifestParser
 import com.autonomousapps.internal.utils.*
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -38,61 +39,22 @@ abstract class ManifestPackageExtractionTask : DefaultTask() {
   @TaskAction fun action() {
     val outputFile = output.getAndDelete()
 
+    val parser = ManifestParser()
+
     val manifests: Set<Manifest> = manifestArtifacts.mapNotNullToOrderedSet { manifest ->
       try {
-        extractManifestComponents(manifest.file).let { (pn, componentMap) ->
-          Manifest(
-            packageName = pn,
-            componentMap = componentMap,
-            componentIdentifier = manifest.id.componentIdentifier
-          )
-        }
+        val parseResult = parser.parse(manifest.file)
+
+        Manifest(
+          packageName = parseResult.packageName,
+          componentMap = parseResult.components,
+          componentIdentifier = manifest.id.componentIdentifier
+        )
       } catch (_: GradleException) {
         null
       }
     }
 
     outputFile.writeText(manifests.toJson())
-  }
-
-  // "service" is enough to catch LeakCanary, and "provider" makes sense in principle. Trying not to be too aggressive.
-  private fun extractManifestComponents(manifest: File): Pair<String, Map<String, Set<String>>> {
-    val document = buildDocument(manifest)
-
-    val pn = packageName(document)
-//    val activities = document.componentNames(Component.ACTIVITY, pn)
-//    val receivers = document.componentNames(Component.RECEIVER, pn)
-    val services = document.componentNames(Manifest.Component.SERVICE, pn)
-    val providers = document.componentNames(Manifest.Component.PROVIDER, pn)
-
-    val map = mutableMapOf<String, Set<String>>()
-//    if (activities.isNotEmpty()) map[Manifest.Component.ACTIVITY.plural] = activities
-//    if (receivers.isNotEmpty()) map[Manifest.Component.RECEIVER.plural] = receivers
-    if (services.isNotEmpty()) map[Manifest.Component.SERVICE.mapKey] = services
-    if (providers.isNotEmpty()) map[Manifest.Component.PROVIDER.mapKey] = providers
-
-    return packageName(document) to map
-  }
-
-  private fun packageName(document: Document): String {
-    return document.getElementsByTagName("manifest").item(0)
-      .attributes
-      .getNamedItem("package")
-      .nodeValue
-  }
-
-  private fun Document.componentNames(component: Manifest.Component, packageName: String): Set<String> {
-    return getElementsByTagName(component.tagName)
-      .mapToSet { it.attributes.getNamedItem(component.attrName).nodeValue.withPackageName(packageName) }
-  }
-
-  private fun String.withPackageName(packageName: String): String {
-    return if (startsWith(".")) {
-      // item name is relative, so prefix with the package name
-      "$packageName$this"
-    } else {
-      // item name is absolute, so use it as-is
-      this
-    }
   }
 }

--- a/src/test/kotlin/com/autonomousapps/internal/ManifestParserTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/ManifestParserTest.kt
@@ -1,0 +1,102 @@
+package com.autonomousapps.internal
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ManifestParserTest {
+
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  @Test fun `parse package name`() {
+    val manifest = parse(
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.app" />
+    """.trimIndent()
+    )
+
+    assertThat(manifest.packageName).isEqualTo("com.app")
+  }
+
+  @Test fun `parse services`() {
+    val manifest = parse(
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
+          package="com.app" >
+      
+          <application>
+              <service
+                  android:name="com.app.ServiceA"
+                  android:exported="false"/>
+              <service
+                  android:name=".ServiceB"
+                  android:exported="false"/>
+          </application>
+      </manifest>
+    """.trimIndent()
+    )
+
+    val services = manifest.components["services"]
+    assertThat(services).isNotNull()
+    assertThat(services).isEqualTo(
+      setOf("com.app.ServiceA", "com.app.ServiceB")
+    )
+  }
+
+  @Test fun `parse providers`() {
+    val manifest = parse(
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
+          package="com.app" >
+          
+          <queries>
+          
+            <package android:name="com.otherapp" />
+            
+            <intent>
+                <action android:name="com.otherapp.ACTION" />
+            </intent>
+            
+            <provider
+              android:authorities="com.otherapp.provider" />
+              
+          </queries>
+      
+          <application>
+              <provider
+                  android:name="com.app.ContentProviderA"
+                  android:authorities="com.app.provider"
+                  android:enabled="true"
+                  android:exported="true" >
+              </provider>
+              <provider
+                  android:name=".ContentProviderB"
+                  android:authorities="com.app.provider"
+                  android:enabled="true"
+                  android:exported="true" >
+              </provider>
+          </application>
+      </manifest>
+    """.trimIndent()
+    )
+
+    val providers = manifest.components["providers"]
+    assertThat(providers).isNotNull()
+    assertThat(providers).isEqualTo(
+      setOf("com.app.ContentProviderA", "com.app.ContentProviderB")
+    )
+  }
+
+  private fun parse(manifest: String): ManifestParser.ParseResult {
+    val file = tempFolder.newFile("AndroidManifest.xml")
+    file.writeText(manifest)
+    return ManifestParser().parse(file)
+  }
+}


### PR DESCRIPTION
### The problem

```
> ./gradlew :lib:projectHealth

Execution failed for task ':lib:extractPackageNameFromManifestDebug':

java.lang.IllegalStateException: it.attributes.getNamedItem(component.attrName) must not be null
  at com.autonomousapps.tasks.ManifestPackageExtractionTask.componentNames(ManifestPackageExtractionTask.kt:86)
  at com.autonomousapps.tasks.ManifestPackageExtractionTask.extractManifestComponents(ManifestPackageExtractionTask.kt:66)
  at com.autonomousapps.tasks.ManifestPackageExtractionTask.action(ManifestPackageExtractionTask.kt:43)
```

It happens for manifests with `provider` inside [queries](https://developer.android.com/guide/topics/manifest/queries-element#provider). It has other attributes.

Example: [com.yandex.android:mobmetricalib:3.20.1](https://repo1.maven.org/maven2/com/yandex/android/mobmetricalib/3.20.1/)

### Changes

Narrowed searching of components in the manifest to the `<application>` node.