### PR TITLE
TestKit now supports included builds. Don't crash in presence of included build. 

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/IncludedBuildSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/IncludedBuildSpec.groovy
@@ -1,0 +1,25 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.IncludedBuildProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+// https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/565
+final class IncludedBuildSpec extends AbstractJvmSpec {
+
+  def "doesn't crash in presence of an included build (#gradleVersion)"() {
+    given:
+    def project = new IncludedBuildProject()
+    gradleProject = project.gradleProject
+
+    when: 'build does not fail'
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then: 'and there is no advice'
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildProject.groovy
@@ -1,0 +1,72 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.advice.ComprehensiveAdvice
+import com.autonomousapps.kit.*
+
+import static com.autonomousapps.AdviceHelper.actualBuildHealth
+import static com.autonomousapps.AdviceHelper.emptyBuildHealthFor
+
+final class IncludedBuildProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  IncludedBuildProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withRootProject { root ->
+      root.withBuildScript { bs ->
+        bs.plugins.add(Plugin.javaLibraryPlugin)
+        bs.dependencies = [new Dependency('implementation', 'second:second-build:1.0')]
+      }
+      root.settingsScript.additions = """\
+        includeBuild 'second-build'
+      """.stripIndent()
+      root.sources = [
+        new Source(
+          SourceType.JAVA, 'Main', 'com/example/main',
+          """\
+            package com.example.main;
+                        
+            public class Main {}
+          """.stripIndent()
+        )
+      ]
+    }
+    builder.withIncludedBuild('second-build') { second ->
+      second.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.additions = """\
+          group = 'second'
+          version = '1.0'
+        """.stripIndent()
+      }
+      second.sources = [
+        new Source(
+          SourceType.JAVA, 'Second', 'com/example/included',
+          """\
+            package com.example.included;
+                        
+            public class Second {}
+          """.stripIndent()
+        )
+      ]
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  @SuppressWarnings('GroovyAssignabilityCheck')
+  List<ComprehensiveAdvice> actualBuildHealth() {
+    actualBuildHealth(gradleProject)
+  }
+
+  final List<ComprehensiveAdvice> expectedBuildHealth = emptyBuildHealthFor(
+    ':',
+  )
+}

--- a/src/main/kotlin/com/autonomousapps/model/Dependency.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Dependency.kt
@@ -39,3 +39,11 @@ data class FlatDependency(
   override val capabilities: Map<String, Capability>,
   override val file: File?
 ) : Dependency(coordinates, capabilities, file)
+
+@TypeLabel("included_build")
+@JsonClass(generateAdapter = false)
+data class IncludedBuildDependency(
+  override val coordinates: IncludedBuildCoordinates,
+  override val capabilities: Map<String, Capability>,
+  override val file: File?
+) : Dependency(coordinates, capabilities, file)

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
@@ -195,6 +195,7 @@ abstract class SynthesizeDependenciesTask @Inject constructor(
         is ProjectCoordinates -> ProjectDependency(coordinates, capabilities, file)
         is ModuleCoordinates -> ModuleDependency(coordinates, capabilities, file)
         is FlatCoordinates -> FlatDependency(coordinates, capabilities, file)
+        is IncludedBuildCoordinates -> IncludedBuildDependency(coordinates, capabilities, file)
       }
     }
   }

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/SettingsScript.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/SettingsScript.kt
@@ -4,7 +4,7 @@ class SettingsScript(
   val pluginManagement: PluginManagement = PluginManagement.DEFAULT,
   val rootProjectName: String = "the-project",
   val plugins: MutableList<Plugin> = mutableListOf(),
-  val subprojects: Set<String> = emptySet(),
+  var subprojects: Set<String> = emptySet(),
   var additions: String = ""
 ) {
 


### PR DESCRIPTION
Resolves crash associated with https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/565, but it doesn't handle any analysis across the composite boundary.