### PR TITLE
Fixes issue 529.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/classReferenceParsers.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/classReferenceParsers.kt
@@ -76,7 +76,7 @@ internal sealed class ProjectClassReferenceParser(
   protected fun normalizePath(filePath: String, source: String? = null): NormalizedPath {
     if (source == null) return NormalizedPath(filePath)
 
-    val dirPath = filePath.substringBeforeLast("/") + "/"
+    val dirPath = filePath.substringBeforeLast(File.separator) + File.separator
     val sourceName = source.substringBeforeLast(".")
     val fileExtension = filePath.substring(filePath.lastIndexOf("."))
 

--- a/src/main/kotlin/com/autonomousapps/tasks/CreateVariantFiles.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/CreateVariantFiles.kt
@@ -33,9 +33,9 @@ abstract class CreateVariantFiles : DefaultTask() {
   protected fun Set<File>.toVariantFiles(name: String): Set<VariantFile> {
     return asSequence().map { file ->
       project.relativePath(file)
-    }.map { it.removePrefix("src/$name/") }
+    }.map { it.removePrefix("src${File.separator}$name${File.separator}") }
       // remove java/, kotlin/ and /res from start
-      .map { it.substring(it.indexOf("/") + 1) }
+      .map { it.substring(it.indexOf(File.separator) + 1) }
       // remove file extension from end
       .mapNotNull {
         val index = it.lastIndexOf(".")


### PR DESCRIPTION
File.separator instead of / so that file system paths are processed properly when running builds on windows. Actually the problem was covered by TestDependenciesSpec "unused test dependencies are reported" already: Running it on windows failed before doing this change. With the change it now passes.