### PR TITLE
Support 'onRuntimeOnly' in issue handler

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/projects/AdviceFilterProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/projects/AdviceFilterProject.groovy
@@ -169,7 +169,8 @@ final class AdviceFilterProject extends AbstractProject {
     kotlinStdLib("implementation"),
     androidxAnnotations("api"),
     coreKtx("implementation"),
-    commonsIO("debugImplementation")
+    commonsIO("debugImplementation"),
+    rxlint('implementation')
   ]
 
   private List<Dependency> androidLibDependencies = [
@@ -196,7 +197,7 @@ final class AdviceFilterProject extends AbstractProject {
     def advice = [
       removeLibAndroid, removeCoreKtx, removeCommonsIo,
       addAppCompat, addCommonsCollections,
-      changeAndroidxAnnotation
+      changeAndroidxAnnotation, changeRxlint
     ]
     advice.removeAll(ignored)
     return advice
@@ -265,6 +266,14 @@ final class AdviceFilterProject extends AbstractProject {
       configurationName: 'api'
     ),
     'compileOnly'
+  )
+  final changeRxlint = Advice.ofChange(
+    dependency(
+      identifier: 'nl.littlerobots.rxlint:rxlint',
+      resolvedVersion: '1.7.6',
+      configurationName: 'implementation'
+    ),
+    'runtimeOnly'
   )
   // lib-android
   final removeNavUiKtx = Advice.ofRemove(

--- a/src/main/kotlin/com/autonomousapps/extension/IssueHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/IssueHandler.kt
@@ -79,6 +79,7 @@ open class IssueHandler @Inject constructor(objects: ObjectFactory) {
   internal fun usedTransitiveDependenciesIssue(): Provider<Behavior> = all.usedTransitiveDependenciesIssue.behavior()
   internal fun incorrectConfigurationIssue(): Provider<Behavior> = all.incorrectConfigurationIssue.behavior()
   internal fun compileOnlyIssue(): Provider<Behavior> = all.compileOnlyIssue.behavior()
+  internal fun runtimeOnlyIssue(): Provider<Behavior> = all.runtimeOnlyIssue.behavior()
   internal fun unusedAnnotationProcessorsIssue(): Provider<Behavior> = all.unusedAnnotationProcessorsIssue.behavior()
   internal fun redundantPluginsIssue(): Provider<Behavior> = all.redundantPluginsIssue.behavior()
 
@@ -109,6 +110,12 @@ open class IssueHandler @Inject constructor(objects: ObjectFactory) {
   internal fun compileOnlyIssueFor(path: String): Provider<Behavior> {
     val global = all.compileOnlyIssue
     val proj = projects.findByName(path)?.compileOnlyIssue
+    return union(global, proj)
+  }
+
+  internal fun runtimeOnlyIssueFor(path: String): Provider<Behavior> {
+    val global = all.runtimeOnlyIssue
+    val proj = projects.findByName(path)?.runtimeOnlyIssue
     return union(global, proj)
   }
 
@@ -173,6 +180,10 @@ open class IssueHandler @Inject constructor(objects: ObjectFactory) {
  *       // otherwise declared.
  *       onCompileOnly { ... }
  *
+ *       // Specify severity and exclude rules for dependencies that could be runtimeOnly but are
+ *       // otherwise declared.
+ *       onRuntimeOnly { ... }
+ *
  *       // Specify severity and exclude rules for unused annotation processors.
  *       onUnusedAnnotationProcessors { ... }
  *
@@ -196,6 +207,7 @@ open class ProjectIssueHandler @Inject constructor(
   internal val incorrectConfigurationIssue = objects.newInstance(Issue::class.java)
   internal val unusedAnnotationProcessorsIssue = objects.newInstance(Issue::class.java)
   internal val compileOnlyIssue = objects.newInstance(Issue::class.java)
+  internal val runtimeOnlyIssue = objects.newInstance(Issue::class.java)
   internal val redundantPluginsIssue = objects.newInstance(Issue::class.java)
 
   // TODO this should be removed or simply redirect to the DependenciesHandler
@@ -226,6 +238,10 @@ open class ProjectIssueHandler @Inject constructor(
 
   fun onCompileOnly(action: Action<Issue>) {
     action.execute(compileOnlyIssue)
+  }
+
+  fun onRuntimeOnly(action: Action<Issue>) {
+    action.execute(runtimeOnlyIssue)
   }
 
   fun onUnusedAnnotationProcessors(action: Action<Issue>) {

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -732,6 +732,7 @@ internal class ProjectPlugin(private val project: Project) {
         usedTransitiveDependenciesBehavior.set(usedTransitiveDependenciesIssueFor(theProjectPath))
         incorrectConfigurationBehavior.set(incorrectConfigurationIssueFor(theProjectPath))
         compileOnlyBehavior.set(compileOnlyIssueFor(theProjectPath))
+        runtimeOnlyBehavior.set(runtimeOnlyIssueFor(theProjectPath))
         unusedProcsBehavior.set(unusedAnnotationProcessorsIssueFor(theProjectPath))
         redundantPluginsBehavior.set(redundantPluginsIssueFor(theProjectPath))
       }

--- a/src/main/kotlin/com/autonomousapps/tasks/FilterAdviceTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FilterAdviceTask.kt
@@ -61,6 +61,9 @@ abstract class FilterAdviceTask @Inject constructor(
   abstract val compileOnlyBehavior: Property<Behavior>
 
   @get:Input
+  abstract val runtimeOnlyBehavior: Property<Behavior>
+
+  @get:Input
   abstract val redundantPluginsBehavior: Property<Behavior>
 
   @get:OutputFile
@@ -77,6 +80,7 @@ abstract class FilterAdviceTask @Inject constructor(
       incorrectConfigurationBehavior.set(this@FilterAdviceTask.incorrectConfigurationBehavior)
       unusedProcsBehavior.set(this@FilterAdviceTask.unusedProcsBehavior)
       compileOnlyBehavior.set(this@FilterAdviceTask.compileOnlyBehavior)
+      runtimeOnlyBehavior.set(this@FilterAdviceTask.runtimeOnlyBehavior)
       redundantPluginsBehavior.set(this@FilterAdviceTask.redundantPluginsBehavior)
       output.set(this@FilterAdviceTask.output)
     }
@@ -92,6 +96,7 @@ abstract class FilterAdviceTask @Inject constructor(
     val incorrectConfigurationBehavior: Property<Behavior>
     val unusedProcsBehavior: Property<Behavior>
     val compileOnlyBehavior: Property<Behavior>
+    val runtimeOnlyBehavior: Property<Behavior>
     val redundantPluginsBehavior: Property<Behavior>
     val output: RegularFileProperty
   }
@@ -110,6 +115,7 @@ abstract class FilterAdviceTask @Inject constructor(
       val incorrectConfigurationBehavior = parameters.incorrectConfigurationBehavior.get()
       val unusedProcsBehavior = parameters.unusedProcsBehavior.get()
       val compileOnlyBehavior = parameters.compileOnlyBehavior.get()
+      val runtimeOnlyBehavior = parameters.runtimeOnlyBehavior.get()
       val redundantPluginsBehavior = parameters.redundantPluginsBehavior.get()
 
       val projectAdvice = parameters.projectAdvice.fromJson<ProjectAdvice>()
@@ -119,6 +125,7 @@ abstract class FilterAdviceTask @Inject constructor(
         .filterOf(usedTransitiveDependenciesBehavior) { it.isAdd() }
         .filterOf(incorrectConfigurationBehavior) { it.isChange() }
         .filterOf(compileOnlyBehavior) { it.isCompileOnly() }
+        .filterOf(runtimeOnlyBehavior) { it.isRuntimeOnly() }
         .filterOf(unusedProcsBehavior) { it.isProcessor() }
         .filterDataBinding()
         .filterViewBinding()


### PR DESCRIPTION
Allows customising the handling of 'runtimeOnly' advices like this:

```
dependencyAnalysis {
  issues {
    project(':lib_android') {
      onRuntimeOnly {
        severity 'fail'
        exclude 'nl.littlerobots.rxlint:rxlint'
      }
    }
  }
}
```

Follow up to #646.