### PR TITLE
Add project path as input to disambiguate.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -617,6 +617,7 @@ internal class ProjectPlugin(private val project: Project) {
     val graphViewTask = tasks.register<GraphViewTask>("graphView$taskNameSuffix") {
       setCompileClasspath(configurations[dependencyAnalyzer.compileConfigurationName])
       jarAttr.set(dependencyAnalyzer.attributeValueJar)
+      projectPath.set(thisProjectPath)
       variant.set(variantName)
       kind.set(dependencyAnalyzer.kind)
       output.set(outputPaths.compileGraphPath)
@@ -686,6 +687,7 @@ internal class ProjectPlugin(private val project: Project) {
     val synthesizeDependenciesTask =
       tasks.register<SynthesizeDependenciesTask>("synthesizeDependencies$taskNameSuffix") {
         inMemoryCache.set(inMemoryCacheProvider)
+        projectPath.set(thisProjectPath)
         graphView.set(graphViewTask.flatMap { it.output })
         physicalArtifacts.set(artifactsReportTask.flatMap { it.output })
         explodedJars.set(explodeJarTask.flatMap { it.output })

--- a/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
@@ -46,6 +46,10 @@ abstract class GraphViewTask : DefaultTask() {
     .artifactsFor(jarAttr.get())
     .artifactFiles
 
+  /** Needed to disambiguate other projects that might have otherwise identical inputs. */
+  @get:Input
+  abstract val projectPath: Property<String>
+
   @get:Input
   abstract val variant: Property<String>
 

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
@@ -32,6 +32,10 @@ abstract class SynthesizeDependenciesTask @Inject constructor(
   @get:Internal
   abstract val inMemoryCache: Property<InMemoryCache>
 
+  /** Needed to disambiguate other projects that might have otherwise identical inputs. */
+  @get:Input
+  abstract val projectPath: Property<String>
+
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
   abstract val graphView: RegularFileProperty


### PR DESCRIPTION
Was getting bad cache hits.