### PR TITLE
Ignore dependencies for and to unsupported sourceSets/variants

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -1,15 +1,50 @@
 package com.autonomousapps.jvm
 
+import com.autonomousapps.jvm.projects.FeatureVariantTestProject
 import com.autonomousapps.jvm.projects.IntegrationTestProject
+import com.autonomousapps.jvm.projects.TestFixturesTestProject
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
 
 final class CustomSourceSetSpec extends AbstractJvmSpec {
 
+  // Not yet implemented: https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/451
   def "transitive dependency for main but declared on custom source set should not prevent advice (#gradleVersion)"() {
     given:
     def project = new IntegrationTestProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  // Not yet implemented: https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/451
+  def "dependencies for feature variant do not produce any advice (#gradleVersion)"() {
+    given:
+    def project = new FeatureVariantTestProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  // Not yet implemented: https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/298
+  def "dependencies for test fixtures do not produce any advice (#gradleVersion)"() {
+    given:
+    def project = new TestFixturesTestProject()
     gradleProject = project.gradleProject
 
     when:

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
@@ -1,0 +1,80 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.advice.Advice
+import com.autonomousapps.advice.ComprehensiveAdvice
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.Dependency.commonsCollections
+
+final class FeatureVariantTestProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  FeatureVariantTestProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('proj') { s ->
+      s.sources = sources
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.sourceSets = ['extraFeature',
+                         'java.registerFeature("extraFeature") { usingSourceSet(sourceSets.extraFeature) }']
+        bs.dependencies = [
+          commonsCollections('api'),
+          commonsCollections('extraFeatureApi')
+        ]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private sources = [
+    new Source(
+      SourceType.JAVA, "Example", "com/example",
+      """\
+        package com.example;
+        
+        import org.apache.commons.collections4.bag.HashBag;
+        
+        public class Example {
+          public HashBag<String> bag;
+        }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.JAVA, "ExtraFeature", "com/example/extra",
+      """\
+        package com.example.extra;
+        
+        import org.apache.commons.collections4.bag.HashBag;
+        
+        public class ExtraFeature {
+          private HashBag<String> internalBag;
+        }
+      """.stripIndent(),
+      "extraFeature"
+    )
+  ]
+
+  @SuppressWarnings('GroovyAssignabilityCheck')
+  List<ComprehensiveAdvice> actualBuildHealth() {
+    actualBuildHealth(gradleProject)
+  }
+
+  final List<ComprehensiveAdvice> expectedBuildHealth = [
+    // Not yet implemented: missing advice to move the dependency of 'extra' to extraFeatureImplementation
+    emptyCompAdviceFor(':proj')
+  ]
+
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IntegrationTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IntegrationTestProject.groovy
@@ -128,7 +128,7 @@ final class IntegrationTestProject extends AbstractProject {
     emptyProjectAdviceFor(':lib'),
     emptyProjectAdviceFor(':core'),
     new ProjectAdvice(':proj', [
-      Advice.ofChange(projectCoordinates(':core'), 'integrationTestImplementation', 'api')
+      Advice.ofAdd(projectCoordinates(':core'), 'api')
     ] as Set<Advice>,
       [] as Set<PluginAdvice>, false
     ),

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject.groovy
@@ -1,0 +1,78 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.advice.ComprehensiveAdvice
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+
+import static com.autonomousapps.AdviceHelper.actualBuildHealth
+import static com.autonomousapps.AdviceHelper.emptyCompAdviceFor
+import static com.autonomousapps.kit.Dependency.commonsCollections
+
+final class TestFixturesTestProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  TestFixturesTestProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('proj') { s ->
+      s.sources = sources
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin, Plugin.javaTestFixturesPlugin]
+        bs.dependencies = [
+          commonsCollections('api'),
+          commonsCollections('testFixturesApi')
+        ]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private sources = [
+    new Source(
+      SourceType.JAVA, "Example", "com/example",
+      """\
+        package com.example;
+        
+        import org.apache.commons.collections4.bag.HashBag;
+        
+        public class Example {
+          public HashBag<String> bag;
+        }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.JAVA, "ExampleFixture", "com/example/fixtures",
+      """\
+        package com.example.fixtures;
+        
+        import org.apache.commons.collections4.bag.HashBag;
+        
+        public class ExampleFixture {
+          private HashBag<String> internalBag;
+        }
+      """.stripIndent(),
+      "testFixtures"
+    )
+  ]
+
+  @SuppressWarnings('GroovyAssignabilityCheck')
+  List<ComprehensiveAdvice> actualBuildHealth() {
+    actualBuildHealth(gradleProject)
+  }
+
+  final List<ComprehensiveAdvice> expectedBuildHealth = [
+    // Not yet implemented: missing advice to move the dependency of 'testFixtures' to testFixturesImplementation
+    emptyCompAdviceFor(':proj')
+  ]
+
+}

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
@@ -16,14 +16,9 @@ import com.autonomousapps.internal.unsafeLazy
 internal data class Declaration(
   val identifier: String,
   val configurationName: String,
-  val attributes: Set<Attribute> = emptySet()
+  val doesNotPointAtMainVariant: Boolean = false
 ) {
 
   val bucket: Bucket by unsafeLazy { Bucket.of(configurationName) }
   fun variant(supportedSourceSets: Set<String>) = Variant.of(configurationName, supportedSourceSets)
-
-  internal enum class Attribute {
-    JAVA_PLATFORM,
-    TEST_FIXTURE,
-  }
 }

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
@@ -20,7 +20,7 @@ internal data class Declaration(
 ) {
 
   val bucket: Bucket by unsafeLazy { Bucket.of(configurationName) }
-  val variant: Variant by unsafeLazy { Variant.of(configurationName) }
+  fun variant(supportedSourceSets: Set<String>) = Variant.of(configurationName, supportedSourceSets)
 
   internal enum class Attribute {
     JAVA_PLATFORM,

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Variant.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Variant.kt
@@ -28,7 +28,8 @@ data class Variant(
     //val ANDROID_TEST = Variant(ANDROID_TEST_NAME, SourceSetKind.TEST)
 
     @JvmStatic
-    fun of(configurationName: String): Variant = Configurations.variantFrom(configurationName)
+    fun of(configurationName: String, supportedSourceSets: Set<String>): Variant? =
+      Configurations.variantFrom(configurationName, supportedSourceSets)
 
     fun String.toVariant(kind: SourceSetKind) = Variant(this, kind)
   }

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -11,6 +11,7 @@ import com.autonomousapps.internal.*
 import com.autonomousapps.internal.advice.DslKind
 import com.autonomousapps.internal.analyzer.*
 import com.autonomousapps.internal.android.AgpVersion
+import com.autonomousapps.internal.utils.flatMapToSet
 import com.autonomousapps.internal.utils.log
 import com.autonomousapps.internal.utils.toJson
 import com.autonomousapps.model.declaration.Configurations
@@ -692,25 +693,6 @@ internal class ProjectPlugin(private val project: Project) {
     }
   }
 
-  private fun Project.supportedSourceSetNames() = provider {
-    if (pluginManager.hasPlugin(ANDROID_APP_PLUGIN)) {
-      the<AppExtension>().applicationVariants.map {
-        it.sourceSets.map { sourceSet -> sourceSet.name } +
-          (it.unitTestVariant?.sourceSets?.map { sourceSet -> sourceSet.name } ?: emptySet())
-        // Not yet supported: + it.testVariant.sourceSets.map { sourceSet -> sourceSet.name }
-      }.flatten()
-    } else if (pluginManager.hasPlugin(ANDROID_LIBRARY_PLUGIN)) {
-      the<LibraryExtension>().libraryVariants.map {
-        it.sourceSets.map { sourceSet -> sourceSet.name } +
-          (it.unitTestVariant?.sourceSets?.map { sourceSet -> sourceSet.name } ?: emptySet())
-        // Not yet supported: + it.testVariant.sourceSets.map { sourceSet -> sourceSet.name }
-      }.flatten()
-    } else {
-      // JVM Plugins - at some point 'the<SourceSetContainer>().names' should be supported for JVM projects
-      setOf(SourceSet.MAIN_SOURCE_SET_NAME, SourceSet.TEST_SOURCE_SET_NAME)
-    }
-  }
-
   private fun Project.configureAggregationTasks() {
     if (aggregatorsRegistered.getAndSet(true)) return
 
@@ -791,6 +773,29 @@ internal class ProjectPlugin(private val project: Project) {
       consumerConfName = Configurations.CONF_ADVICE_ALL_CONSUMER,
       output = filterAdviceTask.flatMap { it.output }
     )
+  }
+
+  /**
+   * Returns the names of the 'source sets' that are currently supported by the plugin.
+   * Dependencies defined on configurations that do not belong to any of these source sets are ignored.
+   */
+  private fun Project.supportedSourceSetNames() = provider {
+    if (pluginManager.hasPlugin(ANDROID_APP_PLUGIN)) {
+      the<AppExtension>().applicationVariants.flatMapToSet {
+        it.sourceSets.map { sourceSet -> sourceSet.name } +
+          (it.unitTestVariant?.sourceSets?.map { sourceSet -> sourceSet.name } ?: emptySet())
+        // Not yet supported: + it.testVariant.sourceSets.map { sourceSet -> sourceSet.name }
+      }
+    } else if (pluginManager.hasPlugin(ANDROID_LIBRARY_PLUGIN)) {
+      the<LibraryExtension>().libraryVariants.flatMapToSet {
+        it.sourceSets.map { sourceSet -> sourceSet.name } +
+          (it.unitTestVariant?.sourceSets?.map { sourceSet -> sourceSet.name } ?: emptySet())
+        // Not yet supported: + it.testVariant.sourceSets.map { sourceSet -> sourceSet.name }
+      }
+    } else {
+      // JVM Plugins - at some point 'the<SourceSetContainer>().names' should be supported for JVM projects
+      setOf(SourceSet.MAIN_SOURCE_SET_NAME, SourceSet.TEST_SOURCE_SET_NAME)
+    }
   }
 
   /**

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
@@ -85,11 +85,6 @@ abstract class FindDeclarationsTask : DefaultTask() {
     ): Sequence<Configuration> {
       val seq = configurations.asSequence()
         .filter { it.isForRegularDependency() || it.isForAnnotationProcessor() }
-        .filterNot {
-          // this is not ideal, but it will solve some problems till we can support androidTest analysis.
-          // will match, e.g., "androidTestImplementation", "debugAndroidTestImplementation", and "kaptAndroidTest".
-          it.name.contains("androidTest", true)
-        }
 
       return if (shouldAnalyzeTests) seq
       else seq.filterNot { it.name.startsWith("test") }

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -17,6 +17,7 @@ import com.autonomousapps.model.intermediates.Usage
 internal class StandardTransform(
   private val coordinates: Coordinates,
   private val declarations: Set<Declaration>,
+  private val supportedSourceSets: Set<String>,
   private val isKaptApplied: Boolean = false
 ) : Usage.Transform {
 
@@ -30,8 +31,8 @@ internal class StandardTransform(
       { it.variant.kind == SourceSetKind.TEST }
     )
     val (mainDeclarations, testDeclarations) = declarations.mutPartitionOf(
-      { it.variant.kind == SourceSetKind.MAIN },
-      { it.variant.kind == SourceSetKind.TEST }
+      { it.variant(supportedSourceSets)?.kind == SourceSetKind.MAIN },
+      { it.variant(supportedSourceSets)?.kind == SourceSetKind.TEST }
     )
 
     /*
@@ -102,7 +103,7 @@ internal class StandardTransform(
     val usageIter = usages.iterator()
     while (usageIter.hasNext()) {
       val usage = usageIter.next()
-      val decl = declarations.find { it.variant == usage.variant }
+      val decl = declarations.find { it.variant(supportedSourceSets) == usage.variant }
 
       // We have a declaration on the same variant as the usage. Remove or change it, if necessary.
       if (decl != null) {

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -252,7 +252,7 @@ private fun Set<Declaration>.forCoordinates(coordinates: Coordinates): Set<Decla
   return asSequence()
     .filter { it.identifier == coordinates.identifier }
     // For now, we ignore any special dependencies like test fixtures or platforms
-    .filter { it.attributes.isEmpty() }
+    .filter { !it.doesNotPointAtMainVariant }
     .toSet()
 }
 

--- a/src/test/groovy/com/autonomousapps/model/declaration/VariantSpec.groovy
+++ b/src/test/groovy/com/autonomousapps/model/declaration/VariantSpec.groovy
@@ -6,25 +6,28 @@ class VariantSpec extends Specification {
 
   def "can compute variant from configuration (#configurationName => #variant)"() {
     expect:
-    Variant.of(configurationName) == variant
+    Variant.of(configurationName, [
+      'main', 'release', 'debug', 'test', 'testDebug', 'testRelease',
+      'flavor', 'flavorRelease', 'flavorDebug', 'testFlavorRelease', 'testFlavorDebug'
+    ] as Set<String>) == variant
 
     where:
     configurationName                  | variant
     'implementation'                   | new Variant('main', SourceSetKind.MAIN)
     'debugImplementation'              | new Variant('debug', SourceSetKind.MAIN)
-    'releaseFlavorImplementation'      | new Variant('releaseFlavor', SourceSetKind.MAIN)
+    'flavorReleaseImplementation'      | new Variant('flavorRelease', SourceSetKind.MAIN)
 
     'api'                              | new Variant('main', SourceSetKind.MAIN)
     'releaseApi'                       | new Variant('release', SourceSetKind.MAIN)
-    'debugFlavorApi'                   | new Variant('debugFlavor', SourceSetKind.MAIN)
+    'flavorDebugApi'                   | new Variant('flavorDebug', SourceSetKind.MAIN)
 
     'compileOnly'                      | new Variant('main', SourceSetKind.MAIN)
     'debugCompileOnly'                 | new Variant('debug', SourceSetKind.MAIN)
-    'releaseFlavorCompileOnly'         | new Variant('releaseFlavor', SourceSetKind.MAIN)
+    'flavorReleaseCompileOnly'         | new Variant('flavorRelease', SourceSetKind.MAIN)
 
     'runtimeOnly'                      | new Variant('main', SourceSetKind.MAIN)
     'releaseRuntimeOnly'               | new Variant('release', SourceSetKind.MAIN)
-    'debugFlavorRuntimeOnly'           | new Variant('debugFlavor', SourceSetKind.MAIN)
+    'flavorDebugRuntimeOnly'           | new Variant('flavorDebug', SourceSetKind.MAIN)
 
     'annotationProcessor'              | new Variant('main', SourceSetKind.MAIN)
     'debugAnnotationProcessor'         | new Variant('debug', SourceSetKind.MAIN)
@@ -42,7 +45,10 @@ class VariantSpec extends Specification {
 
   def "throws when no matching variant found (#configurationName)"() {
     when:
-    Variant.of(configurationName)
+    Variant.of(configurationName, [
+      'main', 'release', 'debug', 'test', 'testDebug', 'testRelease',
+      'flavor', 'flavorRelease', 'flavorDebug', 'testFlavorRelease', 'testFlavorDebug'
+    ] as Set<String>)
 
     then:
     thrown(IllegalArgumentException)

--- a/src/test/kotlin/com/autonomousapps/internal/configuration/ConfigurationsTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/configuration/ConfigurationsTest.kt
@@ -43,7 +43,11 @@ internal class ConfigurationsTest {
     ]
   )
   fun `can get variant from main configuration name`(configuration: String, variant: String) {
-    assertThat(Configurations.variantFrom(configuration)).isEqualTo(Variant(variant, SourceSetKind.MAIN))
+    assertThat(Configurations
+      .variantFrom(configuration, setOf(
+        "main", "release", "debug", "test", "testDebug", "testRelease",
+        "releaseFlavor", "debugFlavor", "testReleaseFlavor", "testDebugFlavor")))
+      .isEqualTo(Variant(variant, SourceSetKind.MAIN))
   }
 
   @ParameterizedTest(name = "{0} => {1}")
@@ -52,7 +56,7 @@ internal class ConfigurationsTest {
       "testDebugApi, debug",
       "testReleaseImplementation, release",
       "kaptTestDebug, debug",
-      "testReleaseFlavorAnnotationProcessor, releaseFlavor",
+      "testFlavorReleaseAnnotationProcessor, flavorRelease",
       "testImplementation, main",
       "testApi, main",
       "testAnnotationProcessor, main",
@@ -60,7 +64,11 @@ internal class ConfigurationsTest {
     ]
   )
   fun `can get variant from test configuration name`(configuration: String, variant: String) {
-    assertThat(Configurations.variantFrom(configuration)).isEqualTo(Variant(variant, SourceSetKind.TEST))
+    assertThat(Configurations
+      .variantFrom(configuration, setOf(
+        "main", "release", "debug", "test", "testDebug", "testRelease",
+        "flavor", "flavorRelease", "flavorDebug", "testFlavorRelease", "testFlavorDebug")))
+      .isEqualTo(Variant(variant, SourceSetKind.TEST))
   }
 
   @Test fun `variant equality works`() {

--- a/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
+++ b/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
@@ -17,6 +17,8 @@ import org.junit.jupiter.params.provider.CsvSource
 
 internal class StandardTransformTest {
 
+  private val supportedSourceSets = setOf("main", "release", "debug", "test", "testDebug", "testRelease")
+
   @Nested inner class SingleVariant {
 
     @Test fun `no advice for correct declaration`() {
@@ -27,7 +29,7 @@ internal class StandardTransformTest {
         configurationName = "implementation"
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -42,7 +44,7 @@ internal class StandardTransformTest {
         configurationName = oldConfiguration
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(
@@ -63,7 +65,7 @@ internal class StandardTransformTest {
         configurationName = oldConfiguration
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(
@@ -83,7 +85,7 @@ internal class StandardTransformTest {
         configurationName = "debugImplementation"
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -98,7 +100,7 @@ internal class StandardTransformTest {
         configurationName = fromConfiguration
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(Advice.ofRemove(coordinates, fromConfiguration))
     }
@@ -108,7 +110,7 @@ internal class StandardTransformTest {
       val usages = usage(Bucket.IMPL, "debug").intoSet()
       val declarations = emptySet<Declaration>()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(Advice.ofAdd(coordinates, "implementation"))
     }
@@ -121,7 +123,7 @@ internal class StandardTransformTest {
         configurationName = "runtimeOnly"
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -134,7 +136,7 @@ internal class StandardTransformTest {
         configurationName = "compileOnly"
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -151,7 +153,7 @@ internal class StandardTransformTest {
         configurationName = "implementation"
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -162,7 +164,7 @@ internal class StandardTransformTest {
       val usages = setOf(usage(bucket, "debug"), usage(bucket, "release"))
       val declarations = emptySet<Declaration>()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -175,7 +177,7 @@ internal class StandardTransformTest {
       )
       val declarations = emptySet<Declaration>()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -189,7 +191,7 @@ internal class StandardTransformTest {
         configurationName = fromConfiguration
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(
@@ -206,7 +208,7 @@ internal class StandardTransformTest {
         configurationName = "implementation"
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(coordinates, "implementation", "debugImplementation"),
@@ -224,7 +226,7 @@ internal class StandardTransformTest {
         configurationName = oldConfiguration
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations, true).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets, true).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(
@@ -240,7 +242,7 @@ internal class StandardTransformTest {
       val usages = setOf(usage(Bucket.NONE, "debug"), usage(Bucket.NONE, "release"))
       val declarations = emptySet<Declaration>()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -254,7 +256,7 @@ internal class StandardTransformTest {
         configurationName = fromConfiguration
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(Advice.ofRemove(coordinates, fromConfiguration))
     }
@@ -271,7 +273,7 @@ internal class StandardTransformTest {
         configurationName = fromConfiguration
       ).intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       // change from impl -> debugImpl (implicit "remove from release variant")
       assertThat(actual).containsExactly(
@@ -284,7 +286,7 @@ internal class StandardTransformTest {
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.IMPL, "release"))
       val declarations = emptySet<Declaration>()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(Advice.ofAdd(coordinates, "implementation"))
     }
@@ -294,7 +296,7 @@ internal class StandardTransformTest {
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.API, "release"))
       val declarations = emptySet<Declaration>()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofAdd(coordinates, "debugImplementation"),
@@ -307,7 +309,7 @@ internal class StandardTransformTest {
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.NONE, "release"))
       val declarations = emptySet<Declaration>()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(Advice.ofAdd(coordinates, "debugImplementation"))
     }
@@ -324,7 +326,7 @@ internal class StandardTransformTest {
         Declaration(id, "releaseApi")
       )
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(coordinates, "debugImplementation", "implementation"),
@@ -341,7 +343,7 @@ internal class StandardTransformTest {
         Declaration(id, "releaseImplementation")
       )
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(coordinates, "releaseImplementation")
@@ -357,7 +359,7 @@ internal class StandardTransformTest {
         Declaration(identifier = coordinates.identifier, configurationName = "kaptRelease")
       )
 
-      val actual = StandardTransform(coordinates, declarations, true).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets, true).reduce(usages)
 
       // The fact that it's kaptDebug -> kapt and kaptRelease -> null and not the other way around is due to alphabetic
       // ordering (Debug comes before Release).
@@ -383,7 +385,7 @@ internal class StandardTransformTest {
         Declaration(id, "releaseApi")
       )
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(coordinates, "debugImplementation", "debugApi"),
@@ -400,7 +402,7 @@ internal class StandardTransformTest {
         Declaration(id, "releaseApi")
       )
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(coordinates, "debugImplementation"),
@@ -417,7 +419,7 @@ internal class StandardTransformTest {
         Declaration(id, "releaseApi")
       )
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(coordinates, "debugImplementation", "debugApi"),
@@ -437,7 +439,7 @@ internal class StandardTransformTest {
         Declaration(id, "releaseImplementation")
       )
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(coordinates, "implementation", "debugImplementation"),
@@ -463,7 +465,7 @@ internal class StandardTransformTest {
       )
       val declarations = Declaration(id, "implementation").intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(coordinates, "implementation", "testImplementation")
@@ -484,7 +486,7 @@ internal class StandardTransformTest {
         Declaration(id, "testImplementation")
       )
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(coordinates, "implementation")
@@ -502,7 +504,7 @@ internal class StandardTransformTest {
       )
       val declarations = Declaration(id, "implementation").intoSet()
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(coordinates, "implementation", "debugImplementation"),
@@ -524,7 +526,7 @@ internal class StandardTransformTest {
         Declaration(id, "testImplementation")
       )
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(coordinates, "implementation", "debugImplementation")
@@ -545,7 +547,7 @@ internal class StandardTransformTest {
         Declaration(id, "testImplementation")
       )
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(coordinates, "testImplementation"),
@@ -565,7 +567,7 @@ internal class StandardTransformTest {
         Declaration(id, "testImplementation")
       )
 
-      val actual = StandardTransform(coordinates, declarations).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(coordinates, "testImplementation", "implementation"),
@@ -586,7 +588,7 @@ internal class StandardTransformTest {
       ).intoSet()
       val declarations = Declaration(id, "kapt").intoSet()
 
-      val actual = StandardTransform(coordinates, declarations, true).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets, true).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(coordinates, "kapt")
@@ -611,7 +613,7 @@ internal class StandardTransformTest {
       )
       val declarations = Declaration(id, "kapt").intoSet()
 
-      val actual = StandardTransform(coordinates, declarations, false).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets, false).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(coordinates, "kapt", "releaseAnnotationProcessor")
@@ -636,7 +638,7 @@ internal class StandardTransformTest {
       ).intoSet()
       val declarations = emptySet<Declaration>()
 
-      val actual = StandardTransform(coordinates, declarations, usesKapt).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets, usesKapt).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofAdd(coordinates, toConfiguration)

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
@@ -5,7 +5,8 @@ import com.autonomousapps.kit.Plugin.Companion.KOTLIN_VERSION
 class Dependency @JvmOverloads constructor(
   val configuration: String,
   private val dependency: String,
-  private val ext: String? = null
+  private val ext: String? = null,
+  private val capability: String? = null
 ) {
 
   private val isProject = dependency.startsWith(":")
@@ -40,6 +41,11 @@ class Dependency @JvmOverloads constructor(
     @JvmStatic
     fun project(configuration: String, path: String): Dependency {
       return Dependency(configuration, path)
+    }
+
+    @JvmStatic
+    fun project(configuration: String, path: String, capability: String): Dependency {
+      return Dependency(configuration, path, capability = capability)
     }
 
     @JvmStatic
@@ -235,6 +241,13 @@ class Dependency @JvmOverloads constructor(
         if (ext == null) "$configuration('$dependency')"
         // flat dependencies, e.g. in a libs/ dir
         else "$configuration(name: '$dependency', ext: '$ext')"
+      }
+    }.let {
+      when {
+        // Note: 'testFixtures("...")' is a shorthand for 'requireCapabilities("...-test-fixtures")'
+        capability == "test-fixtures" -> "testFixtures($it)"
+        capability != null -> "$it { capabilities { requireCapabilities('$capability') } }"
+        else -> it
       }
     }
 }

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Plugin.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Plugin.kt
@@ -35,6 +35,7 @@ class Plugin @JvmOverloads constructor(
     @JvmStatic val groovyGradlePlugin = Plugin("groovy-gradle-plugin")
     @JvmStatic val javaPlugin = Plugin("java")
     @JvmStatic val javaLibraryPlugin = Plugin("java-library")
+    @JvmStatic val javaTestFixturesPlugin = Plugin("java-test-fixtures")
     @JvmStatic val kaptPlugin = Plugin("org.jetbrains.kotlin.kapt")
     @JvmStatic val kotlinAndroidPlugin = Plugin("kotlin-android")
     @JvmStatic val kotlinPluginNoVersion = Plugin("org.jetbrains.kotlin.jvm", null, true)


### PR DESCRIPTION
The plugin currently may give wrong advices for source sets that are not yet supported (see #451 and #298).

This PR:
- Adds tests to show the issues.
- Ignores the unsupported cases for now so that users can use these Gradle features and still use this plugin to analyse the dependencies of the source sets that are supported right now.

Problematic cases are:

### Dependencies from unsupported Source Sets/Variants

The plugin produces advices (often wrong) for source sets that are not
yet supported. For example:

```
testFixturesApi("org.apache.commons:commons-collections4:4.4")

extraFeatureApi("org.apache.commons:commons-collections4:4.4")
```

### Dependencies to unsupported Source Sets/Variants

The plugin may produce wrong advices by ignoring the 'requires capabilities' part of dependencies like this:

```
testImplementation(testFixtures(project(':proj')))

api(project(':proj')) { capabilities {
     requireCapabilities('examplegroup:proj-extra-feature')
} }
```

Note: testFixtures(...) also uses 'requires capabilities'
