### PR TITLE
Give advice to change to runtimeOnly where appropriate

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/LintJarSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/LintJarSpec.groovy
@@ -20,7 +20,7 @@ final class LintJarSpec extends AbstractAndroidSpec {
 
     then:
     assertThat(AdviceHelper.actualBuildHealth(gradleProject))
-      .containsExactlyElementsIn(AdviceHelper.emptyBuildHealthFor(':app'))
+      .containsExactlyElementsIn(project.expectedBuildHealth)
 
     where:
     [gradleVersion, agpVersion] << gradleAgpMatrix()

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/LintJarProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/LintJarProject.groovy
@@ -1,8 +1,12 @@
 package com.autonomousapps.android.projects
 
 import com.autonomousapps.AbstractProject
+import com.autonomousapps.advice.Advice
+import com.autonomousapps.advice.ComprehensiveAdvice
 import com.autonomousapps.kit.*
 
+import static com.autonomousapps.AdviceHelper.compAdviceForDependencies
+import static com.autonomousapps.AdviceHelper.dependency
 import static com.autonomousapps.kit.Dependency.appcompat
 import static com.autonomousapps.kit.Dependency.rxlint
 
@@ -10,6 +14,8 @@ final class LintJarProject extends AbstractProject {
 
   final GradleProject gradleProject
   private final String agpVersion
+
+  private final rxlint = rxlint('implementation')
 
   LintJarProject(String agpVersion) {
     this.agpVersion = agpVersion
@@ -30,7 +36,7 @@ final class LintJarProject extends AbstractProject {
         bs.plugins = [Plugin.androidAppPlugin]
         bs.dependencies = [
           appcompat('implementation'),
-          rxlint('implementation')
+          rxlint
         ]
       }
     }
@@ -39,4 +45,12 @@ final class LintJarProject extends AbstractProject {
     project.writer().write()
     return project
   }
+
+  private final appAdvice = [
+    Advice.ofChange(dependency(rxlint), 'runtimeOnly'),
+  ] as Set<Advice>
+
+  final List<ComprehensiveAdvice> expectedBuildHealth = [
+    compAdviceForDependencies(':app', appAdvice)
+  ]
 }

--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/ServiceLoaderProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/ServiceLoaderProject.groovy
@@ -128,6 +128,7 @@ final class ServiceLoaderProject extends AbstractProject {
   }
 
   private final appAdvice = [
+    Advice.ofChange(dependency(kotlinxCoroutinesAndroid), 'runtimeOnly'),
     Advice.ofAdd(transitiveDependency(dependency(kotlinxCoroutinesCore), []), 'implementation')
   ] as Set<Advice>
 

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SecurityProviderProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/SecurityProviderProject.groovy
@@ -1,11 +1,13 @@
 package com.autonomousapps.jvm.projects
 
 import com.autonomousapps.AbstractProject
+import com.autonomousapps.advice.Advice
 import com.autonomousapps.advice.ComprehensiveAdvice
 import com.autonomousapps.kit.*
 
 import static com.autonomousapps.AdviceHelper.actualBuildHealth
-import static com.autonomousapps.AdviceHelper.emptyCompAdviceFor
+import static com.autonomousapps.AdviceHelper.compAdviceForDependencies
+import static com.autonomousapps.AdviceHelper.dependency
 import static com.autonomousapps.kit.Dependency.conscryptUber
 import static com.autonomousapps.kit.Dependency.okHttp
 
@@ -34,8 +36,10 @@ final class SecurityProviderProject extends AbstractProject {
 
   private List<Plugin> plugins = [Plugin.javaLibraryPlugin]
 
+  private final conscryptUber = conscryptUber("implementation")
+
   private List<Dependency> dependencies = [
-    conscryptUber("implementation"),
+    conscryptUber,
     okHttp("api")
   ]
 
@@ -61,7 +65,11 @@ final class SecurityProviderProject extends AbstractProject {
     actualBuildHealth(gradleProject)
   }
 
+  private final appAdvice = [
+    Advice.ofChange(dependency(conscryptUber), 'runtimeOnly'),
+  ] as Set<Advice>
+
   final List<ComprehensiveAdvice> expectedBuildHealth = [
-    emptyCompAdviceFor(':proj'),
+    compAdviceForDependencies(':proj', appAdvice)
   ]
 }

--- a/src/functionalTest/kotlin/com/autonomousapps/fixtures/LeakCanaryProject.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/fixtures/LeakCanaryProject.kt
@@ -1,6 +1,7 @@
 package com.autonomousapps.fixtures
 
 import com.autonomousapps.advice.Advice
+import com.autonomousapps.advice.Dependency
 import com.autonomousapps.kit.Plugin
 
 class LeakCanaryProject(private val agpVersion: String) {
@@ -28,5 +29,9 @@ class LeakCanaryProject(private val agpVersion: String) {
     )
   )
 
-  val expectedAdviceForApp: Set<Advice> = setOf()
+  val expectedAdviceForApp: Set<Advice> = setOf(
+    Advice.ofChange(
+      Dependency("com.squareup.leakcanary:leakcanary-android", "2.2", "debugImplementation"), "debugRuntimeOnly"
+    )
+  )
 }

--- a/src/main/kotlin/com/autonomousapps/internal/advice/ProjectHealthConsoleReportBuilder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/ProjectHealthConsoleReportBuilder.kt
@@ -19,6 +19,7 @@ internal class ProjectHealthConsoleReportBuilder(
     val removeAdvice = mutableSetOf<Advice>()
     val addAdvice = mutableSetOf<Advice>()
     val changeAdvice = mutableSetOf<Advice>()
+    val runtimeOnlyAdvice = mutableSetOf<Advice>()
     val compileOnlyAdvice = mutableSetOf<Advice>()
     val processorAdvice = mutableSetOf<Advice>()
 
@@ -26,6 +27,7 @@ internal class ProjectHealthConsoleReportBuilder(
       if (advice.isRemove()) removeAdvice += advice
       if (advice.isAdd()) addAdvice += advice
       if (advice.isChange()) changeAdvice += advice
+      if (advice.isRuntimeOnly()) runtimeOnlyAdvice += advice
       if (advice.isCompileOnly()) compileOnlyAdvice += advice
       if (advice.isProcessor()) processorAdvice += advice
     }
@@ -66,6 +68,20 @@ internal class ProjectHealthConsoleReportBuilder(
 
         appendReproducibleNewLine("Existing dependencies which should be modified to be as indicated:")
         val toPrint = changeAdvice.mapToOrderedSet {
+          line(it.toConfiguration!!, printableIdentifier(it.coordinates), " (was ${it.fromConfiguration})")
+        }.joinToString(separator = "\n")
+        append(toPrint)
+      }
+
+      if (runtimeOnlyAdvice.isNotEmpty()) {
+        if (shouldPrintNewLine) {
+          appendReproducibleNewLine()
+          appendReproducibleNewLine()
+        }
+        shouldPrintNewLine = true
+
+        appendReproducibleNewLine("Dependencies which should be removed or changed to runtime-only:")
+        val toPrint = runtimeOnlyAdvice.mapToOrderedSet {
           line(it.toConfiguration!!, printableIdentifier(it.coordinates), " (was ${it.fromConfiguration})")
         }.joinToString(separator = "\n")
         append(toPrint)

--- a/src/main/kotlin/com/autonomousapps/model/Advice.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Advice.kt
@@ -83,7 +83,7 @@ data class Advice(
    * An advice is "change-advice" if it is declared and used (but is on the wrong configuration),
    * AND is not `compileOnly`.
    */
-  fun isChange() = fromConfiguration != null && toConfiguration != null && !isCompileOnly()
+  fun isChange() = fromConfiguration != null && toConfiguration != null && !isCompileOnly() && !isRuntimeOnly()
 
   /**
    * An advice is "processors-advice" if it is declared on a k/apt or annotationProcessor

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -128,8 +128,6 @@ internal class StandardTransform(
           && decl.bucket != Bucket.COMPILE_ONLY
           // Don't change a declaration on runtimeOnly
           && decl.bucket != Bucket.RUNTIME_ONLY
-          // Don't change any declaration to runtimeOnly
-          && usage.bucket != Bucket.RUNTIME_ONLY
         ) {
           advice += Advice.ofChange(
             coordinates = coordinates,


### PR DESCRIPTION
If an advice was computed to change a declaration from 'implementation'/'api' to 'runtimeOnly', this is indeed correct
information. The dependency is *not* required at compile time. But it *might* be required at runtime.

It is not possible for this plugin to make a clear statement about if it is actually needed at runtime. When getting such an advice, the user might also remove the dependency completely. The 'reason' feature will give more insight on why the dependency *might* be needed at runtime. The following cases are covered:

- Contains Service Loader declarations
- Contains Security Provider declarations
- Contains Content Provider or Service declarations (Android)
- Contains Android linters (Lint-Registry entry)

Fixes #387