### PR TITLE
Exclude test based configurations from locations.json if we should not analyze test

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/ConfigurationsToDependenciesTransformer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/ConfigurationsToDependenciesTransformer.kt
@@ -8,7 +8,8 @@ internal class ConfigurationsToDependenciesTransformer(
   private val flavorName: String?,
   private val buildType: String?,
   private val variantName: String,
-  private val configurations: ConfigurationContainer
+  private val configurations: ConfigurationContainer,
+  private val includeTest: Boolean
 ) {
 
   private val logger = getLogger<LocateDependenciesTask>()
@@ -35,7 +36,10 @@ internal class ConfigurationsToDependenciesTransformer(
     val candidateConfNames = buildConfNames() + buildAPConfNames()
 
     // Partition all configurations into those we care about and those we don't
-    val (interestingConfs, otherConfs) = configurations.partition { conf ->
+    val (interestingConfs, otherConfs) = configurations.filter {
+      // Either include all or if we should not analyze test we exclude those who are in the DEFAULT_TEST_CONFS
+      conf -> includeTest || !(conf.name.matches(Regex("^test[A-Z].*")))
+    }.partition { conf ->
       candidateConfNames.contains(conf.name)
     }
 

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -386,6 +386,7 @@ internal class ProjectPlugin(private val project: Project) {
         this@register.flavorName.set(flavorName)
         this@register.variantName.set(variantName)
         this@register.buildType.set(buildType)
+        this@register.includeTest.set(shouldAnalyzeTests())
 
         output.set(outputPaths.locationsPath)
       }

--- a/src/main/kotlin/com/autonomousapps/tasks/LocateDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/LocateDependenciesTask.kt
@@ -36,6 +36,9 @@ abstract class LocateDependenciesTask : DefaultTask() {
   @get:Input
   abstract val variantName: Property<String>
 
+  @get:Input
+  abstract val includeTest: Property<Boolean>
+
   //  For up to date correctness
 //  @get:Classpath
 //  abstract val compileClasspathArtifacts: ConfigurableFileCollection
@@ -54,7 +57,8 @@ abstract class LocateDependenciesTask : DefaultTask() {
       flavorName = flavorName.orNull,
       buildType = buildType.orNull,
       variantName = variantName.get(),
-      configurations = project.configurations
+      configurations = project.configurations,
+      includeTest = includeTest.get()
     ).locations()
 
     outputFile.writeText(locations.toJson())


### PR DESCRIPTION
Preferably most task are run for the `test` variant instead of including it with the `main` variant, but that would require a lot more effort at this time. 