### PR TITLE
Add a trailing space for path linkifying

### DIFF
--- a/src/main/kotlin/com/autonomousapps/tasks/BuildHealthTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/BuildHealthTask.kt
@@ -40,7 +40,8 @@ abstract class BuildHealthTask : DefaultTask() {
       if (printBuildHealth.get()) {
         appendReproducibleNewLine(consoleReportFile.readText())
       }
-      append("There were dependency violations. See report at $consoleReportPath")
+      // Trailing space so terminal UIs linkify it
+      append("There were dependency violations. See report at $consoleReportPath ")
     }
 
     if (shouldFail) {


### PR DESCRIPTION
Terminal UIs often only linkify paths if there's a trailing space, so this should help avoid these not linking otherwise