### PR TITLE
Allow common configuration through build logic and override on project level

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/GradleBuildSrcConventionMultiConfigSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/GradleBuildSrcConventionMultiConfigSpec.groovy
@@ -1,0 +1,25 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.GradleBuildSrcConventionMultiConfigProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class GradleBuildSrcConventionMultiConfigSpec extends AbstractJvmSpec {
+
+  def "allow common configuration through conventions and project level configuration (#gradleVersion)"() {
+    given:
+    def project = new GradleBuildSrcConventionMultiConfigProject()
+    gradleProject = project.gradleProject
+
+    when: 'build does not fail'
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then: 'and there is no advice'
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GradleBuildSrcConventionMultiConfigProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GradleBuildSrcConventionMultiConfigProject.groovy
@@ -1,0 +1,136 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.advice.ComprehensiveAdvice
+import com.autonomousapps.kit.*
+
+import static com.autonomousapps.AdviceHelper.actualBuildHealth
+import static com.autonomousapps.AdviceHelper.emptyCompAdviceFor
+import static com.autonomousapps.kit.Dependency.*
+
+final class GradleBuildSrcConventionMultiConfigProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  GradleBuildSrcConventionMultiConfigProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withBuildSrc { s ->
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.groovyGradlePlugin]
+        bs.repositories = [Repository.MAVEN_LOCAL, Repository.MAVEN_CENTRAL]
+        bs.dependencies = [dagp('implementation')]
+      }
+      s.sources = buildSrcSources()
+    }
+    builder.withRootProject { s ->
+      s.withBuildScript { bs ->
+        bs.plugins = [new Plugin('com.autonomousapps.dependency-analysis-root-convention')]
+      }
+    }
+    builder.withSubproject('proj-a') { s ->
+      s.sources = []
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin, new Plugin('com.autonomousapps.dependency-analysis-project-convention')]
+        bs.dependencies = [
+          new Dependency('implementation', 'gradleApi()'),
+          project('implementation', ':proj-b')
+        ]
+        bs.additions = """\
+          dependencyAnalysis {
+              issues {
+                // For some weird reason we still want to keep this dependency
+                onUnusedDependencies {
+                  exclude(
+                    // bla bla some reason to keep this dependency
+                    ':proj-b',
+                  )
+                }
+              }
+          }
+        """.stripIndent()
+      }
+    }
+    builder.withSubproject('proj-b') { s ->
+      s.sources = [JAVA_SOURCE]
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin, new Plugin('com.autonomousapps.dependency-analysis-project-convention')]
+        bs.dependencies = [commonsMath('api')]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private static final Source JAVA_SOURCE = new Source(
+    SourceType.JAVA, "Main", "com/example",
+    """\
+      package com.example;
+      
+      public class Main {
+        public static void main(String... args) {
+        }
+      }
+     """.stripIndent()
+  )
+
+  private static final Source[] buildSrcSources() {
+    return [
+      new Source(
+        SourceType.GROOVY, "com.autonomousapps.dependency-analysis-root-convention", "",
+        """\
+          plugins {
+              id 'com.autonomousapps.dependency-analysis'
+          }
+  
+          dependencyAnalysis {
+              issues {
+                  all {
+                      onAny {
+                          severity('ignore')
+                      }
+                      onUnusedDependencies {
+                        exclude(
+                          // Common util dependencies are always applied, don't fail on these
+                          'org.apache.commons:commons-math3',
+                        )
+                      }
+                  }
+              }
+          }
+       """.stripIndent()
+      ),
+      new Source(
+        SourceType.GROOVY, "com.autonomousapps.dependency-analysis-project-convention", "",
+        """\
+          project.getPluginManager().withPlugin("com.autonomousapps.dependency-analysis", { plugin ->
+              dependencyAnalysis {
+                  issues {
+                      onAny {
+                          severity('fail')
+                      }
+                  }
+              }
+          })
+       """.stripIndent()
+      )
+    ]
+  }
+
+
+  @SuppressWarnings('GroovyAssignabilityCheck')
+  List<ComprehensiveAdvice> actualBuildHealth() {
+    actualBuildHealth(gradleProject)
+  }
+
+  final List<ComprehensiveAdvice> expectedBuildHealth = [
+    emptyCompAdviceFor(':'),
+    emptyCompAdviceFor(':proj-a'),
+    emptyCompAdviceFor(':proj-b'),
+  ]
+}

--- a/src/main/kotlin/com/autonomousapps/extension/IssueHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/IssueHandler.kt
@@ -47,12 +47,8 @@ open class IssueHandler @Inject constructor(objects: ObjectFactory) {
   }
 
   fun project(path: String, action: Action<ProjectIssueHandler>) {
-    try {
-      projects.create(path) {
-        action.execute(this)
-      }
-    } catch (e: GradleException) {
-      throw wrapException(e)
+    projects.maybeCreate(path).apply {
+      action.execute(this)
     }
   }
 

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Plugin.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Plugin.kt
@@ -32,6 +32,7 @@ class Plugin @JvmOverloads constructor(
     @JvmStatic val applicationPlugin = Plugin("application")
     @JvmStatic val gradleEnterprisePlugin = Plugin("com.gradle.enterprise", "3.7")
     @JvmStatic val javaGradlePlugin = Plugin("java-gradle-plugin")
+    @JvmStatic val groovyGradlePlugin = Plugin("groovy-gradle-plugin")
     @JvmStatic val javaPlugin = Plugin("java")
     @JvmStatic val javaLibraryPlugin = Plugin("java-library")
     @JvmStatic val kaptPlugin = Plugin("org.jetbrains.kotlin.kapt")

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/SourceType.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/SourceType.kt
@@ -4,5 +4,5 @@ enum class SourceType(
   val value: String,
   val fileExtension: String
 ) {
-  JAVA("java", "java"), KOTLIN("kotlin", "kt")
+  JAVA("java", "java"), KOTLIN("kotlin", "kt"),GROOVY("groovy", "gradle")
 }


### PR DESCRIPTION
To share configuration across multiple sub projects we make use of the Gradle convention plugins. We have a few common dependency which we want to ignore for unused/configuration advices but sometimes this is also needed per-subproject level. We ran into the following on RC3:

```
Caused by: org.gradle.api.GradleException: You must configure this project either at the root or the project level, not both
Caused by: org.gradle.api.InvalidUserDataException: Cannot add a ProjectIssueHandler with name ':BLA:BLA' as a ProjectIssueHandler with that name already exists.
```