### PR TITLE
Introduce UsagesHandler that allows to exclude particular classes fro…

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/DataBindingUsagesExclusionsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/DataBindingUsagesExclusionsSpec.groovy
@@ -1,0 +1,40 @@
+package com.autonomousapps.android
+
+import com.autonomousapps.android.projects.DataBindingUsagesExclusionsProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+@SuppressWarnings("GroovyAssignabilityCheck")
+final class DataBindingUsagesExclusionsSpec extends AbstractAndroidSpec {
+
+  def "doesn't report unused dataBinding module by default (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new DataBindingUsagesExclusionsProject(agpVersion, false)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix(AGP_4_2)
+  }
+
+  def "reports unused dataBinding module when DataBinderMapperImpl usages are excluded (#gradleVersion AGP #agpVersion)"() {
+    given:
+    def project = new DataBindingUsagesExclusionsProject(agpVersion, true)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    [gradleVersion, agpVersion] << gradleAgpMatrix(AGP_4_2)
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/DataBindingUsagesExclusionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/DataBindingUsagesExclusionsProject.groovy
@@ -1,0 +1,141 @@
+package com.autonomousapps.android.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.AdviceHelper
+import com.autonomousapps.advice.Advice
+import com.autonomousapps.advice.ComprehensiveAdvice
+import com.autonomousapps.kit.*
+
+final class DataBindingUsagesExclusionsProject extends AbstractProject {
+
+  final GradleProject gradleProject
+  private final String agpVersion
+  private final boolean excludeDataBinderMapper
+
+  DataBindingUsagesExclusionsProject(String agpVersion, boolean excludeDataBinderMapper) {
+    this.agpVersion = agpVersion
+    this.excludeDataBinderMapper = excludeDataBinderMapper
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withRootProject { root ->
+      root.gradleProperties = GradleProperties.minimalAndroidProperties()
+      root.withBuildScript { bs ->
+        bs.buildscript = BuildscriptBlock.defaultAndroidBuildscriptBlock(agpVersion)
+
+        if (excludeDataBinderMapper) {
+          bs.additions = """\
+            dependencyAnalysis {
+              usages {
+                exclusions {
+                  excludeClasses(".*\\\\.DataBinderMapperImpl\\\$")
+                }
+              }
+            }
+          """.stripIndent()
+        }
+      }
+    }
+    builder.withAndroidSubproject('app') { app ->
+      app.withBuildScript { bs ->
+        bs.plugins = [Plugin.androidAppPlugin, Plugin.kotlinAndroidPlugin, Plugin.kaptPlugin]
+        bs.android = AndroidBlock.defaultAndroidAppBlock(true)
+        bs.dependencies = appDependencies
+        bs.additions = "android.buildFeatures.dataBinding true"
+      }
+      app.manifest = AndroidManifest.defaultLib("com.example.app")
+      app.sources = appSources
+    }
+
+    builder.withAndroidSubproject('lib') { lib ->
+      lib.withBuildScript { bs ->
+        bs.plugins = [Plugin.androidLibPlugin, Plugin.kotlinAndroidPlugin, Plugin.kaptPlugin]
+        bs.android = AndroidBlock.defaultAndroidLibBlock(true)
+        bs.dependencies = libDependencies
+        bs.additions = "android.buildFeatures.dataBinding true"
+      }
+      lib.manifest = AndroidManifest.defaultLib("com.example.lib")
+      lib.sources = libSources
+      lib.withFile('src/main/res/layout/hello.xml', """\
+          <?xml version="1.0" encoding="utf-8"?>
+          <layout
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:binding="http://schemas.android.com/apk/res-auto">
+
+            <TextView
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              binding:text="@{`Hello`}" />
+
+          </layout>
+        """.stripIndent()
+      )
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private appSources = [
+    new Source(
+      SourceType.KOTLIN, 'MainActivity', 'com/example/app',
+      """
+        package com.example.app
+        
+        import androidx.appcompat.app.AppCompatActivity
+        
+        class MainActivity : AppCompatActivity() {
+        }
+      """.stripIndent()
+    )
+  ]
+
+  private List<Dependency> appDependencies = [
+    Dependency.kotlinStdLib("implementation"),
+    Dependency.appcompat("implementation"),
+    Dependency.project("implementation", ":lib"),
+  ]
+
+  private libSources = [
+    new Source(
+      SourceType.KOTLIN, 'Bindings', 'com/example/lib',
+      """
+        package com.example.lib
+        
+        import android.widget.TextView
+        import androidx.databinding.BindingAdapter
+        
+        @BindingAdapter("text")
+        fun setText(view: TextView, text: String) {
+          view.text = text
+        }
+      """.stripIndent()
+    )
+  ]
+
+  private List<Dependency> libDependencies = [
+    Dependency.kotlinStdLib("api")
+  ]
+
+  private final List<ComprehensiveAdvice> expectedBuildHealthWithExclusions = [
+    AdviceHelper.emptyCompAdviceFor(':'),
+    AdviceHelper.compAdviceForDependencies(':app', [
+      Advice.ofRemove(AdviceHelper.dependency(":lib", null, "implementation"))
+    ] as Set<Advice>),
+    AdviceHelper.emptyCompAdviceFor(':lib'),
+  ]
+
+  private final List<ComprehensiveAdvice> expectedBuildHealthWithoutExclusions =
+    AdviceHelper.emptyBuildHealthFor(':', ':app', ':lib')
+
+  final List<ComprehensiveAdvice> expectedBuildHealth = excludeDataBinderMapper
+    ? expectedBuildHealthWithExclusions
+    : expectedBuildHealthWithoutExclusions
+
+  List<ComprehensiveAdvice> actualBuildHealth() {
+    return AdviceHelper.actualBuildHealth(gradleProject)
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
@@ -5,6 +5,7 @@ package com.autonomousapps
 import com.autonomousapps.extension.AbiHandler
 import com.autonomousapps.extension.DependenciesHandler
 import com.autonomousapps.extension.IssueHandler
+import com.autonomousapps.extension.UsagesHandler
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
@@ -35,6 +36,7 @@ open class DependencyAnalysisExtension @Inject constructor(objects: ObjectFactor
 
   override val issueHandler = objects.newInstance(IssueHandler::class)
   internal val abiHandler = objects.newInstance(AbiHandler::class)
+  internal val usagesHandler = objects.newInstance(UsagesHandler::class)
   internal val dependenciesHandler = objects.newInstance(DependenciesHandler::class)
 
   /**
@@ -64,6 +66,13 @@ open class DependencyAnalysisExtension @Inject constructor(objects: ObjectFactor
    */
   fun abi(action: Action<AbiHandler>) {
     action.execute(abiHandler)
+  }
+
+  /**
+   * Customize how used classes are calculated. See [UsagesHandler] for more information.
+   */
+  fun usages(action: Action<UsagesHandler>) {
+    action.execute(usagesHandler)
   }
 
   /**

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisExtension.kt
@@ -26,6 +26,9 @@ import javax.inject.Inject
  *
  *   // Configure ABI exclusion rules.
  *   abi { ... }
+ *
+ *   // Configure usages exclusion rules.
+ *   usages { ... }
  * }
  * ```
  */

--- a/src/main/kotlin/com/autonomousapps/extension/UsagesHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/UsagesHandler.kt
@@ -1,0 +1,39 @@
+@file:Suppress("unused", "MemberVisibilityCanBePrivate")
+
+package com.autonomousapps.extension
+
+import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.setProperty
+import org.intellij.lang.annotations.Language
+import javax.inject.Inject
+
+/**
+ * ```
+ * dependencyAnalysis {
+ *   usages {
+ *     exclusions {
+ *       excludeClasses(".*\\.internal\\..*")
+ *     }
+ *   }
+ * }
+ * ```
+ */
+open class UsagesHandler @Inject constructor(objects: ObjectFactory) {
+
+  internal val exclusionsHandler: UsagesExclusionsHandler = objects.newInstance(UsagesExclusionsHandler::class)
+
+  fun exclusions(action: Action<UsagesExclusionsHandler>) {
+    action.execute(exclusionsHandler)
+  }
+}
+
+abstract class UsagesExclusionsHandler @Inject constructor(objects: ObjectFactory) {
+
+  internal val classExclusions = objects.setProperty<String>().convention(emptySet())
+
+  fun excludeClasses(@Language("RegExp") vararg classRegexes: String) {
+    classExclusions.addAll(*classRegexes)
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/internal/advice/filter/DataBindingFilter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/filter/DataBindingFilter.kt
@@ -7,6 +7,7 @@ import com.autonomousapps.advice.HasDependency
  * * androidx.databinding:databinding-adapters
  * * androidx.databinding:databinding-runtime
  * * androidx.databinding:databinding-common
+ * * androidx.databinding:databinding-compiler
  *
  * For AGP 7+
  * * androidx.databinding:databinding-ktx
@@ -18,6 +19,7 @@ internal class DataBindingFilter : DependencyFilter {
       "androidx.databinding:databinding-adapters",
       "androidx.databinding:databinding-runtime",
       "androidx.databinding:databinding-common",
+      "androidx.databinding:databinding-compiler",
       "androidx.databinding:databinding-ktx"
     )
   }

--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -673,6 +673,27 @@ internal data class AbiExclusions(
   }
 }
 
+internal data class UsagesExclusions(
+  val classExclusions: Set<String> = emptySet()
+) {
+
+  @Transient
+  private val classRegexes = classExclusions.mapToSet(String::toRegex)
+
+  fun excludesClass(fqcn: String) = classRegexes.any { it.containsMatchIn(fqcn.dotty()) }
+
+  fun excludeClassesFromSet(fqcn: Set<String>): Set<String> {
+    return fqcn.filterNotToSet { excludesClass(it) }
+  }
+
+  // The user-facing regex expects FQCNs to be delimited with dots, not slashes
+  private fun String.dotty() = replace("/", ".")
+
+  companion object {
+    val NONE = UsagesExclusions()
+  }
+}
+
 internal data class ProjectMetrics(
   val origGraph: GraphMetrics,
   val newGraph: GraphMetrics

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -738,6 +738,14 @@ internal class ProjectPlugin(private val project: Project) {
       }
     })
 
+    val usagesExclusionsProvider = provider {
+      with(getExtension().usagesHandler.exclusionsHandler) {
+        UsagesExclusions(
+          classExclusions = classExclusions.get(),
+        ).toJson()
+      }
+    }
+
     // Synthesizes the above into a single view of this project's usages.
     val synthesizeProjectViewTask = tasks.register<SynthesizeProjectViewTask>("synthesizeProjectView$taskNameSuffix") {
       projectPath.set(thisProjectPath)
@@ -749,6 +757,7 @@ internal class ProjectPlugin(private val project: Project) {
       annotationProcessors.set(declaredProcsTask.flatMap { it.output })
       explodedBytecode.set(explodeBytecodeTask.flatMap { it.output })
       explodedSourceCode.set(explodeCodeSourceTask.flatMap { it.output })
+      usagesExclusions.set(usagesExclusionsProvider)
       // Optional: only exists for libraries.
       abiAnalysisTask?.let { t -> explodingAbi.set(t.flatMap { it.output }) }
       // Optional: only exists for Android libraries.
@@ -981,6 +990,14 @@ internal class ProjectPlugin(private val project: Project) {
       redundantKaptAdvice.add(kaptAlertTask.flatMap { it.output })
     }
 
+    val usagesExclusionsProvider = provider {
+      with(getExtension().usagesHandler.exclusionsHandler) {
+        UsagesExclusions(
+          classExclusions = classExclusions.get(),
+        ).toJson()
+      }
+    }
+
     // A report of all unused dependencies and used-transitive dependencies
     val misusedDependenciesTask = tasks.register<DependencyMisuseTask>("misusedDependencies$variantTaskName") {
       jarAttr.set(dependencyAnalyzer.attributeValueJar)
@@ -992,6 +1009,7 @@ internal class ProjectPlugin(private val project: Project) {
       usedInlineDependencies.set(inlineTask.flatMap { it.inlineUsageReport })
       usedConstantDependencies.set(constantTask.flatMap { it.constantUsageReport })
       usedGenerally.set(generalUsageTask.flatMap { it.output })
+      usagesExclusions.set(usagesExclusionsProvider)
       manifestPackageExtractionTask?.let { task -> manifests.set(task.flatMap { it.output }) }
       androidResBySourceUsageTask?.let { task -> usedAndroidResBySourceDependencies.set(task.flatMap { it.output }) }
       androidResByResUsageTask?.let { task -> usedAndroidResByResDependencies.set(task.flatMap { it.output }) }

--- a/src/main/kotlin/com/autonomousapps/tasks/DependencyMisuseTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/DependencyMisuseTask.kt
@@ -84,6 +84,10 @@ abstract class DependencyMisuseTask : DefaultTask() {
   @get:InputFile
   abstract val usedGenerally: RegularFileProperty
 
+  @get:Optional
+  @get:Input
+  abstract val usagesExclusions: Property<String>
+
   @get:PathSensitive(PathSensitivity.NONE)
   @get:Optional
   @get:InputFile
@@ -134,9 +138,13 @@ abstract class DependencyMisuseTask : DefaultTask() {
       ?.resolutionResult
       ?.root
 
+    val usageExclusions = usagesExclusions.orNull?.fromJson<UsagesExclusions>() ?: UsagesExclusions.NONE
+    val usedClasses = usedClasses.fromJsonSet<VariantClass>()
+      .filterNotToSet { usageExclusions.excludesClass(it.theClass) }
+
     val dependencyReport = MisusedDependencyDetector(
       declaredComponents = declaredDependencies.fromJsonSet(),
-      usedClasses = usedClasses.fromJsonSet(),
+      usedClasses = usedClasses,
       usedInlineDependencies = usedInlineDependencies.fromJsonSet(),
       usedConstantDependencies = usedConstantDependencies.fromJsonSet(),
       usedGenerally = usedGenerally.fromJsonSet(),


### PR DESCRIPTION
I'm working on a project that heavily depends on [`Data Binding Library`](https://developer.android.com/topic/libraries/data-binding).

Data Binding compiler automatically generates `DataBinderMapperImpl` class for every data binding powered module:
```java
package com.example.compositefeature

public class DataBinderMapperImpl extends DataBinderMapper {
  @Override
  public List<DataBinderMapper> collectDependencies() {
    ArrayList<DataBinderMapper> result = new ArrayList<DataBinderMapper>(14);
    result.add(new androidx.databinding.library.baseAdapters.DataBinderMapperImpl());
    result.add(new com.example.feature1.DataBinderMapperImpl());
    result.add(new com.example.feature2.DataBinderMapperImpl());
    result.add(new com.example.feature3.DataBinderMapperImpl());
    return result;
  }
}
```
The implementation of `collectDependencies` method includes all `DataBinderMapperImpl` classes provided by dependencies of current module. It means `dependency-analysis-plugin` will never report data binding related dependencies as unused, because there is always at least one usage in generated `DataBinderMapperImpl` code.

The goal of this PR is to introduce an API that will allow to exclude particular classes (`DataBinderMapperImpl` in my case) from a list of used classes.

I've implemented a proof of concept version of the API and added new functional tests to verify it solves the problem I'm trying to solve.