### PR TITLE
Detect KMP usages more vigorously.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/BundleSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/BundleSpec.groovy
@@ -1,6 +1,7 @@
 package com.autonomousapps.jvm
 
 import com.autonomousapps.jvm.projects.BundleKmpProject
+import com.autonomousapps.jvm.projects.BundleKmpProject2
 import com.autonomousapps.jvm.projects.BundleProject
 
 import static com.autonomousapps.utils.Runner.build
@@ -23,7 +24,7 @@ final class BundleSpec extends AbstractJvmSpec {
     gradleVersion << gradleVersions()
   }
 
-  def "kmp deps form implicit bundles (#gradleVersion)"() {
+  def "kmp deps form implicit bundles when kmp dep is declared (#gradleVersion)"() {
     given:
     def project = new BundleKmpProject()
     gradleProject = project.gradleProject
@@ -36,5 +37,27 @@ final class BundleSpec extends AbstractJvmSpec {
 
     where:
     gradleVersion << gradleVersions()
+  }
+
+  def "kmp deps form implicit bundles when none are declared (#gradleVersion)"() {
+    given:
+    def project = new BundleKmpProject2()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualProjectAdvice()).containsExactlyElementsIn(project.expectedProjectAdvice)
+
+    // TODO reason needs to be updated to show that the -jvm variant is used
+    when:
+    build(gradleVersion, gradleProject.rootDir, ':consumer:reason', '--id', 'com.squareup.okio:okio')
+
+    then:
+    true
+
+    where:
+    gradleVersion << [gradleVersions().last()]
   }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/BundleKmpProject2.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/BundleKmpProject2.groovy
@@ -1,0 +1,101 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.Dependency.okio3
+import static com.autonomousapps.kit.Dependency.project
+
+final class BundleKmpProject2 extends AbstractProject {
+
+  private final kotlinLibrary = [Plugin.kotlinPluginNoVersion]
+  final GradleProject gradleProject
+
+  BundleKmpProject2() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('consumer') { s ->
+      s.sources = sourcesConsumer
+      s.withBuildScript { bs ->
+        bs.plugins = kotlinLibrary
+        bs.dependencies = [
+          // gets okio-jvm from this
+          project('api', ':producer')
+        ]
+      }
+    }
+    builder.withSubproject('producer') { s ->
+      s.sources = sourcesProducer
+      s.withBuildScript { bs ->
+        bs.plugins = kotlinLibrary
+        bs.dependencies = [okio3('api')]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private sourcesConsumer = [
+    new Source(
+      SourceType.KOTLIN, 'Consumer', 'com/example/consumer',
+      """\
+        package com.example.consumer
+        
+        import okio.ByteString
+        
+        interface Consumer {
+          fun string(): ByteString
+        }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.KOTLIN, 'ABC', 'com/example/consumer',
+      """\
+        package com.example.consumer
+        
+        import com.example.producer.Producer
+        
+        abstract class ABC : Producer
+      """.stripIndent()
+    )
+  ]
+
+  private sourcesProducer = [
+    new Source(
+      SourceType.KOTLIN, 'Producer', 'com/example/producer',
+      """\
+        package com.example.producer
+        
+        import okio.ByteString
+        
+        interface Producer {
+          fun string(): ByteString
+        }
+      """.stripIndent()
+    )
+  ]
+
+  Set<ProjectAdvice> actualProjectAdvice() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> projAdvice = [
+    Advice.ofAdd(moduleCoordinates('com.squareup.okio:okio:3.0.0'), 'api')
+  ]
+
+  final Set<ProjectAdvice> expectedProjectAdvice = [
+    projectAdviceForDependencies(':consumer', projAdvice),
+    emptyProjectAdviceFor(':producer')
+  ]
+}

--- a/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
@@ -43,6 +43,13 @@ sealed class Coordinates(
         else FlatCoordinates(raw)
       }
     }
+
+    internal fun Coordinates.copy(identifier: String): Coordinates = when (this) {
+      is ProjectCoordinates -> copy(identifier = identifier)
+      is ModuleCoordinates -> copy(identifier = identifier)
+      is FlatCoordinates -> copy(identifier = identifier)
+      is IncludedBuildCoordinates -> copy(identifier = identifier)
+    }
   }
 }
 

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
@@ -134,6 +134,11 @@ class Dependency @JvmOverloads constructor(
     }
 
     @JvmStatic
+    fun okio3(configuration: String): Dependency {
+      return Dependency(configuration, "com.squareup.okio:okio:3.0.0")
+    }
+
+    @JvmStatic
     fun okHttp(configuration: String): Dependency {
       return Dependency(configuration, "com.squareup.okhttp3:okhttp:4.6.0")
     }


### PR DESCRIPTION
Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/701.

Not yet resolved: output of `reason` still appears nonsensical. It needs to be enhanced with more knowledge about the results of bundle rule resolution.