### PR TITLE
onAny should also control onRedundantPlugins behavior.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AnnotationProcessorSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AnnotationProcessorSpec.groovy
@@ -71,7 +71,7 @@ final class AnnotationProcessorSpec extends AbstractAndroidSpec {
     gradleProject = project.gradleProject
 
     when:
-    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth', '-Pdependency.analysis.print.build.health=true')
 
     then:
     def actualPluginAdvice = AdviceHelper.actualBuildHealth(gradleProject)

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/KaptProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/KaptProject.groovy
@@ -34,7 +34,7 @@ final class KaptProject extends AbstractProject {
       }
     }
     builder.withAndroidSubproject('lib') { a ->
-      a.sources = []
+      a.sources = sources
       a.withBuildScript { bs ->
         bs.plugins = [Plugin.androidLibPlugin, Plugin.kotlinAndroidPlugin, Plugin.kaptPlugin]
         bs.android = AndroidBlock.defaultAndroidLibBlock(true)
@@ -46,6 +46,17 @@ final class KaptProject extends AbstractProject {
     project.writer().write()
     return project
   }
+
+  private static final List<Source> sources = [
+    new Source(
+      SourceType.KOTLIN, 'Main', 'com/example',
+      """\
+        package com.example
+        
+        class Main
+       """.stripIndent()
+    )
+  ]
 
   private List<Dependency> dependencies = [
     Dependency.appcompat("implementation"),

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/RedundantJvmPluginsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/RedundantJvmPluginsSpec.groovy
@@ -1,5 +1,6 @@
 package com.autonomousapps.jvm
 
+import com.autonomousapps.advice.PluginAdvice
 import com.autonomousapps.jvm.projects.RedundantJvmPluginsProject
 
 import static com.autonomousapps.utils.Runner.buildAndFail
@@ -13,11 +14,13 @@ final class RedundantJvmPluginsSpec extends AbstractJvmSpec {
     gradleProject = project.gradleProject
 
     when:
-    buildAndFail(gradleVersion, gradleProject.rootDir, 'buildHealth')
+    buildAndFail(gradleVersion, gradleProject.rootDir, 'buildHealth', '-Pdependency.analysis.print.build.health=true')
 
     then:
-
-    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+    def buildHealth = project.actualBuildHealth()
+    def projAdvice = buildHealth.find { it.projectPath == ':proj' }
+    assertThat(buildHealth).containsExactlyElementsIn(project.expectedBuildHealth)
+    assertThat(projAdvice.pluginAdvice).contains(PluginAdvice.redundantKotlinJvm())
 
     where:
     gradleVersion << gradleVersions()

--- a/src/main/kotlin/com/autonomousapps/internal/advice/SeverityHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/SeverityHandler.kt
@@ -25,7 +25,7 @@ internal class SeverityHandler(
   }
 
   fun shouldFailPlugins(pluginAdvice: Set<PluginAdvice>): Boolean {
-    return redundantPluginsBehavior.isFail() && pluginAdvice.isNotEmpty()
+    return (redundantPluginsBehavior.isFail() || anyBehavior.isFail()) && pluginAdvice.isNotEmpty()
   }
 
   private fun Behavior.isFail(): Boolean = this is Fail

--- a/src/main/kotlin/com/autonomousapps/tasks/FilterAdviceTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FilterAdviceTask.kt
@@ -123,7 +123,11 @@ abstract class FilterAdviceTask @Inject constructor(
         .filterDataBinding()
         .filterViewBinding()
         .toSortedSet()
+
       val pluginAdvice: Set<PluginAdvice> = projectAdvice.pluginAdvice
+        .filterNotToOrderedSet {
+          anyBehavior is Ignore || anyBehavior.filter.contains(it.redundantPlugin)
+        }
         .filterNotToOrderedSet {
           redundantPluginsBehavior is Ignore || redundantPluginsBehavior.filter.contains(it.redundantPlugin)
         }


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/462.