### PR TITLE
Filter out 'module-info.class' files in all places

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/kotlin/PublicApiDump.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/kotlin/PublicApiDump.kt
@@ -30,7 +30,7 @@ fun main(args: Array<String>) {
 }
 
 fun JarFile.classEntries() = Sequence { entries().iterator() }.filter {
-  !it.isDirectory && it.name.endsWith(".class") && !it.name.startsWith("META-INF/")
+  !it.isDirectory && it.name.endsWith(".class") && it.name != "module-info.class" && !it.name.startsWith("META-INF/")
 }
 
 fun getBinaryAPI(jar: JarFile, visibilityFilter: (String) -> Boolean = { true }): List<ClassBinarySignature> =

--- a/src/main/kotlin/com/autonomousapps/tasks/AbiAnalysisTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/AbiAnalysisTask.kt
@@ -105,6 +105,6 @@ abstract class AbiAnalysisTask @Inject constructor(
 
     private fun allClassFiles(): Set<File> =
       parameters.javaClasses.asFileTree.files.plus(parameters.kotlinClasses.asFileTree.files)
-        .filterToSet { it.path.endsWith(".class") }
+        .filterToSet { it.path.endsWith(".class") && it.name != "module-info.class" }
   }
 }


### PR DESCRIPTION
This is in symmetry with other places where files are filtered by 'endsWith(".class")'. Without this, the plugin may attempt to analyses 'module-info.class' files of your own projects leading to an NPE.