### PR TITLE
Do not retrieve non-main declarations when shouldAnalyzeTests is disabled

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/configuration/Configurations.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/configuration/Configurations.kt
@@ -23,6 +23,10 @@ internal object Configurations {
     return MAIN_SUFFIXES.any { suffix -> configurationName.endsWith(suffix = suffix, ignoreCase = true) }
   }
 
+  internal fun isMainStrict(configurationName: String): Boolean {
+    return MAIN_SUFFIXES.any { suffix -> configurationName == suffix }
+  }
+
   internal fun isAnnotationProcessor(configurationName: String): Boolean {
     return ANNOTATION_PROCESSOR_PREFIXES.any { prefix -> configurationName.startsWith(prefix) }
   }


### PR DESCRIPTION
Including the declarations of non-main configurations when analyzing with the following configuration:
```
systemProp.v=2
systemProp.dependency.analysis.test.analysis=false
```
Resulted in suggestions related to test (and not yet supported testFixtures) source sets. This PR fixes that when the test analysis is disabled.