### PR TITLE
Specifically opt out of configuration cache support.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
@@ -17,6 +17,7 @@ abstract class AbstractFunctionalSpec extends Specification {
   protected static final GRADLE_7_2 = GradleVersion.version('7.2')
   protected static final GRADLE_7_3 = GradleVersion.version('7.3.3')
   protected static final GRADLE_7_4 = GradleVersion.version('7.4.2')
+  protected static final GRADLE_7_5 = GradleVersion.version('7.5-rc-1')
 
   // For faster CI times, we only test min + max. Testing all would be preferable, but we don't have till the heat death
   // of the universe to wait.
@@ -26,6 +27,7 @@ abstract class AbstractFunctionalSpec extends Specification {
     //    GRADLE_7_2,
     //    GRADLE_7_3,
     GRADLE_7_4,
+    GRADLE_7_5,
   ]
 
   protected GradleProject gradleProject = null

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -48,8 +48,16 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
 
   @SuppressWarnings(["GroovyAssignabilityCheck", "GrUnresolvedAccess"])
   protected static List<List<Object>> gradleAgpMatrix(AgpVersion minAgpVersion = AgpVersion.AGP_MIN) {
+    return gradleAgpMatrix(gradleVersions(), minAgpVersion)
+  }
+
+  @SuppressWarnings(["GroovyAssignabilityCheck", "GrUnresolvedAccess"])
+  protected static List<List<Object>> gradleAgpMatrix(
+    List<GradleVersion> gradleVersions,
+    AgpVersion minAgpVersion = AgpVersion.AGP_MIN
+  ) {
     // Cartesian product
-    def matrix = Arrays.asList(gradleVersions(), agpVersions(minAgpVersion)).combinations()
+    def matrix = Arrays.asList(gradleVersions, agpVersions(minAgpVersion)).combinations()
 
     // Strip out incompatible combinations
     matrix.removeAll { m ->

--- a/src/functionalTest/groovy/com/autonomousapps/android/ConfigurationCacheSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/ConfigurationCacheSpec.groovy
@@ -1,0 +1,55 @@
+package com.autonomousapps.android
+
+import com.autonomousapps.android.projects.AndroidAssetsProject
+import org.gradle.util.GradleVersion
+
+import static com.autonomousapps.kit.truth.BuildTaskSubject.buildTasks
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertAbout
+import static com.google.common.truth.Truth.assertThat
+
+final class ConfigurationCacheSpec extends AbstractAndroidSpec {
+
+  def "buildHealth succeeds when configuration-cache flag is used (#gradleVersion AGP #agpVersion)"() {
+    given: 'A complicated Android project'
+    def project = new AndroidAssetsProject(agpVersion as String)
+    gradleProject = project.gradleProject
+
+    when: 'We build the first time'
+    def result = build(
+      gradleVersion as GradleVersion,
+      gradleProject.rootDir,
+      'buildHealth', '--configuration-cache'
+    )
+
+    then: 'buildHealth produces expected results'
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    and: 'generateBuildHealth succeeded'
+    assertAbout(buildTasks()).that(result.task(':generateBuildHealth')).succeeded()
+
+    and: 'This plugin is not yet compatible with the configuration cache'
+    assertThat(result.output).contains('0 problems were found storing the configuration cache.')
+    assertThat(result.output).contains('Configuration cache entry discarded.')
+
+    when: 'We build again'
+    result = build(
+      gradleVersion as GradleVersion,
+      gradleProject.rootDir,
+      'buildHealth', '--configuration-cache'
+    )
+
+    then: 'buildHealth produces expected results'
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    and: 'generateBuildHealth was up-to-date'
+    assertAbout(buildTasks()).that(result.task(':generateBuildHealth')).upToDate()
+
+    and: 'This plugin is not yet compatible with the configuration cache'
+    assertThat(result.output).contains('0 problems were found storing the configuration cache.')
+    assertThat(result.output).contains('Configuration cache entry discarded.')
+
+    where: 'Min support for this is Gradle 7.5'
+    [gradleVersion, agpVersion] << gradleAgpMatrix([GRADLE_7_5])
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
@@ -1,0 +1,9 @@
+package com.autonomousapps.internal
+
+import org.gradle.util.GradleVersion
+
+internal object GradleVersions {
+  val current: GradleVersion = GradleVersion.current()
+  val gradle74: GradleVersion = GradleVersion.version("7.4")
+  val isAtLeastGradle74: Boolean = current >= gradle74
+}

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
@@ -2,6 +2,7 @@ package com.autonomousapps.tasks
 
 import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
 import com.autonomousapps.internal.ANNOTATION_PROCESSOR_PATH
+import com.autonomousapps.internal.unsafeLazy
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.toJson
 import com.autonomousapps.internal.utils.toPrettyString
@@ -14,12 +15,13 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Optional
 import java.io.BufferedReader
 import java.io.File
 import java.io.Writer
 import java.net.URL
 import java.net.URLClassLoader
-import java.util.Locale
+import java.util.*
 import java.util.zip.ZipFile
 import javax.annotation.processing.Filer
 import javax.annotation.processing.Messager
@@ -84,7 +86,8 @@ abstract class FindDeclaredProcsTask : DefaultTask() {
   @get:Internal
   abstract val inMemoryCacheProvider: Property<InMemoryCache>
 
-  private val inMemoryCache by lazy { inMemoryCacheProvider.get() }
+  @delegate:Transient
+  private val inMemoryCache by unsafeLazy { inMemoryCacheProvider.get() }
 
   @TaskAction fun action() {
     val outputFile = output.getAndDelete()

--- a/src/main/kotlin/com/autonomousapps/tasks/GenerateBuildHealthTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GenerateBuildHealthTask.kt
@@ -1,6 +1,7 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
+import com.autonomousapps.internal.GradleVersions
 import com.autonomousapps.internal.advice.DslKind
 import com.autonomousapps.internal.advice.ProjectHealthConsoleReportBuilder
 import com.autonomousapps.internal.utils.fromJson
@@ -21,8 +22,14 @@ abstract class GenerateBuildHealthTask : DefaultTask() {
   init {
     group = TASK_GROUP_DEP_INTERNAL
     description = "Generates json report for build health"
+
+    if (GradleVersions.isAtLeastGradle74) {
+      @Suppress("LeakingThis")
+      notCompatibleWithConfigurationCache("Cannot serialize Configurations")
+    }
   }
 
+  @Transient
   @get:PathSensitive(PathSensitivity.RELATIVE)
   @get:InputFiles
   lateinit var projectHealthReports: Configuration

--- a/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
@@ -1,13 +1,10 @@
 package com.autonomousapps.tasks
 
 import com.autonomousapps.TASK_GROUP_DEP_INTERNAL
+import com.autonomousapps.internal.GradleVersions
 import com.autonomousapps.internal.artifactsFor
 import com.autonomousapps.internal.isJavaPlatform
-import com.autonomousapps.internal.utils.getAndDelete
-import com.autonomousapps.internal.utils.mapNotNullToSet
-import com.autonomousapps.internal.utils.rootCoordinates
-import com.autonomousapps.internal.utils.toCoordinates
-import com.autonomousapps.internal.utils.toJson
+import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.Coordinates
 import com.autonomousapps.model.DependencyGraphView
 import com.autonomousapps.model.ProjectCoordinates
@@ -22,14 +19,7 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.support.appendReproducibleNewLine
 
 @CacheableTask
@@ -38,8 +28,14 @@ abstract class GraphViewTask : DefaultTask() {
   init {
     group = TASK_GROUP_DEP_INTERNAL
     description = "Constructs a variant-specific view of this project's dependency graph"
+
+    if (GradleVersions.isAtLeastGradle74) {
+      @Suppress("LeakingThis")
+      notCompatibleWithConfigurationCache("Cannot serialize Configurations")
+    }
   }
 
+  @Transient
   private lateinit var compileClasspath: Configuration
 
   fun setCompileClasspath(compileClasspath: Configuration) {


### PR DESCRIPTION
This will prevent users' builds from breaking when they use configuration caching.

https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/306

I will consider supporting configuration cache sometime after Gradle 7.5 is GA.