### PR TITLE
Don't register tasks if they can't be used.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/DependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/DependenciesSpec.groovy
@@ -60,7 +60,7 @@ final class DependenciesSpec extends AbstractAndroidSpec {
 
     then:
     assertThat(AdviceHelper.actualBuildHealth(gradleProject))
-      .containsExactlyElementsIn(AdviceHelper.emptyBuildHealthFor(':app', ':'))
+      .containsExactlyElementsIn(AdviceHelper.emptyBuildHealthFor(':app'))
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/LintJarSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/LintJarSpec.groovy
@@ -20,7 +20,7 @@ final class LintJarSpec extends AbstractAndroidSpec {
 
     then:
     assertThat(AdviceHelper.actualBuildHealth(gradleProject))
-      .containsExactlyElementsIn(AdviceHelper.emptyBuildHealthFor(':app', ':'))
+      .containsExactlyElementsIn(AdviceHelper.emptyBuildHealthFor(':app'))
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()
@@ -38,7 +38,6 @@ final class LintJarSpec extends AbstractAndroidSpec {
     assertThat(AdviceHelper.actualBuildHealth(gradleProject))
       .containsExactlyElementsIn([
         TimberProject.removeTimberAdvice(),
-        AdviceHelper.emptyCompAdviceFor(':')
       ])
 
     where:

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidKotlinInlineProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidKotlinInlineProject.groovy
@@ -68,7 +68,6 @@ final class AndroidKotlinInlineProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':lib'),
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidMenuProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidMenuProject.groovy
@@ -78,5 +78,5 @@ final class AndroidMenuProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth =
-    AdviceHelper.emptyBuildHealthFor(':', ':consumer', ':producer')
+    AdviceHelper.emptyBuildHealthFor(':consumer', ':producer')
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestDependenciesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidTestDependenciesProject.groovy
@@ -175,7 +175,6 @@ abstract class AndroidTestDependenciesProject extends AbstractProject {
     ]
 
     final List<ComprehensiveAdvice> expectedBuildHealth = [
-      emptyCompAdviceFor(':'),
       compAdviceForDependencies(':proj', expectedAdvice)
     ]
   }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidThreeTenProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AndroidThreeTenProject.groovy
@@ -111,12 +111,10 @@ final class AndroidThreeTenProject extends AbstractProject {
   ] as Set<Advice>
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     compAdviceForDependencies(':app', appAdvice),
   ]
 
   final List<ComprehensiveAdvice> expectedBundleBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':app'),
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/ArbitraryFileProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/ArbitraryFileProject.groovy
@@ -76,7 +76,6 @@ final class ArbitraryFileProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    new ComprehensiveAdvice(":", [] as Set, [] as Set, false),
     new ComprehensiveAdvice(":app", [] as Set, [] as Set, false),
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AttrResProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AttrResProject.groovy
@@ -87,5 +87,5 @@ final class AttrResProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth =
-    AdviceHelper.emptyBuildHealthFor(':', ':consumer', ':producer')
+    AdviceHelper.emptyBuildHealthFor(':consumer', ':producer')
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AttrResWithNullProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AttrResWithNullProject.groovy
@@ -95,5 +95,5 @@ final class AttrResWithNullProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth =
-    AdviceHelper.emptyBuildHealthFor(':', ':consumer', ':producer')
+    AdviceHelper.emptyBuildHealthFor(':consumer', ':producer')
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/DataBindingUsagesExclusionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/DataBindingUsagesExclusionsProject.groovy
@@ -117,19 +117,18 @@ final class DataBindingUsagesExclusionsProject extends AbstractProject {
   ]
 
   private List<Dependency> libDependencies = [
-    Dependency.kotlinStdLib("api")
+    Dependency.kotlinStdLib('api')
   ]
 
   private final List<ComprehensiveAdvice> expectedBuildHealthWithExclusions = [
-    AdviceHelper.emptyCompAdviceFor(':'),
     AdviceHelper.compAdviceForDependencies(':app', [
-      Advice.ofRemove(AdviceHelper.dependency(":lib", null, "implementation"))
+      Advice.ofRemove(AdviceHelper.dependency(':lib', null, 'implementation'))
     ] as Set<Advice>),
     AdviceHelper.emptyCompAdviceFor(':lib'),
   ]
 
   private final List<ComprehensiveAdvice> expectedBuildHealthWithoutExclusions =
-    AdviceHelper.emptyBuildHealthFor(':', ':app', ':lib')
+    AdviceHelper.emptyBuildHealthFor(':app', ':lib')
 
   final List<ComprehensiveAdvice> expectedBuildHealth = excludeDataBinderMapper
     ? expectedBuildHealthWithExclusions

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/DataBindingWithExpressionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/DataBindingWithExpressionsProject.groovy
@@ -76,5 +76,5 @@ final class DataBindingWithExpressionsProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth =
-    AdviceHelper.emptyBuildHealthFor(':', ':app')
+    AdviceHelper.emptyBuildHealthFor(':app')
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/DoubleDeclarationsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/DoubleDeclarationsProject.groovy
@@ -72,7 +72,6 @@ final class DoubleDeclarationsProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':lib'),
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/NoOpProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/NoOpProject.groovy
@@ -63,6 +63,6 @@ final class NoOpProject extends AbstractProject {
 
   @SuppressWarnings('GrMethodMayBeStatic')
   List<ComprehensiveAdvice> expectedBuildHealth() {
-    return AdviceHelper.emptyBuildHealthFor(':', ':app')
+    return AdviceHelper.emptyBuildHealthFor(':app')
   }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/ServiceLoaderProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/ServiceLoaderProject.groovy
@@ -132,7 +132,6 @@ final class ServiceLoaderProject extends AbstractProject {
   ] as Set<Advice>
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     compAdviceForDependencies(':app', appAdvice)
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/TestDependenciesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/TestDependenciesProject.groovy
@@ -140,7 +140,6 @@ final class TestDependenciesProject extends AbstractProject {
 
   List<ComprehensiveAdvice> expectedBuildHealth() {
     [
-      emptyCompAdviceFor(':'),
       appAdvice(),
       libAdvice()
     ]

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/TestSourceProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/TestSourceProject.groovy
@@ -198,11 +198,7 @@ class TestSourceProject extends AbstractProject {
 
   @SuppressWarnings('GrMethodMayBeStatic')
   List<ComprehensiveAdvice> expectedBuildHealth() {
-    return [emptyRoot(), app(), libAndroid(), libJava(), libKt()]
-  }
-
-  private static ComprehensiveAdvice emptyRoot() {
-    return new ComprehensiveAdvice(':', [] as Set<Advice>, [] as Set<PluginAdvice>, false)
+    return [app(), libAndroid(), libJava(), libKt()]
   }
 
   private static ComprehensiveAdvice app() {

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/VariantProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/VariantProject.groovy
@@ -187,7 +187,6 @@ final class VariantProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    AdviceHelper.emptyCompAdviceFor(':'),
     getAppAdvice()
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiAnnotationsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiAnnotationsProject.groovy
@@ -229,7 +229,7 @@ final class AbiAnnotationsProject extends AbstractProject {
   }
 
   private final expectedBuildHealthForRuntimeRetention = emptyBuildHealthFor(
-    ':proj', ':annos', ':property', ':'
+    ':proj', ':annos', ':property'
   )
 
   private final Set<Advice> toCompileOnly = [Advice.ofChange(
@@ -238,7 +238,6 @@ final class AbiAnnotationsProject extends AbstractProject {
   )] as Set<Advice>
 
   private final List<ComprehensiveAdvice> expectedBuildHealthForSourceRetention = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':annos'),
     compAdviceForDependencies(':proj', toCompileOnly),
     emptyCompAdviceFor(':property'),

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiExceptionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiExceptionsProject.groovy
@@ -81,6 +81,6 @@ final class AbiExceptionsProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = emptyBuildHealthFor(
-    ':proj', ':exceptions', ':'
+    ':proj', ':exceptions'
   )
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiExclusionsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiExclusionsProject.groovy
@@ -93,7 +93,6 @@ final class AbiExclusionsProject extends AbstractProject {
   ] as Set<Advice>
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     compAdviceForDependencies(':proj', projAdvice)
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiGenericsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiGenericsProject.groovy
@@ -118,6 +118,6 @@ class AbiGenericsProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = emptyBuildHealthFor(
-    ':proj', ':genericsFoo', ':genericsBar', ':'
+    ':proj', ':genericsFoo', ':genericsBar'
   )
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiInterfaceProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiInterfaceProject.groovy
@@ -88,7 +88,6 @@ class AbiInterfaceProject extends AbstractProject {
   ] as Set<Advice>
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     compAdviceForDependencies(':impl', implAdvice),
     emptyCompAdviceFor(':abstract'),
   ]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiProject.groovy
@@ -63,7 +63,6 @@ final class AbiProject extends AbstractProject {
   ] as Set<Advice>
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     compAdviceForDependencies(':proj', projAdvice)
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ApplicationProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ApplicationProject.groovy
@@ -120,7 +120,6 @@ final class ApplicationProject extends AbstractProject {
   ] as Set<Advice>
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     compAdviceForDependencies(':proj', projAdvice)
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/CompileOnlyJarProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/CompileOnlyJarProject.groovy
@@ -82,7 +82,6 @@ final class CompileOnlyJarProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':proj'),
     emptyCompAdviceFor(':external'),
   ]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ConstantsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ConstantsProject.groovy
@@ -77,7 +77,6 @@ final class ConstantsProject extends AbstractProject {
   ] as Set<Advice>
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':lib'),
     compAdviceForDependencies(':proj', projAdvice)
   ]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/DefaultVariantProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/DefaultVariantProject.groovy
@@ -77,7 +77,6 @@ final class DefaultVariantProject {
     }
 
     final List<ComprehensiveAdvice> expectedBuildHealth = [
-      emptyCompAdviceFor(':'),
       emptyCompAdviceFor(':lib'),
     ]
   }
@@ -143,7 +142,6 @@ final class DefaultVariantProject {
     }
 
     final List<ComprehensiveAdvice> expectedBuildHealth = [
-      emptyCompAdviceFor(':'),
       emptyCompAdviceFor(':lib'),
     ]
   }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/EnumOnlyLibProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/EnumOnlyLibProject.groovy
@@ -72,7 +72,6 @@ final class EnumOnlyLibProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':proj'),
     emptyCompAdviceFor(':lib'),
   ]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GenericsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GenericsProject.groovy
@@ -87,7 +87,6 @@ final class GenericsProject extends AbstractProject {
   ] as Set<Advice>
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     compAdviceForDependencies(':proj-1', proj1Advice),
     emptyCompAdviceFor(':proj-2'),
   ]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GradleApiProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GradleApiProject.groovy
@@ -40,7 +40,6 @@ final class GradleApiProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':proj'),
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GradleBuildSrcConventionMultiConfigProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GradleBuildSrcConventionMultiConfigProject.groovy
@@ -129,7 +129,6 @@ final class GradleBuildSrcConventionMultiConfigProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':proj-a'),
     emptyCompAdviceFor(':proj-b'),
   ]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GradlePluginProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GradlePluginProject.groovy
@@ -55,7 +55,6 @@ final class GradlePluginProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':plugin'),
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GraphViewCacheProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/GraphViewCacheProject.groovy
@@ -3,6 +3,7 @@ package com.autonomousapps.jvm.projects
 import com.autonomousapps.AbstractProject
 import com.autonomousapps.kit.GradleProject
 import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.SettingsScript
 import com.autonomousapps.kit.Source
 import com.autonomousapps.kit.SourceType
 
@@ -16,11 +17,23 @@ final class GraphViewCacheProject extends AbstractProject {
 
   private GradleProject build() {
     def builder = newGradleProjectBuilder()
+    builder.withRootProject { s ->
+      s.settingsScript = new SettingsScript().tap {
+        // Since this test exercises the build cache, we can't rely on the default location
+        additions = """
+          buildCache {
+            local {
+              directory = new File(rootDir, 'build-cache')
+            }
+          }        
+        """.stripIndent()
+      }
+    }
     builder.withSubproject('proj') { s ->
       s.sources = [SOURCE]
       s.withBuildScript { bs ->
         bs.plugins = [Plugin.kotlinPluginNoVersion]
-        bs.additions = """
+        bs.additions = """\
           dependencies {
             implementation providers.systemProperty('v').map { v ->
               "com.freeletics.mad:state-machine-jvm:\$v"

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/InlinePackageCollisionProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/InlinePackageCollisionProject.groovy
@@ -96,6 +96,6 @@ final class InlinePackageCollisionProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = emptyBuildHealthFor(
-    ':', ':lib-consumer-1', ':lib-consumer-2', ':lib-producer'
+    ':lib-consumer-1', ':lib-consumer-2', ':lib-producer'
   )
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IntegrationTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IntegrationTestProject.groovy
@@ -130,7 +130,6 @@ final class IntegrationTestProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':lib'),
     emptyCompAdviceFor(':core'),
     new ComprehensiveAdvice(':proj', [

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/KotlinStdlibProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/KotlinStdlibProject.groovy
@@ -60,7 +60,6 @@ final class KotlinStdlibProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBundleBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':proj'),
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/LombokProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/LombokProject.groovy
@@ -77,7 +77,6 @@ final class LombokProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':proj'),
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/MinimalAdviceProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/MinimalAdviceProject.groovy
@@ -114,7 +114,6 @@ abstract class MinimalAdviceProject extends AbstractProject {
     }
 
     final List<ComprehensiveAdvice> expectedAdvice = [
-      emptyCompAdviceFor(':'),
       compAdviceForDependencies(':app', [] as Set<Advice>),
       compAdviceForDependencies(':lib', [
         Advice.ofRemove(
@@ -200,7 +199,6 @@ abstract class MinimalAdviceProject extends AbstractProject {
     }
 
     final List<ComprehensiveAdvice> expectedAdvice = [
-      emptyCompAdviceFor(':'),
       compAdviceForDependencies(':app', [
         Advice.ofAdd(transitiveDependency(
           dependency: 'com.squareup.moshi:moshi', resolvedVersion: '1.11.0'
@@ -280,7 +278,6 @@ abstract class MinimalAdviceProject extends AbstractProject {
     }
 
     final List<ComprehensiveAdvice> expectedAdvice = [
-      emptyCompAdviceFor(':'),
       compAdviceForDependencies(':app', [
         Advice.ofAdd(transitiveDependency(
           dependency: 'com.squareup.moshi:moshi', resolvedVersion: '1.11.0'

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/MinimalFailProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/MinimalFailProject.groovy
@@ -111,7 +111,6 @@ final class MinimalFailProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedAdvice = [
-    emptyCompAdviceFor(':'),
     compAdviceForDependencies(':app', [] as Set<Advice>),
     compAdviceForDependencies(':lib', [] as Set<Advice>)
   ]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/RedundantJvmPluginsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/RedundantJvmPluginsProject.groovy
@@ -76,7 +76,6 @@ final class RedundantJvmPluginsProject extends AbstractProject {
       [Advice.ofRemove(dependency(kotlinStdLib('api')))] as Set<Advice>,
       [PluginAdvice.redundantKotlinJvm()] as Set<PluginAdvice>,
       true
-    ),
-    new ComprehensiveAdvice(':', [] as Set<Advice>, [] as Set<PluginAdvice>, false)
+    )
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/RippleProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/RippleProject.groovy
@@ -125,7 +125,6 @@ final class RippleProject extends AbstractProject {
   ]
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    AdviceHelper.emptyCompAdviceFor(':'),
     AdviceHelper.emptyCompAdviceFor(':c'),
     AdviceHelper.emptyCompAdviceFor(':d'),
     new ComprehensiveAdvice(

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SecurityProviderProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SecurityProviderProject.groovy
@@ -62,7 +62,6 @@ final class SecurityProviderProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':proj'),
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SpringBootProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SpringBootProject.groovy
@@ -57,7 +57,6 @@ final class SpringBootProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':proj'),
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestBundleProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestBundleProject.groovy
@@ -88,7 +88,6 @@ final class TestBundleProject extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':proj'),
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestDependenciesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestDependenciesProject.groovy
@@ -91,12 +91,10 @@ final class TestDependenciesProject extends AbstractProject {
   ] as Set<Advice>
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     compAdviceForDependencies(':proj', projAdvice)
   ]
 
   final List<ComprehensiveAdvice> expectedBuildHealthWithoutTest = [
-    emptyCompAdviceFor(':'),
     compAdviceForDependencies(':proj', projAdviceWithoutTest)
   ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestDependenciesProject2.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestDependenciesProject2.groovy
@@ -103,7 +103,6 @@ final class TestDependenciesProject2 extends AbstractProject {
   }
 
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':'),
     emptyCompAdviceFor(':a'),
     emptyCompAdviceFor(':b'),
   ]

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/SettingsScript.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/SettingsScript.kt
@@ -1,6 +1,6 @@
 package com.autonomousapps.kit
 
-class SettingsScript(
+class SettingsScript @JvmOverloads constructor(
   val pluginManagement: PluginManagement = PluginManagement.DEFAULT,
   val rootProjectName: String = "the-project",
   val plugins: MutableList<Plugin> = mutableListOf(),


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/463.