### PR TITLE
Wrap manifest parsing exception in stronger exception type.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/BytecodeParsers.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/BytecodeParsers.kt
@@ -53,7 +53,8 @@ private class BytecodeReader(
 ) {
   /**
    * This (currently, maybe forever) fails to detect constant usage in Kotlin-generated class files.
-   * Works just fine for Java.
+   * Works just fine for Java (but
+   * [not the ecj compiler](https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/735)).
    *
    * Returns a pair of values:
    * 1. The "source" of the class file (the source file name, like "Main.kt").

--- a/src/test/kotlin/com/autonomousapps/internal/ManifestParserTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/ManifestParserTest.kt
@@ -1,5 +1,6 @@
 package com.autonomousapps.internal
 
+import com.autonomousapps.internal.ManifestParser.ManifestParseException
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -47,8 +48,8 @@ class ManifestParserTest {
     assertThat(manifest.packageName).isEqualTo("better.app")
   }
 
-  @Test fun `throws NPE when manifest is missing package declaration and there is no DSL namespace`() {
-    assertThrows(NullPointerException::class.java) {
+  @Test fun `throws ManifestParseException when manifest is missing package declaration and there is no DSL namespace`() {
+    assertThrows(ManifestParseException::class.java) {
       parse(
         """
           <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
Mitigates https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/720.