### PR TITLE
Fix build cache issue with GraphViewTask.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/GraphViewCacheSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/GraphViewCacheSpec.groovy
@@ -1,0 +1,31 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.GraphViewCacheProject
+import org.gradle.util.GradleVersion
+
+import static com.autonomousapps.kit.truth.BuildTaskSubject.buildTasks
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertAbout
+
+final class GraphViewCacheSpec extends AbstractJvmSpec {
+
+  def "graphViewTask is sensitive to changing dependencies"() {
+    given:
+    def project = new GraphViewCacheProject()
+    gradleProject = project.gradleProject
+    def task = ':proj:graphViewMain'
+    def gradleVersion = GradleVersion.current()
+
+    when: 'First build'
+    def result = build(gradleVersion, gradleProject.rootDir, task, '--build-cache', '-Dv=0.3.0-alpha27')
+
+    then: 'Task executed'
+    assertAbout(buildTasks()).that(result.task(task)).succeeded()
+
+    when: 'Second build'
+    result = build(gradleVersion, gradleProject.rootDir, 'clean', task, '--build-cache', '-Dv=0.3.0-alpha28')
+
+    then: 'Task executed (not FROM_CACHE)'
+    assertAbout(buildTasks()).that(result.task(task)).succeeded()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GraphViewCacheProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GraphViewCacheProject.groovy
@@ -1,0 +1,46 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+
+final class GraphViewCacheProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  GraphViewCacheProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('proj') { s ->
+      s.sources = [SOURCE]
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.kotlinPluginNoVersion]
+        bs.additions = """
+          dependencies {
+            implementation providers.systemProperty('v').map { v ->
+              "com.freeletics.mad:state-machine-jvm:\$v"
+            }
+          }
+        """.stripIndent()
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private static final Source SOURCE = new Source(
+    SourceType.KOTLIN, 'Main', 'com/example',
+    """\
+      package com.example
+            
+      class Main {}
+     """.stripIndent()
+  )
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
@@ -3,7 +3,11 @@ package com.autonomousapps.tasks
 import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.artifactsFor
 import com.autonomousapps.internal.isJavaPlatform
-import com.autonomousapps.internal.utils.*
+import com.autonomousapps.internal.utils.getAndDelete
+import com.autonomousapps.internal.utils.mapNotNullToSet
+import com.autonomousapps.internal.utils.rootCoordinates
+import com.autonomousapps.internal.utils.toCoordinates
+import com.autonomousapps.internal.utils.toJson
 import com.autonomousapps.model.Coordinates
 import com.autonomousapps.model.DependencyGraphView
 import com.autonomousapps.model.ProjectCoordinates
@@ -18,7 +22,14 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.support.appendReproducibleNewLine
 
 @CacheableTask
@@ -38,7 +49,8 @@ abstract class GraphViewTask : DefaultTask() {
   @get:Internal
   abstract val jarAttr: Property<String>
 
-  @Classpath
+  @PathSensitive(PathSensitivity.NAME_ONLY)
+  @InputFiles
   fun getCompileClasspath(): FileCollection = compileClasspath
     .artifactsFor(jarAttr.get())
     .artifactFiles


### PR DESCRIPTION
Don't use @Classpath, use @InputFiles.

Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/612