### PR TITLE
Can now ignore a 'redundant plugin' error.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AnnotationProcessorSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AnnotationProcessorSpec.groovy
@@ -1,7 +1,8 @@
 package com.autonomousapps.android
 
+import com.autonomousapps.AdviceHelper
+import com.autonomousapps.android.projects.KaptProject
 import com.autonomousapps.fixtures.*
-import spock.lang.Unroll
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
@@ -9,7 +10,6 @@ import static com.google.common.truth.Truth.assertThat
 @SuppressWarnings("GroovyAssignabilityCheck")
 final class AnnotationProcessorSpec extends AbstractAndroidSpec {
 
-  @Unroll
   def "kapt is not redundant when there are used procs (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new AutoValueProjectUsedByKapt(agpVersion)
@@ -27,7 +27,6 @@ final class AnnotationProcessorSpec extends AbstractAndroidSpec {
     [gradleVersion, agpVersion] << gradleAgpMatrix()
   }
 
-  @Unroll
   def "kapt is redundant when no procs are used (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new KaptIsRedundantWithUnusedProcsProject(agpVersion)
@@ -47,7 +46,6 @@ final class AnnotationProcessorSpec extends AbstractAndroidSpec {
     [gradleVersion, agpVersion] << gradleAgpMatrix()
   }
 
-  @Unroll
   def "kapt is redundant when no procs are declared (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new KaptIsRedundantProject(agpVersion)
@@ -67,7 +65,24 @@ final class AnnotationProcessorSpec extends AbstractAndroidSpec {
     [gradleVersion, agpVersion] << gradleAgpMatrix()
   }
 
-  @Unroll
+  def "kapt redundancy can be ignored by user (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new KaptProject(agpVersion)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    def actualPluginAdvice = AdviceHelper.actualBuildHealth(gradleProject)
+      .find { it.projectPath == ':lib' }
+      .pluginAdvice
+    assertThat(actualPluginAdvice.size()).isEqualTo(0)
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix()
+  }
+
   def "autovalue is used with kapt (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new AutoValueProjectUsedByKapt(agpVersion)
@@ -85,7 +100,6 @@ final class AnnotationProcessorSpec extends AbstractAndroidSpec {
     [gradleVersion, agpVersion] << gradleAgpMatrix()
   }
 
-  @Unroll
   def "dagger is unused with kapt (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new DaggerProjectUnusedByKapt(agpVersion)
@@ -103,7 +117,6 @@ final class AnnotationProcessorSpec extends AbstractAndroidSpec {
     [gradleVersion, agpVersion] << gradleAgpMatrix()
   }
 
-  @Unroll
   def "dagger is used with kapt on method (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new DaggerProjectUsedByKaptForMethod(agpVersion)
@@ -121,7 +134,6 @@ final class AnnotationProcessorSpec extends AbstractAndroidSpec {
     [gradleVersion, agpVersion] << gradleAgpMatrix()
   }
 
-  @Unroll
   def "dagger is used with kapt on class (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new DaggerProjectUsedByKaptForClass(agpVersion)
@@ -139,7 +151,6 @@ final class AnnotationProcessorSpec extends AbstractAndroidSpec {
     [gradleVersion, agpVersion] << gradleAgpMatrix()
   }
 
-  @Unroll
   def "dagger is unused with annotationProcessor (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new DaggerProjectUnusedByAnnotationProcessor(agpVersion)
@@ -157,7 +168,6 @@ final class AnnotationProcessorSpec extends AbstractAndroidSpec {
     [gradleVersion, agpVersion] << gradleAgpMatrix()
   }
 
-  @Unroll
   def "dagger is used with annotationProcessor on method (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new DaggerProjectUsedByAnnotationProcessorForMethod(agpVersion)
@@ -175,7 +185,6 @@ final class AnnotationProcessorSpec extends AbstractAndroidSpec {
     [gradleVersion, agpVersion] << gradleAgpMatrix()
   }
 
-  @Unroll
   def "dagger is used with annotationProcessor on class (#gradleVersion AGP #agpVersion)"() {
     given:
     def project = new DaggerProjectUsedByAnnotationProcessorForClass(agpVersion)

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/KaptProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/KaptProject.groovy
@@ -1,0 +1,55 @@
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.*
+
+final class KaptProject extends AbstractProject {
+
+  final String agpVersion
+  final GradleProject gradleProject
+
+  KaptProject(String agpVersion) {
+    this.agpVersion = agpVersion
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withRootProject { root ->
+      root.gradleProperties = GradleProperties.minimalAndroidProperties()
+      root.withBuildScript { bs ->
+        bs.buildscript = BuildscriptBlock.defaultAndroidBuildscriptBlock(agpVersion)
+        bs.additions = """
+          dependencyAnalysis {
+            issues {
+              all {
+                onRedundantPlugins {
+                  severity('fail')
+                  exclude('kotlin-kapt')
+                }
+              }
+            }
+          }
+        """.stripIndent()
+      }
+    }
+    builder.withAndroidSubproject('lib') { a ->
+      a.sources = []
+      a.withBuildScript { bs ->
+        bs.plugins = [Plugin.androidLibPlugin, Plugin.kotlinAndroidPlugin, Plugin.kaptPlugin]
+        bs.android = AndroidBlock.defaultAndroidLibBlock(true)
+        bs.dependencies = dependencies
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private List<Dependency> dependencies = [
+    Dependency.appcompat("implementation"),
+    Dependency.dagger("androidTestImplementation"),
+    Dependency.daggerCompiler("kaptAndroidTest")
+  ]
+}

--- a/src/main/kotlin/com/autonomousapps/advice/PluginAdvice.kt
+++ b/src/main/kotlin/com/autonomousapps/advice/PluginAdvice.kt
@@ -6,22 +6,27 @@ data class PluginAdvice(
 ) : Comparable<PluginAdvice> {
 
   companion object {
+    const val JAVA_LIBRARY = "java-library"
+    const val KOTLIN_JVM = "org.jetbrains.kotlin.jvm"
+    const val KOTLIN_KAPT = "kotlin-kapt"
+
     @JvmStatic
     fun redundantJavaLibrary() = PluginAdvice(
-      redundantPlugin = "java-library",
+      redundantPlugin = JAVA_LIBRARY,
       reason = "this project has both java-library and org.jetbrains.kotlin.jvm applied, which " +
         "is redundant. You can remove java-library"
     )
 
     @JvmStatic
     fun redundantKotlinJvm() = PluginAdvice(
-      redundantPlugin = "org.jetbrains.kotlin.jvm",
+      redundantPlugin = KOTLIN_JVM,
       reason = "this project has both java-library and org.jetbrains.kotlin.jvm applied, which " +
         "is redundant. You can remove org.jetbrains.kotlin.jvm"
     )
 
+    @JvmStatic
     fun redundantKapt() = PluginAdvice(
-      redundantPlugin = "kotlin-kapt",
+      redundantPlugin = KOTLIN_KAPT,
       reason = "this project has the kotlin-kapt (org.jetbrains.kotlin.kapt) plugin applied, but " +
         "no annotation processors (or no used annotation processors), which is redundant."
     )

--- a/src/main/kotlin/com/autonomousapps/tasks/RedundantKaptAlertTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/RedundantKaptAlertTask.kt
@@ -74,12 +74,13 @@ abstract class RedundantKaptAlertWorkAction : WorkAction<RedundantKaptAlertParam
 
   override fun execute() {
     val outputFile = parameters.output.getAndDelete()
-    val shouldIgnore = parameters.redundantPluginsBehavior.get() is Ignore
 
-    // TODO Issue 427: use plugin excludes
-    // https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/427
-    val pluginAdvice = if (!parameters.kapt.get() || shouldIgnore) {
-      // kapt is not applied
+    val behavior = parameters.redundantPluginsBehavior.get()
+    val excludes = behavior.filter
+    val shouldIgnore = behavior is Ignore
+
+    val pluginAdvice = if (shouldIgnore || !parameters.kapt.get() || excludes.contains(PluginAdvice.KOTLIN_KAPT)) {
+      // kapt is not applied or the user has configured to ignore kapt
       emptySet()
     } else {
       // kapt is applied

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
@@ -134,6 +134,16 @@ class Dependency @JvmOverloads constructor(
     }
 
     @JvmStatic
+    fun dagger(configuration: String): Dependency {
+      return Dependency(configuration, "com.google.dagger:dagger:2.33")
+    }
+
+    @JvmStatic
+    fun daggerCompiler(configuration: String): Dependency {
+      return Dependency(configuration, "com.google.dagger:dagger-compiler:2.33")
+    }
+
+    @JvmStatic
     fun firebaseAnalytics(configuration: String): Dependency {
       return Dependency(configuration, "com.google.firebase:firebase-analytics:17.6.0")
     }


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/427.