### PR TITLE
Support Components with multiple Jar files

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ComponentWithMultipleArtifactsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ComponentWithMultipleArtifactsSpec.groovy
@@ -1,0 +1,24 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.JarTransformingProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class ComponentWithMultipleArtifactsSpec extends AbstractJvmSpec {
+
+  def "one component can have multiple Jars (#gradleVersion)"() {
+    given:
+    def project = new JarTransformingProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ComponentWithMultipleArtifactsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ComponentWithMultipleArtifactsSpec.groovy
@@ -1,6 +1,7 @@
 package com.autonomousapps.jvm
 
 import com.autonomousapps.jvm.projects.JarTransformingProject
+import com.autonomousapps.jvm.projects.MultipleJarsProject
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
@@ -8,6 +9,21 @@ import static com.google.common.truth.Truth.assertThat
 final class ComponentWithMultipleArtifactsSpec extends AbstractJvmSpec {
 
   def "one component can have multiple Jars (#gradleVersion)"() {
+    given:
+    def project = new MultipleJarsProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "one component can have multiple Jars produced by a transform (#gradleVersion)"() {
     given:
     def project = new JarTransformingProject()
     gradleProject = project.gradleProject

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
@@ -97,6 +97,13 @@ final class FeatureVariantTestProject extends AbstractProject {
   }
 
   // Note: 'producer-extra-feature.jar' is considered part of the 'main variant' of ':producer', which is not correct.
+  // This is due to the following:
+  // - PhysicalArtifact.coordinates only knows about component IDs, 'Module GA' or 'Project Name', but not capabilities.
+  //   This should probably be improved by adding the Capabilities GA coordinates to the 'Coordinates' data classes.
+  // - Right now, the plugin thinks that the 'producer-extra-feature.jar' artifact belongs to
+  //   'ProjectCoordinates(identifier=:producer)'. It finds classes in that Jar that are used.
+  //   But there is no dependency (without requires capabilities) to the producer project.
+  //   It gives the advice to add it.
   private final Set<Advice> expectedConsumerAdvice = [
     Advice.ofAdd(projectCoordinates(':producer'), 'implementation'),
   ]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/JarTransformingProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/JarTransformingProject.groovy
@@ -1,0 +1,113 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.Dependency.commonsCollections
+
+final class JarTransformingProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  JarTransformingProject() {
+    this.gradleProject = build()
+  }
+
+  private def commonsCollections = commonsCollections("api")
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('proj') { s ->
+      s.sources = PROJ_SOURCES
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.sourceSets = ['integrationTest']
+        bs.dependencies = [
+          commonsCollections,
+        ]
+        bs.additions = '''
+          // We do some post processing of Jars on the classpath using a transform (split one Jar into multiple).
+          // A similar situation can also be created by publishing a component that has multiple Jars
+          // using Gradle Metadata to express that. 
+          def artifactType = Attribute.of("artifactType", String)
+          def split = Attribute.of("split", Boolean)
+          dependencies.attributesSchema { attribute(split) }
+          dependencies.artifactTypes.jar.attributes.attribute(split, false)
+          dependencies.registerTransform(SplitJarTransform) {
+            from.attribute(split, false).attribute(artifactType, "jar")
+            to.attribute(split, true).attribute(artifactType, "jar")
+          }
+          configurations.compileClasspath.attributes.attribute(split, false)
+          configurations.runtimeClasspath.attributes.attribute(split, false)
+          
+          afterEvaluate {
+            tasks.named("artifactsReportMain") {
+              // also use our custom view as input for the artifacts report task
+              compileClasspath = configurations.compileClasspath.incoming.artifactView {
+                attributes.attribute(artifactType, "jar")
+                attributes.attribute(split, true)
+                lenient(true)
+              }.artifacts
+            }
+          }
+          
+          import org.gradle.api.artifacts.transform.*
+          
+          abstract class SplitJarTransform implements TransformAction<TransformParameters.None> {
+            @InputArtifact
+            @PathSensitive(PathSensitivity.NAME_ONLY)
+            abstract Provider<FileSystemLocation> getInputJar()
+            
+            @Override
+            void transform(TransformOutputs outputs) {
+              def jarFile = inputJar.get().asFile
+              def splitOutJar = outputs.file("split-out-${jarFile.name}") // add the empty jar file first
+              
+              def os = new java.util.jar.JarOutputStream(new FileOutputStream(splitOutJar)) // empty for test case
+              os.close()
+              
+              outputs.file(jarFile) // add the jar file with the classes last
+            }
+          }
+        '''
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private List<Source> PROJ_SOURCES = [
+    new Source(
+      SourceType.JAVA, "Example", "com/example",
+      """\
+        package com.example;
+        
+        import org.apache.commons.collections4.map.HashedMap;
+        
+        public class Example {
+          private HashedMap<String, String> map;
+        }
+      """.stripIndent()
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> projAdvice = [
+    Advice.ofChange(moduleCoordinates(commonsCollections), commonsCollections.configuration, 'implementation')
+  ]
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':proj', projAdvice)
+  ]
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/MultipleJarsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/MultipleJarsProject.groovy
@@ -1,0 +1,95 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.Dependency.project
+
+final class MultipleJarsProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  MultipleJarsProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('producer') { s ->
+      s.sources = producerSources
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.additions = '''
+          def extraJar = tasks.register("extraJar", Jar) {
+            archiveClassifier = 'extra'
+          }
+          configurations.apiElements.outgoing {
+            // make sure the extraJar (which is empty) turns up first
+            artifacts.clear()
+            artifact(extraJar)
+            artifact(tasks.jar)
+          }
+        '''
+      }
+    }
+    builder.withSubproject('consumer') { s ->
+      s.sources = consumerSources
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.dependencies = [
+          project('implementation', ':producer')
+        ]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private producerSources = [
+    new Source(
+      SourceType.JAVA, "ExampleProducer", "com/example/producer",
+      """\
+        package com.example.producer;
+        
+        public class ExampleProducer {
+        }
+      """.stripIndent()
+    )
+  ]
+
+  private consumerSources = [
+    new Source(
+      SourceType.JAVA, "ExampleConsumer", "com/example/consumer",
+      """\
+        package com.example.consumer;
+        
+        import com.example.producer.ExampleProducer;
+        
+        public class ExampleConsumer {
+          public ExampleProducer producer;
+        }
+      """.stripIndent()
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> producerProjAdvice = [
+    Advice.ofChange(projectCoordinates(':producer'), 'implementation', 'api')
+  ]
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':consumer', producerProjAdvice),
+    emptyProjectAdviceFor(':producer')
+  ]
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject.groovy
@@ -94,16 +94,10 @@ final class TestFixturesTestProject extends AbstractProject {
     return actualProjectAdvice(gradleProject)
   }
 
-  // Note: 'producer-test-fixtures.jar' is considered part of the 'main variant' of ':producer', which is not correct.
-  // See comment in 'FeatureVariantTestProject' for more details.
-  private final Set<Advice> expectedConsumerAdvice = [
-    Advice.ofAdd(projectCoordinates(':producer'), 'testImplementation'),
-  ]
-
   final Set<ProjectAdvice> expectedBuildHealth = [
     // Not yet implemented:
     // missing advice to move dependency 'consumer' -> 'producer-testFixtures' to implementation
-    projectAdviceForDependencies(':consumer', expectedConsumerAdvice),
+    emptyProjectAdviceFor(':consumer'),
     // Not yet implemented:
     // missing advice to move dependency 'producer-testFixtures' -> 'commons-collections4' to testFixturesImplementation
     emptyProjectAdviceFor(':producer')

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject.groovy
@@ -95,6 +95,7 @@ final class TestFixturesTestProject extends AbstractProject {
   }
 
   // Note: 'producer-test-fixtures.jar' is considered part of the 'main variant' of ':producer', which is not correct.
+  // See comment in 'FeatureVariantTestProject' for more details.
   private final Set<Advice> expectedConsumerAdvice = [
     Advice.ofAdd(projectCoordinates(':producer'), 'testImplementation'),
   ]

--- a/src/main/kotlin/com/autonomousapps/model/Dependency.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Dependency.kt
@@ -8,9 +8,9 @@ import java.io.File
 sealed class Dependency(
   open val coordinates: Coordinates,
   open val capabilities: Map<String, Capability>,
-  // Nullable because we don't get file for annotation processor dependencies.
+  // Can be empty because we don't get file for annotation processor dependencies.
   // This property is also unused and was only added speculatively, so maybe it doesn't matter
-  open val file: File?
+  open val files: List<File>
 ) : Comparable<Dependency> {
   override fun compareTo(other: Dependency): Int = coordinates.compareTo(other.coordinates)
 }
@@ -21,29 +21,29 @@ data class ProjectDependency(
   override val coordinates: ProjectCoordinates,
   /** Map of [Capability] canonicalName to the capability. */
   override val capabilities: Map<String, Capability>,
-  override val file: File?
-) : Dependency(coordinates, capabilities, file)
+  override val files: List<File>
+) : Dependency(coordinates, capabilities, files)
 
 @TypeLabel("module")
 @JsonClass(generateAdapter = true)
 data class ModuleDependency(
   override val coordinates: ModuleCoordinates,
   override val capabilities: Map<String, Capability>,
-  override val file: File?
-) : Dependency(coordinates, capabilities, file)
+  override val files: List<File>
+) : Dependency(coordinates, capabilities, files)
 
 @TypeLabel("flat")
 @JsonClass(generateAdapter = true)
 data class FlatDependency(
   override val coordinates: FlatCoordinates,
   override val capabilities: Map<String, Capability>,
-  override val file: File?
-) : Dependency(coordinates, capabilities, file)
+  override val files: List<File>
+) : Dependency(coordinates, capabilities, files)
 
 @TypeLabel("included_build")
 @JsonClass(generateAdapter = true)
 data class IncludedBuildDependency(
   override val coordinates: IncludedBuildCoordinates,
   override val capabilities: Map<String, Capability>,
-  override val file: File?
-) : Dependency(coordinates, capabilities, file)
+  override val files: List<File>
+) : Dependency(coordinates, capabilities, files)

--- a/src/main/kotlin/com/autonomousapps/model/PhysicalArtifact.kt
+++ b/src/main/kotlin/com/autonomousapps/model/PhysicalArtifact.kt
@@ -2,7 +2,6 @@ package com.autonomousapps.model
 
 import com.autonomousapps.internal.utils.toCoordinates
 import com.squareup.moshi.JsonClass
-import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import java.io.File
 
@@ -14,7 +13,9 @@ internal data class PhysicalArtifact(
 ) : Comparable<PhysicalArtifact> {
 
   override fun compareTo(other: PhysicalArtifact): Int {
-    return coordinates.compareTo(other.coordinates)
+    return coordinates.compareTo(other.coordinates).let {
+      if (it == 0) file.compareTo(other.file) else it
+    }
   }
 
   companion object {

--- a/src/main/kotlin/com/autonomousapps/model/intermediates/producers.kt
+++ b/src/main/kotlin/com/autonomousapps/model/intermediates/producers.kt
@@ -5,6 +5,7 @@ import com.autonomousapps.internal.utils.toCoordinates
 import com.autonomousapps.model.*
 import com.squareup.moshi.JsonClass
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
+import java.io.File
 
 internal interface DependencyView<T> : Comparable<T> where T : DependencyView<T> {
   val coordinates: Coordinates
@@ -140,6 +141,7 @@ internal data class ServiceLoaderDependency(
 internal data class ExplodedJar(
 
   override val coordinates: Coordinates,
+  val jarFile: File,
 
   /**
    * True if this dependency contains only annotation that are only needed at compile-time (`CLASS`
@@ -180,6 +182,7 @@ internal data class ExplodedJar(
     exploding: ExplodingJar
   ) : this(
     coordinates = artifact.coordinates,
+    jarFile = artifact.file,
     isCompileOnlyAnnotations = exploding.isCompileOnlyCandidate,
     securityProviders = exploding.securityProviders,
     androidLintRegistry = exploding.androidLintRegistry,
@@ -188,6 +191,12 @@ internal data class ExplodedJar(
     constantFields = exploding.constants,
     ktFiles = exploding.ktFiles
   )
+
+  override fun compareTo(other: ExplodedJar): Int {
+    return coordinates.compareTo(other.coordinates).let {
+      if (it == 0) jarFile.compareTo(other.jarFile) else it
+    }
+  }
 
   init {
     if (isLintJar && androidLintRegistry == null) {

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
@@ -144,7 +144,7 @@ abstract class SynthesizeDependenciesTask @Inject constructor(
       physicalArtifacts.forEach { artifact ->
         builders.merge(
           artifact.coordinates,
-          DependencyBuilder(artifact.coordinates).apply { file = artifact.file },
+          DependencyBuilder(artifact.coordinates).apply { files.add(artifact.file) },
           DependencyBuilder::concat
         )
       }
@@ -190,10 +190,10 @@ abstract class SynthesizeDependenciesTask @Inject constructor(
   private class DependencyBuilder(val coordinates: Coordinates) {
 
     val capabilities: MutableList<Capability> = mutableListOf()
-    var file: File? = null
+    val files: MutableList<File> = mutableListOf()
 
     fun concat(other: DependencyBuilder): DependencyBuilder {
-      other.file?.let { file = it }
+      files.addAll(other.files)
       capabilities.addAll(other.capabilities)
       return this
     }
@@ -201,10 +201,10 @@ abstract class SynthesizeDependenciesTask @Inject constructor(
     fun build(): Dependency {
       val capabilities: Map<String, Capability> = capabilities.associateBy { it.javaClass.canonicalName }
       return when (coordinates) {
-        is ProjectCoordinates -> ProjectDependency(coordinates, capabilities, file)
-        is ModuleCoordinates -> ModuleDependency(coordinates, capabilities, file)
-        is FlatCoordinates -> FlatDependency(coordinates, capabilities, file)
-        is IncludedBuildCoordinates -> IncludedBuildDependency(coordinates, capabilities, file)
+        is ProjectCoordinates -> ProjectDependency(coordinates, capabilities, files)
+        is ModuleCoordinates -> ModuleDependency(coordinates, capabilities, files)
+        is FlatCoordinates -> FlatDependency(coordinates, capabilities, files)
+        is IncludedBuildCoordinates -> IncludedBuildDependency(coordinates, capabilities, files)
       }
     }
   }

--- a/testkit/build.gradle.kts
+++ b/testkit/build.gradle.kts
@@ -1,14 +1,8 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
   kotlin("jvm")
   id("org.jetbrains.dokka") version "0.10.0"
   `maven-publish`
   signing
-}
-
-repositories {
-  mavenCentral()
 }
 
 group = "com.autonomousapps"


### PR DESCRIPTION
In Gradle, one component - i.e. one logical component identified by GA coordinates or Gradle project path - can have multiple Jars. So far, the plugin would silently ignore all Jars except for the first it finds. With this fix, all Jars are considered part of the component during the analysis.

This used to work in older versions; tested with 0.71.0