### PR TITLE
Put 'compileOnlyApi' and 'providedCompile' into the COMPILE_ONLY bucket

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CompileOnlyJarSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CompileOnlyJarSpec.groovy
@@ -1,6 +1,7 @@
 package com.autonomousapps.jvm
 
 import com.autonomousapps.jvm.projects.CompileOnlyJarProject
+import com.autonomousapps.jvm.projects.WarTestProject
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
@@ -14,6 +15,27 @@ final class CompileOnlyJarSpec extends AbstractJvmSpec {
 
     when:
     build(gradleVersion, gradleProject.rootDir, ':external:jar')
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  // The plugin cannot decide if something that is required for compilation is only needed at compile time.
+  // Currently, such dependencies produce now advice at all. In the future the plugin could:
+  // - Give an advice if one of these dependencies can be removed completely
+  //   https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/648
+  // - Give an advice id a dependency could be moved between 'compileOnly' <-> 'compileOnlyApi'
+  //   (in projects where 'compileOnlyApi' exists)
+  def "no advices for compileOnly, compileOnlyApi and providedCompile"() {
+    given:
+    def project = new WarTestProject()
+    gradleProject = project.gradleProject
+
+    when:
     build(gradleVersion, gradleProject.rootDir, 'buildHealth')
 
     then:

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/WarTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/WarTestProject.groovy
@@ -1,0 +1,85 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.Dependency.*
+
+final class WarTestProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  WarTestProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('proj') { s ->
+      s.sources = PROJ_SOURCES
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.warPlugin, Plugin.javaLibraryPlugin]
+        bs.dependencies = [
+          commonsIO('compileOnly'),
+          jsr305('compileOnlyApi'),
+          javaxServlet("providedCompile")
+        ]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private List<Source> PROJ_SOURCES = [
+    new Source(SourceType.JAVA, "AppServlet", "com/example",
+      """\
+        package com.example;
+        
+        import javax.annotation.Nullable;
+        import javax.servlet.annotation.WebServlet;
+        import javax.servlet.http.HttpServlet;
+        import javax.servlet.http.HttpServletRequest;
+        import javax.servlet.http.HttpServletResponse;
+        import java.io.IOException;
+        import java.io.PrintWriter;
+        import org.apache.commons.io.output.ByteArrayOutputStream;
+        
+        @WebServlet("/check")
+        public class AppServlet extends HttpServlet {
+          public void doGet(HttpServletRequest req, HttpServletResponse res) throws IOException {
+            res.setContentType("text/html");
+            PrintWriter pw = res.getWriter();
+            pw.println("<html><body>");
+            pw.println("App is running...");
+            pw.println("</body></html>");
+            pw.close();
+          }
+          
+          @Nullable
+          public java.io.OutputStream getSomeDataStream() {
+            try {
+              return new ByteArrayOutputStream();
+            } catch (NoClassDefFoundError e) {
+              return null;
+            }
+          }
+        }
+      """.stripIndent()
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    emptyProjectAdviceFor(':proj')
+  ]
+}

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Bucket.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Bucket.kt
@@ -4,11 +4,9 @@ package com.autonomousapps.model.declaration
 internal enum class Bucket(val value: String) {
   API("api"),
   IMPL("implementation"),
+  // These configurations go into the compileOnly bucket: '...CompileOny', '...CompileOnlyApi', 'providedCompile'
   COMPILE_ONLY("compileOnly"),
   RUNTIME_ONLY("runtimeOnly"),
-
-  // note that only the java-library plugin currently supports this configuration
-  // COMPILE_ONLY_API("compileOnlyApi"),
 
   // TODO: somewhat problematic since this value can be used naively. Should probably be a function that can return
   //  either kapt or annotationProcessor...
@@ -26,6 +24,7 @@ internal enum class Bucket(val value: String) {
     @JvmStatic
     fun of(configurationName: String): Bucket {
       if (Configurations.isForAnnotationProcessor(configurationName)) return ANNOTATION_PROCESSOR
+      if (Configurations.isForCompileOnly(configurationName)) return COMPILE_ONLY
 
       return values().find { bucket ->
         configurationName.endsWith(bucket.value, true)

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Configurations.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Configurations.kt
@@ -10,7 +10,8 @@ internal object Configurations {
   internal const val CONF_ADVICE_ALL_CONSUMER = "adviceAllConsumer"
   internal const val CONF_ADVICE_ALL_PRODUCER = "adviceAllProducer"
 
-  private val MAIN_SUFFIXES = listOf("api", "implementation", "compileOnly", "runtimeOnly")
+  private val COMPILE_ONLY_SUFFIXES = listOf("compileOnly", "compileOnlyApi", "providedCompile")
+  private val MAIN_SUFFIXES = COMPILE_ONLY_SUFFIXES + listOf("api", "implementation", "runtimeOnly")
 
   private val ANNOTATION_PROCESSOR_TEMPLATES = listOf(
     Template("kapt", BY_PREFIX),
@@ -22,6 +23,10 @@ internal object Configurations {
    */
   internal fun isForRegularDependency(configurationName: String): Boolean {
     return MAIN_SUFFIXES.any { suffix -> configurationName.endsWith(suffix = suffix, ignoreCase = true) }
+  }
+
+  internal fun isForCompileOnly(configurationName: String): Boolean {
+    return COMPILE_ONLY_SUFFIXES.any { suffix -> configurationName.endsWith(suffix = suffix, ignoreCase = true) }
   }
 
   internal fun isForAnnotationProcessor(configurationName: String): Boolean {
@@ -77,7 +82,11 @@ internal object Configurations {
 
   // we want dependency buckets only
   fun Configuration.isForRegularDependency() =
-    !isCanBeConsumed && !isCanBeResolved && isForRegularDependency(name)
+    // do not check '!isCanBeConsumed && !isCanBeResolved' due to https://github.com/gradle/gradle/issues/20547 or
+    // similar situations. Other plugins or users (although not recommended) might change these flags. Since we know
+    // the exact names of the Configurations we support (based on to which source set they are linked) this check
+    // is not necessary.
+    isForRegularDependency(name)
 
   // as in so many things, "kapt" is special: it is a resolvable configuration
   fun Configuration.isForAnnotationProcessor() = isForAnnotationProcessor(name)

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -112,7 +112,7 @@ internal class StandardTransform(
 
         if (
           usage.bucket == Bucket.NONE
-          // Don't remove a declaration on compileOnly
+          // Don't remove a declaration on compileOnly, compileOnlyApi, providedCompile
           && decl.bucket != Bucket.COMPILE_ONLY
           // Don't remove a declaration on runtimeOnly
           && decl.bucket != Bucket.RUNTIME_ONLY
@@ -124,7 +124,7 @@ internal class StandardTransform(
         } else if (
         // Don't change a match, it's correct!
           !usage.bucket.matches(decl)
-          // Don't change a declaration on compileOnly
+          // Don't change a declaration on compileOnly, compileOnlyApi, providedCompile
           && decl.bucket != Bucket.COMPILE_ONLY
           // Don't change a declaration on runtimeOnly
           && decl.bucket != Bucket.RUNTIME_ONLY
@@ -161,7 +161,7 @@ internal class StandardTransform(
     usages.asSequence()
       // Don't add unused usages!
       .filterUsed()
-      // Don't add runtimeOnly or compileOnly declarations
+      // Don't add runtimeOnly or compileOnly (compileOnly, compileOnlyApi, providedCompile) declarations
       .filterNot { it.bucket == Bucket.RUNTIME_ONLY || it.bucket == Bucket.COMPILE_ONLY }
       .mapTo(advice) { usage ->
         Advice.ofAdd(coordinates, usage.toConfiguration())

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
@@ -168,6 +168,16 @@ class Dependency @JvmOverloads constructor(
     }
 
     @JvmStatic
+    fun javaxServlet(configuration: String): Dependency {
+      return Dependency(configuration, "javax.servlet:javax.servlet-api:3.0.1")
+    }
+
+    @JvmStatic
+    fun jsr305(configuration: String): Dependency {
+      return Dependency(configuration, "com.google.code.findbugs:jsr305:3.0.2")
+    }
+
+    @JvmStatic
     fun kotlinxCoroutinesAndroid(configuration: String): Dependency {
       return Dependency(configuration, "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.5")
     }

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Plugin.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Plugin.kt
@@ -39,6 +39,7 @@ class Plugin @JvmOverloads constructor(
     @JvmStatic val kotlinAndroidPlugin = Plugin("kotlin-android")
     @JvmStatic val kotlinPluginNoVersion = Plugin("org.jetbrains.kotlin.jvm", null, true)
     @JvmStatic val springBootPlugin = Plugin("org.springframework.boot", "2.3.1.RELEASE")
+    @JvmStatic val warPlugin = Plugin("war")
 
     @JvmStatic
     fun kotlinPlugin(version: String? = KOTLIN_VERSION, apply: Boolean = true): Plugin {


### PR DESCRIPTION
Similar to #651, the goal of this to avoid **wrong advices** to be reported rather than fully supporting what could be possible here (a follow up could be #648). The test in this PR shows an example where the plugin right now suggests moving dependencies aways from "compileOnlyApi" or "providedCompile".

From the perspective of this plugin right now, dependencies defined as 'compileOnlyApi' or 'providedCompile' should be treated the same as 'compileOnly'. Which is, there are no advices produced for them.

Some context on 'providedCompile':
The configuration is added by the 'war' Gradle core plugin if applied. This configuration exists for years already. If it would be introduced today, it would probably be called 'providedApi'. It has the same behaviour as the 'api' configuration, but with the difference that it is not packaged into the 'war' file that makes up the final application. Because the Jar behind the dependency is expected to be provided by the runtime environment. Currently, there is no 'providedImplementation'. So an analysis whether a 'providedCompile' dependency has "api" or "implementation" characteristics won't be useful because there is not distinction right now.

Using the 'war' plugin and 'providedCompile' can be seen as a bit of an edge case. But there are many Java (Enterprise) projects out there using it as it exists for a long time. This change would make it easier for such projects to use this plugin without having to manually exclude certain analysis results.