### PR TITLE
Set default to new model. Prepare initial 1.0.0 release candidate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Dependency Analysis Plugin Changelog
 
+# Version 1.0.0-rc01 (unreleased)
+* New model is now the default. To use the old model, specify `-Ddependency.analysis.old.model=true`.
+* [Fixed] Don't report kotlin as unused when it is in fact used.
+
 # Version 0.80.0
 * [Fixed] Resolve LinkageError when more than one annotation processor references the same class.
   ([#556](https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/pull/556))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -200,10 +200,13 @@ fun quickTest(): Boolean = providers.systemProperty("funcTest.quick")
   .forUseAtConfigurationTime()
   .orNull != null
 
-// 1 or 2
-fun implementation(): String = providers.systemProperty("v")
-  .forUseAtConfigurationTime()
-  .getOrElse("1")
+// "false" means use new model. Default is false.
+fun implementation(): Boolean {
+  return providers.systemProperty("dependency.analysis.old.model")
+    .forUseAtConfigurationTime()
+    .getOrElse("false")
+    .toBoolean()
+}
 
 val functionalTest by tasks.registering(Test::class) {
   dependsOn(deleteOldFuncTests, installForFuncTest)
@@ -223,7 +226,7 @@ val functionalTest by tasks.registering(Test::class) {
   systemProperty("org.gradle.testkit.dir", file("${buildDir}/tmp/test-kit"))
   systemProperty("com.autonomousapps.pluginversion", version.toString())
   systemProperty("com.autonomousapps.quick", "${quickTest()}")
-  systemProperty("v", implementation())
+  systemProperty("dependency.analysis.old.model", "${implementation()}")
 
   beforeTest(closureOf<TestDescriptor> {
     logger.lifecycle("Running test: $this")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError -XX:GCT
 org.gradle.caching=true
 org.gradle.parallel=true
 
-VERSION=0.80.1-SNAPSHOT
+VERSION=1.0.0-SNAPSHOT
 
 # https://docs.gradle.org/6.5-rc-1/userguide/configuration_cache.html#use_project_during_execution
 # values include `on`, `warn`. The former will lead to build failures. The latter console warnings.

--- a/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
@@ -32,7 +32,7 @@ abstract class AbstractFunctionalSpec extends Specification {
   }
 
   static Boolean isV1() {
-    return System.getProperty('v') == '1'
+    return System.getProperty('dependency.analysis.old.model').toBoolean()
   }
 
   protected static void clean(ProjectDirProvider projectDirProvider) {

--- a/src/functionalTest/groovy/com/autonomousapps/android/BuildMetricsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/BuildMetricsSpec.groovy
@@ -11,7 +11,7 @@ import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
 
 // TODO V2: Uncertain if we want to keep this feature in v2
-@IgnoreIf({ PreconditionContext it -> it.sys.v == '2' })
+@IgnoreIf({ PreconditionContext it -> it.sys.'dependency.analysis.old.model' == 'false' })
 @SuppressWarnings("GroovyAssignabilityCheck")
 final class BuildMetricsSpec extends AbstractAndroidSpec {
 

--- a/src/functionalTest/groovy/com/autonomousapps/android/TestDependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/TestDependenciesSpec.groovy
@@ -11,7 +11,7 @@ import static com.google.common.truth.Truth.assertThat
 
 final class TestDependenciesSpec extends AbstractAndroidSpec {
 
-  @IgnoreIf({ PreconditionContext it -> it.sys.v == '1' })
+  @IgnoreIf({ PreconditionContext it -> it.sys.'dependency.analysis.old.model' == 'true' })
   def "don't advise removing test declarations when test analysis is disabled (#gradleVersion AGP #agpVersion analyzeTests=#analyzeTests)"() {
     given:
     def project = new TestDependenciesProject(agpVersion as String, analyzeTests as Boolean)
@@ -19,11 +19,7 @@ final class TestDependenciesSpec extends AbstractAndroidSpec {
 
     when:
     def testFlag = "-D${FlagsKt.FLAG_TEST_ANALYSIS}=$analyzeTests"
-    build(
-      gradleVersion as GradleVersion,
-      gradleProject.rootDir,
-      'buildHealth', '-Dv=2', testFlag
-    )
+    build(gradleVersion as GradleVersion, gradleProject.rootDir, 'buildHealth', testFlag)
 
     then:
     assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth())

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -7,7 +7,7 @@ import spock.lang.IgnoreIf
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
 
-@IgnoreIf({ PreconditionContext it -> it.sys.v == '1' })
+@IgnoreIf({ PreconditionContext it -> it.sys.'dependency.analysis.old.model' == 'true' })
 final class CustomSourceSetSpec extends AbstractJvmSpec {
 
   def "transitive dependency for main but declared on custom source set should not prevent advice (#gradleVersion)"() {

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/JvmSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/JvmSpec.groovy
@@ -180,7 +180,7 @@ final class JvmSpec extends AbstractFunctionalSpec {
   }
 
   // Not worth fixing up for v2
-  @IgnoreIf({ PreconditionContext it -> it.sys.v == '2' })
+  @IgnoreIf({ PreconditionContext it -> it.sys.'dependency.analysis.old.model' == 'false' })
   def "does not declare superclass used when it's only needed for compilation (#gradleVersion)"() {
     given:
     def libSpecs = [ABI_SUPER_LIB, ABI_CHILD_LIB, ABI_CONSUMER_LIB]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/MinimalAdviceSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/MinimalAdviceSpec.groovy
@@ -9,7 +9,7 @@ import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
 
 // TODO V2: Uncertain if we want to keep this feature in v2
-@IgnoreIf({ PreconditionContext it -> it.sys.v == '2' })
+@IgnoreIf({ PreconditionContext it -> it.sys.'dependency.analysis.old.model' == 'false' })
 final class MinimalAdviceSpec extends AbstractJvmSpec {
 
   def "minimized advice skips impl dependencies (#gradleVersion)"() {

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/PostProcessingSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/PostProcessingSpec.groovy
@@ -18,7 +18,7 @@ final class PostProcessingSpec extends AbstractJvmSpec {
     def result = build(
       gradleVersion as GradleVersion,
       gradleProject.rootDir,
-      ':proj-1:postProcess', isV1 ? '-Dv=1' : '-Dv=2'
+      ':proj-1:postProcess', isV1 ? '-Ddependency.analysis.old.model=true' : '-Ddependency.analysis.old.model=false'
     )
 
     then: 'The advice task executes (task dependencies work)'

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/RenamingSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/RenamingSpec.groovy
@@ -10,7 +10,7 @@ import static com.google.common.truth.Truth.assertThat
 final class RenamingSpec extends AbstractJvmSpec {
 
   // TODO V2: support has not yet been added to v2
-  @IgnoreIf({ PreconditionContext it -> it.sys.v == '2' })
+  @IgnoreIf({ PreconditionContext it -> it.sys.'dependency.analysis.old.model' == 'false' })
   def "dependencies are renamed when renamer is used (#gradleVersion)"() {
     given:
     def project = new RenamingProject()

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/RippleSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/RippleSpec.groovy
@@ -2,7 +2,6 @@ package com.autonomousapps.jvm
 
 import com.autonomousapps.jvm.projects.RippleProject
 import org.spockframework.runtime.extension.builtin.PreconditionContext
-import spock.lang.IgnoreIf
 import spock.lang.PendingFeatureIf
 
 import static com.autonomousapps.utils.Runner.build
@@ -11,7 +10,7 @@ import static com.google.common.truth.Truth.assertThat
 final class RippleSpec extends AbstractJvmSpec {
 
   // TODO V2: Uncertain if we want to keep this feature in v2
-  @PendingFeatureIf({ PreconditionContext it -> it.sys.v == '2' })
+  @PendingFeatureIf({ PreconditionContext it -> it.sys.'dependency.analysis.old.model' == 'false' })
   def "ripples account for transitive dependencies (#gradleVersion)"() {
     given:
     def project = new RippleProject()

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/SimilarAdviceSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/SimilarAdviceSpec.groovy
@@ -8,7 +8,7 @@ import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
 
 // TODO V2: this test can be deleted once we are fully migrated to v2
-@IgnoreIf({ PreconditionContext it -> it.sys.v == '2' })
+@IgnoreIf({ PreconditionContext it -> it.sys.'dependency.analysis.old.model' == 'false' })
 final class SimilarAdviceSpec extends AbstractJvmSpec {
 
   // https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/386

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/TestDependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/TestDependenciesSpec.groovy
@@ -58,7 +58,7 @@ final class TestDependenciesSpec extends AbstractJvmSpec {
     gradleVersion << gradleVersions()
   }
 
-  @IgnoreIf({ PreconditionContext it -> it.sys.v == '1' })
+  @IgnoreIf({ PreconditionContext it -> it.sys.'dependency.analysis.old.model' == 'true' })
   def "don't advise removing test declarations when test analysis is disabled (#gradleVersion analyzeTests=#analyzeTests)"() {
     given:
     def project = new TestDependenciesProject2()
@@ -66,11 +66,7 @@ final class TestDependenciesSpec extends AbstractJvmSpec {
 
     when:
     def flag = "-D${FlagsKt.FLAG_TEST_ANALYSIS}=$analyzeTests"
-    build(
-      gradleVersion as GradleVersion,
-      gradleProject.rootDir,
-      'buildHealth', '-Dv=2', flag
-    )
+    build(gradleVersion as GradleVersion, gradleProject.rootDir, 'buildHealth', flag)
 
     then:
     assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)

--- a/src/functionalTest/kotlin/com/autonomousapps/fixtures/ProjectDirProvider.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/fixtures/ProjectDirProvider.kt
@@ -179,4 +179,4 @@ interface ProjectDirProvider {
   }
 }
 
-private fun isV1() = System.getProperty("v") == "1"
+private fun isV1() = System.getProperty("dependency.analysis.old.model").toBoolean()

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -64,6 +64,7 @@ class DependencyAnalysisPlugin : Plugin<Project> {
 }
 
 internal fun Project.isV1(): Boolean = providers
-  .systemProperty("v")
+  .systemProperty("dependency.analysis.old.model")
   .forUseAtConfigurationTime()
-  .getOrElse("1") == "1"
+  .getOrElse("false")
+  .toBoolean()


### PR DESCRIPTION
My plan is to release 1.0.0-rc01 with a new default and the ability to use the old model if desired. Then I will immediately release 1.0.0-rc02 that _deletes_ the old model completely; this will be the only change between rc01 and rc02. RCs after that will include bug fixes, only for the new model. No new features planned, but I will consider reintroducing removed features before the final 1.0.0 release.