### PR TITLE
Treat KMP modules as implicit bundles.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/BundleSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/BundleSpec.groovy
@@ -1,5 +1,6 @@
 package com.autonomousapps.jvm
 
+import com.autonomousapps.jvm.projects.BundleKmpProject
 import com.autonomousapps.jvm.projects.BundleProject
 
 import static com.autonomousapps.utils.Runner.build
@@ -10,6 +11,21 @@ final class BundleSpec extends AbstractJvmSpec {
   def "can define entry point to bundle (#gradleVersion)"() {
     given:
     def project = new BundleProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualProjectAdvice()).containsExactlyElementsIn(project.expectedProjectAdvice)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "kmp deps form implicit bundles (#gradleVersion)"() {
+    given:
+    def project = new BundleKmpProject()
     gradleProject = project.gradleProject
 
     when:

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/BundleKmpProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/BundleKmpProject.groovy
@@ -1,0 +1,65 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.emptyProjectAdviceFor
+import static com.autonomousapps.kit.Dependency.clikt
+
+final class BundleKmpProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  BundleKmpProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('consumer') { c ->
+      c.sources = sourcesConsumer
+      c.withBuildScript { bs ->
+        bs.plugins = [
+          Plugin.kotlinPluginNoVersion,
+          Plugin.applicationPlugin
+        ]
+        bs.dependencies = [
+          clikt('implementation')
+        ]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private sourcesConsumer = [
+    new Source(
+      SourceType.KOTLIN, "Consumer", "com/example/consumer",
+      """\
+        package com.example.consumer
+        
+        import com.github.ajalt.clikt.core.CliktCommand
+        
+        class Consumer : CliktCommand() {
+          override fun run() {
+          }
+        }
+      """.stripIndent()
+    )
+  ]
+
+  Set<ProjectAdvice> actualProjectAdvice() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedProjectAdvice = [
+    emptyProjectAdviceFor(':consumer')
+  ]
+}

--- a/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
@@ -110,6 +110,12 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
               }?.let { bundles[parentNode] = it }
             }
           }
+
+          // Implicit KMP bundles (inverse form compared to ktx)
+          val jvmCandidate = parentNode.identifier + "-jvm"
+          view.graph.children(parentNode)
+            .find { it.identifier == jvmCandidate }
+            ?.let { bundles[parentNode] = it }
         }
       }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
@@ -189,6 +189,13 @@ private class GraphVisitor(project: ProjectVariant) : GraphViewVisitor {
       }
     }
 
+    // TODO KMP dependencies only contain metadata (pom/module files). This is good evidence of a facade and could be
+    //  used for smarter detection of same.
+    // An example are KMP facades that resolve to -jvm artifacts
+    if (dependency.capabilities.isEmpty()) {
+      isUnusedCandidate = true
+    }
+
     // this is not mutually exclusive with other buckets. E.g., Lombok is both an annotation processor and a "normal"
     // dependency. See LombokSpec.
     if (isAnnotationProcessorCandidate) {

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
@@ -89,6 +89,11 @@ class Dependency @JvmOverloads constructor(
     }
 
     @JvmStatic
+    fun clikt(configuration: String): Dependency {
+      return Dependency(configuration, "com.github.ajalt.clikt:clikt:3.4.2")
+    }
+
+    @JvmStatic
     fun conscryptUber(configuration: String): Dependency {
       return Dependency(configuration, "org.conscrypt:conscrypt-openjdk-uber:2.4.0")
     }


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/659.