### PR TITLE
Use code gen for moshi adapters instead of reflection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   id("org.jetbrains.kotlin.jvm")
   `kotlin-dsl`
   groovy
+  id("com.google.devtools.ksp") version "1.5.31-1.0.0"
 }
 
 // This version string comes from gradle.properties
@@ -79,10 +80,14 @@ dependencies {
   implementation("com.squareup.moshi:moshi-adapters:1.12.0") {
     because("For writing reports based on Kotlin classes")
   }
+  // TODO switch to moshi-kotlin-codegen (where this was upstreamed to) once updated to Moshi 1.13.0
+  ksp("dev.zacsweers.moshix:moshi-ksp:0.14.1") {
+    because("For writing reports in JSON format")
+  }
   implementation("dev.zacsweers.moshix:moshi-sealed-runtime:0.14.1") {
     because("Better support for de/serializing sealed types")
   }
-  implementation("dev.zacsweers.moshix:moshi-sealed-metadata-reflect:0.14.1") {
+  ksp("dev.zacsweers.moshix:moshi-sealed-codegen:0.14.1") {
     because("Better support for de/serializing sealed types")
   }
   implementation("org.jetbrains.kotlin:kotlin-reflect") {

--- a/src/main/kotlin/com/autonomousapps/advice/PluginAdvice.kt
+++ b/src/main/kotlin/com/autonomousapps/advice/PluginAdvice.kt
@@ -1,6 +1,9 @@
 package com.autonomousapps.advice
 
+import com.squareup.moshi.JsonClass
+
 // TODO move to com.autonomousapps.model package (breaking ABI change)
+@JsonClass(generateAdapter = true)
 data class PluginAdvice(
   val redundantPlugin: String,
   val reason: String

--- a/src/main/kotlin/com/autonomousapps/internal/models.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/models.kt
@@ -4,6 +4,7 @@ import com.autonomousapps.internal.asm.Opcodes
 import com.autonomousapps.internal.utils.efficient
 import com.autonomousapps.internal.utils.filterNotToSet
 import com.autonomousapps.internal.utils.mapToSet
+import com.squareup.moshi.JsonClass
 import java.lang.annotation.RetentionPolicy
 import java.util.regex.Pattern
 
@@ -126,6 +127,7 @@ data class Method internal constructor(val types: Set<String>) {
   }
 }
 
+@JsonClass(generateAdapter = true)
 internal data class AbiExclusions(
   val annotationExclusions: Set<String> = emptySet(),
   val classExclusions: Set<String> = emptySet(),
@@ -153,6 +155,7 @@ internal data class AbiExclusions(
   }
 }
 
+@JsonClass(generateAdapter = true)
 internal data class UsagesExclusions(
   val classExclusions: Set<String> = emptySet()
 ) {

--- a/src/main/kotlin/com/autonomousapps/internal/utils/moshi.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/moshi.kt
@@ -8,6 +8,7 @@ import com.autonomousapps.model.declaration.Variant
 import com.google.common.graph.Graph
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types.newParameterizedType
@@ -142,6 +143,7 @@ internal class GraphViewAdapter {
     return graphBuilder.build()
   }
 
+  @JsonClass(generateAdapter = true)
   internal data class GraphViewJson(
     val variant: Variant,
     val configurationName: String,

--- a/src/main/kotlin/com/autonomousapps/internal/utils/moshi.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/moshi.kt
@@ -151,6 +151,7 @@ internal class GraphViewAdapter {
     val edges: Set<EdgeJson>
   )
 
+  @JsonClass(generateAdapter = true)
   internal data class EdgeJson(val source: Coordinates, val target: Coordinates)
 
   private infix fun Coordinates.to(target: Coordinates) = EdgeJson(this, target)

--- a/src/main/kotlin/com/autonomousapps/internal/utils/moshi.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/moshi.kt
@@ -11,16 +11,12 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types.newParameterizedType
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import dev.zacsweers.moshix.sealed.reflect.MetadataMoshiSealedJsonAdapterFactory
 import java.io.File
 
 val MOSHI: Moshi by lazy {
   Moshi.Builder()
     .add(GraphViewAdapter())
-    .add(MetadataMoshiSealedJsonAdapterFactory())
     .add(TypeAdapters())
-    .addLast(KotlinJsonAdapterFactory())
     .build()
 }
 

--- a/src/main/kotlin/com/autonomousapps/model/Advice.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Advice.kt
@@ -2,6 +2,7 @@ package com.autonomousapps.model
 
 import com.autonomousapps.internal.utils.isTrue
 import com.autonomousapps.model.declaration.Declaration
+import com.squareup.moshi.JsonClass
 
 /**
  * An "advice" is a kind of _transform_ that users ought to perform to bring their dependency declarations into a more
@@ -9,6 +10,7 @@ import com.autonomousapps.model.declaration.Declaration
  *
  * See also [Usage][com.autonomousapps.model.intermediates.Usage].
  */
+@JsonClass(generateAdapter = true)
 data class Advice(
   /** The coordinates of the dependency that ought to be modified in some way. */
   val coordinates: Coordinates,

--- a/src/main/kotlin/com/autonomousapps/model/BuildHealth.kt
+++ b/src/main/kotlin/com/autonomousapps/model/BuildHealth.kt
@@ -1,5 +1,8 @@
 package com.autonomousapps.model
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
 data class BuildHealth(
   val projectAdvice: Set<ProjectAdvice>,
   val shouldFail: Boolean,

--- a/src/main/kotlin/com/autonomousapps/model/Capability.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Capability.kt
@@ -55,6 +55,7 @@ data class AndroidResCapability(
   val lines: List<Line>
 ) : Capability() {
 
+  @JsonClass(generateAdapter = true)
   data class Line(val type: String, val value: String)
 }
 
@@ -96,6 +97,7 @@ data class InlineMemberCapability(
   val inlineMembers: Set<InlineMember>
 ) : Capability() {
 
+  @JsonClass(generateAdapter = true)
   data class InlineMember(
     val packageName: String,
     val inlineMembers: Set<String>

--- a/src/main/kotlin/com/autonomousapps/model/Capability.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Capability.kt
@@ -4,7 +4,7 @@ import com.autonomousapps.internal.utils.LexicographicIterableComparator
 import com.squareup.moshi.JsonClass
 import dev.zacsweers.moshix.sealed.annotations.TypeLabel
 
-@JsonClass(generateAdapter = false, generator = "sealed:type")
+@JsonClass(generateAdapter = true, generator = "sealed:type")
 sealed class Capability : Comparable<Capability> {
   override fun compareTo(other: Capability): Int = javaClass.simpleName.compareTo(other.javaClass.simpleName)
 }

--- a/src/main/kotlin/com/autonomousapps/model/Capability.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Capability.kt
@@ -10,7 +10,7 @@ sealed class Capability : Comparable<Capability> {
 }
 
 @TypeLabel("linter")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class AndroidLinterCapability(
   val lintRegistry: String,
   /** True if this dependency contains _only_ an Android lint jar/registry. */
@@ -18,7 +18,7 @@ data class AndroidLinterCapability(
 ) : Capability()
 
 @TypeLabel("manifest")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class AndroidManifestCapability(
   val packageName: String,
   val componentMap: Map<Component, Set<String>>
@@ -43,13 +43,13 @@ data class AndroidManifestCapability(
 }
 
 @TypeLabel("asset")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class AndroidAssetCapability(
   val assets: List<String>
 ) : Capability()
 
 @TypeLabel("res")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class AndroidResCapability(
   val rImport: String,
   val lines: List<Line>
@@ -59,20 +59,20 @@ data class AndroidResCapability(
 }
 
 @TypeLabel("proc")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class AnnotationProcessorCapability(
   val processor: String,
   val supportedAnnotationTypes: Set<String>
 ) : Capability()
 
 @TypeLabel("class")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class ClassCapability(
   val classes: Set<String>
 ) : Capability()
 
 @TypeLabel("const")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class ConstantCapability(
   /** Map of fully-qualified class names to constant field names. */
   val constants: Map<String, Set<String>>,
@@ -81,7 +81,7 @@ data class ConstantCapability(
 ) : Capability()
 
 @TypeLabel("inferred")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class InferredCapability(
   /**
    * True if this dependency contains only annotations that are only needed at compile-time (`CLASS`
@@ -91,7 +91,7 @@ data class InferredCapability(
 ) : Capability()
 
 @TypeLabel("inline")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class InlineMemberCapability(
   val inlineMembers: Set<InlineMember>
 ) : Capability() {
@@ -107,20 +107,20 @@ data class InlineMemberCapability(
 }
 
 @TypeLabel("native")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class NativeLibCapability(
   val fileNames: Set<String>
 ) : Capability()
 
 @TypeLabel("service_loader")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class ServiceLoaderCapability(
   val providerFile: String,
   val providerClasses: Set<String>
 ) : Capability()
 
 @TypeLabel("security_provider")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class SecurityProviderCapability(
   val securityProviders: Set<String>
 ) : Capability()

--- a/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
@@ -47,7 +47,7 @@ sealed class Coordinates(
 }
 
 @TypeLabel("project")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class ProjectCoordinates(
   override val identifier: String
 ) : Coordinates(identifier) {
@@ -60,7 +60,7 @@ data class ProjectCoordinates(
 }
 
 @TypeLabel("module")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class ModuleCoordinates(
   override val identifier: String,
   val resolvedVersion: String
@@ -70,7 +70,7 @@ data class ModuleCoordinates(
 
 /** For dependencies that have no version information. They might be a flat file on disk, or e.g. "Gradle API". */
 @TypeLabel("flat")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class FlatCoordinates(
   override val identifier: String
 ) : Coordinates(identifier) {
@@ -78,7 +78,7 @@ data class FlatCoordinates(
 }
 
 @TypeLabel("included_build")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class IncludedBuildCoordinates(
   override val identifier: String,
   val requestedVersion: String,

--- a/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
@@ -3,7 +3,7 @@ package com.autonomousapps.model
 import com.squareup.moshi.JsonClass
 import dev.zacsweers.moshix.sealed.annotations.TypeLabel
 
-@JsonClass(generateAdapter = false, generator = "sealed:type")
+@JsonClass(generateAdapter = true, generator = "sealed:type")
 sealed class Coordinates(
   open val identifier: String
 ) : Comparable<Coordinates> {

--- a/src/main/kotlin/com/autonomousapps/model/Dependency.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Dependency.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.JsonClass
 import dev.zacsweers.moshix.sealed.annotations.TypeLabel
 import java.io.File
 
-@JsonClass(generateAdapter = false, generator = "sealed:type")
+@JsonClass(generateAdapter = true, generator = "sealed:type")
 sealed class Dependency(
   open val coordinates: Coordinates,
   open val capabilities: Map<String, Capability>,

--- a/src/main/kotlin/com/autonomousapps/model/Dependency.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Dependency.kt
@@ -16,7 +16,7 @@ sealed class Dependency(
 }
 
 @TypeLabel("project")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class ProjectDependency(
   override val coordinates: ProjectCoordinates,
   /** Map of [Capability] canonicalName to the capability. */
@@ -25,7 +25,7 @@ data class ProjectDependency(
 ) : Dependency(coordinates, capabilities, file)
 
 @TypeLabel("module")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class ModuleDependency(
   override val coordinates: ModuleCoordinates,
   override val capabilities: Map<String, Capability>,
@@ -33,7 +33,7 @@ data class ModuleDependency(
 ) : Dependency(coordinates, capabilities, file)
 
 @TypeLabel("flat")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class FlatDependency(
   override val coordinates: FlatCoordinates,
   override val capabilities: Map<String, Capability>,
@@ -41,7 +41,7 @@ data class FlatDependency(
 ) : Dependency(coordinates, capabilities, file)
 
 @TypeLabel("included_build")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class IncludedBuildDependency(
   override val coordinates: IncludedBuildCoordinates,
   override val capabilities: Map<String, Capability>,

--- a/src/main/kotlin/com/autonomousapps/model/KtFile.kt
+++ b/src/main/kotlin/com/autonomousapps/model/KtFile.kt
@@ -1,5 +1,6 @@
 package com.autonomousapps.model
 
+import com.squareup.moshi.JsonClass
 import kotlinx.metadata.jvm.KotlinModuleMetadata
 import java.util.zip.ZipFile
 
@@ -8,6 +9,7 @@ import java.util.zip.ZipFile
  * `com.example.ThingKt`, but imports in Kotlin code look like `com.example.CONSTANT` (rather than
  * `com.example.ThingKt.CONSTANT`).
  */
+@JsonClass(generateAdapter = true)
 data class KtFile(
   val fqcn: String,
   val name: String

--- a/src/main/kotlin/com/autonomousapps/model/PhysicalArtifact.kt
+++ b/src/main/kotlin/com/autonomousapps/model/PhysicalArtifact.kt
@@ -1,10 +1,12 @@
 package com.autonomousapps.model
 
 import com.autonomousapps.internal.utils.toCoordinates
+import com.squareup.moshi.JsonClass
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import java.io.File
 
+@JsonClass(generateAdapter = true)
 internal data class PhysicalArtifact(
   val coordinates: Coordinates,
   /** Physical artifact on disk; a jar file. */

--- a/src/main/kotlin/com/autonomousapps/model/ProjectAdvice.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ProjectAdvice.kt
@@ -1,8 +1,10 @@
 package com.autonomousapps.model
 
 import com.autonomousapps.advice.PluginAdvice
+import com.squareup.moshi.JsonClass
 
 /** Collection of all dependency- and plugin-related advice for a single project, across all variants. */
+@JsonClass(generateAdapter = true)
 data class ProjectAdvice(
   val projectPath: String,
   val dependencyAdvice: Set<Advice> = emptySet(),

--- a/src/main/kotlin/com/autonomousapps/model/ProjectVariant.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ProjectVariant.kt
@@ -5,10 +5,12 @@ import com.autonomousapps.internal.utils.flatMapToOrderedSet
 import com.autonomousapps.internal.utils.flatMapToSet
 import com.autonomousapps.model.CodeSource.Kind
 import com.autonomousapps.model.declaration.Variant
+import com.squareup.moshi.JsonClass
 
 /**
  * Represents a variant-specific view of the project under analysis.
  */
+@JsonClass(generateAdapter = true)
 data class ProjectVariant(
   val coordinates: ProjectCoordinates,
   val buildType: String?,

--- a/src/main/kotlin/com/autonomousapps/model/Source.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Source.kt
@@ -52,10 +52,12 @@ data class AndroidResSource(
   val usedClasses: Set<String>
 ) : Source(relativePath) {
 
+  @JsonClass(generateAdapter = true)
   /** The parent of a style resource, e.g. "Theme.AppCompat.Light.DarkActionBar". */
   data class StyleParentRef(val styleParent: String)
 
   /** * Any attribute that looks like a reference to another resource. */
+  @JsonClass(generateAdapter = true)
   data class AttrRef(val type: String, val id: String) {
     companion object {
 

--- a/src/main/kotlin/com/autonomousapps/model/Source.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Source.kt
@@ -19,7 +19,7 @@ sealed class Source(
 
 /** A single `.class` file in this project. */
 @TypeLabel("code")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class CodeSource(
   override val relativePath: String,
   val kind: Kind,
@@ -43,7 +43,7 @@ data class CodeSource(
 
 /** A single `.xml` (Android resource) file in this project. */
 @TypeLabel("android_res")
-@JsonClass(generateAdapter = false)
+@JsonClass(generateAdapter = true)
 data class AndroidResSource(
   override val relativePath: String,
   val styleParentRefs: Set<StyleParentRef>,

--- a/src/main/kotlin/com/autonomousapps/model/Source.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Source.kt
@@ -3,7 +3,7 @@ package com.autonomousapps.model
 import com.squareup.moshi.JsonClass
 import dev.zacsweers.moshix.sealed.annotations.TypeLabel
 
-@JsonClass(generateAdapter = false, generator = "sealed:type")
+@JsonClass(generateAdapter = true, generator = "sealed:type")
 sealed class Source(
   /** Source file path relative to project dir (e.g. `src/main/com/foo/Bar.kt`). */
   open val relativePath: String

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Bucket.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Bucket.kt
@@ -1,6 +1,9 @@
 package com.autonomousapps.model.declaration
 
+import com.squareup.moshi.JsonClass
+
 /** Standard user-facing dependency buckets (such as **implementation** and **api**), [variant][Variant]-agnostic. */
+@JsonClass(generateAdapter = false)
 internal enum class Bucket(val value: String) {
   API("api"),
   IMPL("implementation"),

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
@@ -1,6 +1,7 @@
 package com.autonomousapps.model.declaration
 
 import com.autonomousapps.internal.unsafeLazy
+import com.squareup.moshi.JsonClass
 
 /**
  * A dependency's declaration is the configuration that it's declared on (by user or plugin). A dependency may actually
@@ -13,6 +14,7 @@ import com.autonomousapps.internal.unsafeLazy
  * of referring to the _source set_ (main, test). For Android projects, it is the combination of source set and
  * _variant_ (e.g., debug, release, buildTypeFlavor).
  */
+@JsonClass(generateAdapter = true)
 internal data class Declaration(
   val identifier: String,
   val configurationName: String,

--- a/src/main/kotlin/com/autonomousapps/model/declaration/SourceSetKind.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/SourceSetKind.kt
@@ -1,7 +1,9 @@
 package com.autonomousapps.model.declaration
 
 import com.autonomousapps.internal.utils.lowercase
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = false)
 enum class SourceSetKind(
   val taskNameSuffix: String,
   private val compileClasspathFormatString: String,

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Variant.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Variant.kt
@@ -1,11 +1,14 @@
 package com.autonomousapps.model.declaration
 
+import com.squareup.moshi.JsonClass
+
 /**
  * A "Variant" has two meanings depending on context:
  * 1. For the JVM, it is simply the source set (e.g., "main" and "test").
  * 2. For Android, it is the combination of _variant_ (e.g., "debug" and "release") and [SourceSetKind] ("main" and
  * "test").
  */
+@JsonClass(generateAdapter = true)
 data class Variant(
   val variant: String,
   val kind: SourceSetKind

--- a/src/main/kotlin/com/autonomousapps/model/intermediates/DependencyTraceReport.kt
+++ b/src/main/kotlin/com/autonomousapps/model/intermediates/DependencyTraceReport.kt
@@ -4,7 +4,9 @@ import com.autonomousapps.internal.utils.mapToSet
 import com.autonomousapps.model.Coordinates
 import com.autonomousapps.model.declaration.Bucket
 import com.autonomousapps.model.declaration.Variant
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
 internal data class DependencyTraceReport(
   val buildType: String?,
   val flavor: String?,
@@ -13,12 +15,14 @@ internal data class DependencyTraceReport(
   val annotationProcessors: Set<Trace>
 ) {
 
+  @JsonClass(generateAdapter = true)
   data class Trace(
     val coordinates: Coordinates,
     val bucket: Bucket,
     val reasons: Set<Reason> = emptySet()
   )
 
+  @JsonClass(generateAdapter = false)
   enum class Kind {
     DEPENDENCY,
     ANNOTATION_PROCESSOR;

--- a/src/main/kotlin/com/autonomousapps/model/intermediates/Reason.kt
+++ b/src/main/kotlin/com/autonomousapps/model/intermediates/Reason.kt
@@ -23,13 +23,13 @@ internal sealed class Reason(open val reason: String) {
   }
 
   @TypeLabel("abi")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class Abi(override val reason: String) : Reason(reason) {
     override val configurationName: String = "api"
   }
 
   @TypeLabel("proc")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class AnnotationProcessor(override val reason: String) : Reason(reason) {
     override val configurationName: String
       get() = throw OperationNotSupportedException("Annotation processor configuration name is indeterminate")
@@ -41,79 +41,79 @@ internal sealed class Reason(open val reason: String) {
   }
 
   @TypeLabel("compile_time_anno")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class CompileTimeAnnotations(override val reason: String) : Reason(reason) {
     override val configurationName: String = "compileOnly"
   }
 
   @TypeLabel("constant")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class Constant(override val reason: String) : Reason(reason) {
     override val configurationName: String = "implementation"
   }
 
   @TypeLabel("impl")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class Impl(override val reason: String) : Reason(reason) {
     override val configurationName: String = "implementation"
   }
 
   @TypeLabel("imported")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class Imported(override val reason: String) : Reason(reason) {
     override val configurationName: String = "implementation"
   }
 
   @TypeLabel("inline")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class Inline(override val reason: String) : Reason(reason) {
     override val configurationName: String = "implementation"
   }
 
   @TypeLabel("lint")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class LintJar(override val reason: String) : Reason(reason) {
     override val configurationName: String = "implementation"
   }
 
   @TypeLabel("native")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class NativeLib(override val reason: String) : Reason(reason) {
     override val configurationName: String = "runtimeOnly"
   }
 
   @TypeLabel("res_by_src")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class ResBySrc(override val reason: String) : Reason(reason) {
     override val configurationName: String = "implementation"
   }
 
   @TypeLabel("res_by_res")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class ResByRes(override val reason: String) : Reason(reason) {
     override val configurationName: String = "implementation"
   }
 
   @TypeLabel("asset")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class Asset(override val reason: String) : Reason(reason) {
     override val configurationName: String = "runtimeOnly"
   }
 
   @TypeLabel("runtime_android")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class RuntimeAndroid(override val reason: String) : Reason(reason) {
     override val configurationName: String = "runtimeOnly"
   }
 
   @TypeLabel("security_provider")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class SecurityProvider(override val reason: String) : Reason(reason) {
     override val configurationName: String = "runtimeOnly"
   }
 
   @TypeLabel("service_loader")
-  @JsonClass(generateAdapter = false)
+  @JsonClass(generateAdapter = true)
   data class ServiceLoader(override val reason: String) : Reason(reason) {
     override val configurationName: String = "runtimeOnly"
   }

--- a/src/main/kotlin/com/autonomousapps/model/intermediates/Reason.kt
+++ b/src/main/kotlin/com/autonomousapps/model/intermediates/Reason.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonClass
 import dev.zacsweers.moshix.sealed.annotations.TypeLabel
 import javax.naming.OperationNotSupportedException
 
-@JsonClass(generateAdapter = false, generator = "sealed:type")
+@JsonClass(generateAdapter = true, generator = "sealed:type")
 internal sealed class Reason(open val reason: String) {
 
   abstract val configurationName: String

--- a/src/main/kotlin/com/autonomousapps/model/intermediates/Usage.kt
+++ b/src/main/kotlin/com/autonomousapps/model/intermediates/Usage.kt
@@ -4,7 +4,9 @@ import com.autonomousapps.model.Advice
 import com.autonomousapps.model.Coordinates
 import com.autonomousapps.model.declaration.Bucket
 import com.autonomousapps.model.declaration.Variant
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
 internal data class Usage(
   val buildType: String?,
   val flavor: String?,

--- a/src/main/kotlin/com/autonomousapps/model/intermediates/consumer.kt
+++ b/src/main/kotlin/com/autonomousapps/model/intermediates/consumer.kt
@@ -1,7 +1,9 @@
 package com.autonomousapps.model.intermediates
 
 import com.autonomousapps.model.CodeSource
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
 /** A single source file (e.g., `.java`, `.kt`) in this project. */
 internal data class ExplodingSourceCode(
   val relativePath: String,
@@ -13,6 +15,7 @@ internal data class ExplodingSourceCode(
   override fun compareTo(other: ExplodingSourceCode): Int = relativePath.compareTo(other.relativePath)
 }
 
+@JsonClass(generateAdapter = true)
 internal data class ExplodingBytecode(
   val relativePath: String,
   val className: String,
@@ -21,6 +24,7 @@ internal data class ExplodingBytecode(
   val usedClasses: Set<String>
 )
 
+@JsonClass(generateAdapter = true)
 internal data class ExplodingAbi(
   val className: String,
   val sourceFile: String?,

--- a/src/main/kotlin/com/autonomousapps/model/intermediates/producers.kt
+++ b/src/main/kotlin/com/autonomousapps/model/intermediates/producers.kt
@@ -3,6 +3,7 @@ package com.autonomousapps.model.intermediates
 import com.autonomousapps.internal.utils.ifNotEmpty
 import com.autonomousapps.internal.utils.toCoordinates
 import com.autonomousapps.model.*
+import com.squareup.moshi.JsonClass
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 
 internal interface DependencyView<T> : Comparable<T> where T : DependencyView<T> {
@@ -20,6 +21,7 @@ internal interface DependencyView<T> : Comparable<T> where T : DependencyView<T>
  * nb: Deliberately does not implement [DependencyView]. For various reasons, this information gets embedded in
  * [ExplodedJar], which is the preferred access point for deeper analysis.
  */
+@JsonClass(generateAdapter = true)
 internal data class AndroidLinterDependency(
   val coordinates: Coordinates,
   val lintRegistry: String

--- a/src/main/kotlin/com/autonomousapps/model/intermediates/producers.kt
+++ b/src/main/kotlin/com/autonomousapps/model/intermediates/producers.kt
@@ -30,6 +30,7 @@ internal data class AndroidLinterDependency(
 }
 
 /** Metadata from an Android manifest. */
+@JsonClass(generateAdapter = true)
 internal data class AndroidManifestDependency(
   override val coordinates: Coordinates,
   /** The package name per `<manifest package="...">`. */
@@ -52,6 +53,7 @@ internal data class AndroidManifestDependency(
 }
 
 /** A dependency that includes Android assets (e.g., src/main/assets). A runtime dependency. */
+@JsonClass(generateAdapter = true)
 internal data class AndroidAssetDependency(
   override val coordinates: Coordinates,
   val assets: List<String>
@@ -60,6 +62,7 @@ internal data class AndroidAssetDependency(
   override fun toCapabilities(): List<Capability> = listOf(AndroidAssetCapability(assets))
 }
 
+@JsonClass(generateAdapter = true)
 internal data class AndroidResDependency(
   override val coordinates: Coordinates,
   /** An import that indicates a possible use of an Android resource from this dependency. */
@@ -70,6 +73,7 @@ internal data class AndroidResDependency(
   override fun toCapabilities(): List<Capability> = listOf(AndroidResCapability(import, lines))
 }
 
+@JsonClass(generateAdapter = true)
 internal data class AnnotationProcessorDependency(
   override val coordinates: Coordinates,
   val processor: String,
@@ -90,6 +94,7 @@ internal data class AnnotationProcessorDependency(
   )
 }
 
+@JsonClass(generateAdapter = true)
 internal data class InlineMemberDependency(
   override val coordinates: Coordinates,
   val inlineMembers: Set<InlineMemberCapability.InlineMember>
@@ -98,6 +103,7 @@ internal data class InlineMemberDependency(
   override fun toCapabilities(): List<Capability> = listOf(InlineMemberCapability(inlineMembers))
 }
 
+@JsonClass(generateAdapter = true)
 internal data class NativeLibDependency(
   override val coordinates: Coordinates,
   val fileNames: Set<String>
@@ -106,6 +112,7 @@ internal data class NativeLibDependency(
   override fun toCapabilities(): List<Capability> = listOf(NativeLibCapability(fileNames))
 }
 
+@JsonClass(generateAdapter = true)
 internal data class ServiceLoaderDependency(
   override val coordinates: Coordinates,
   val providerFile: String,
@@ -129,6 +136,7 @@ internal data class ServiceLoaderDependency(
  * A library or project, along with the set of classes declared by, and other information contained within, this
  * exploded jar. This is the serialized form of [ExplodingJar].
  */
+@JsonClass(generateAdapter = true)
 internal data class ExplodedJar(
 
   override val coordinates: Coordinates,


### PR DESCRIPTION
Faster runtime performance plus it should resolve #667 along the way.

Couldn't use moshi-ir due to the low kotlin version here (it only supports Kotlin 1.6+) and lucked out that the first stable version of KSP happened to be the version of Kotlin this uses.