### PR TITLE
Detect more Android res usages.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -173,13 +173,13 @@ internal fun <R> Iterable<NamedNodeMap>.flatMap(transform: (Node) -> R): List<R>
   return destination
 }
 
-internal fun Document.attrs(): Map<String, String> {
+internal fun Document.attrs(): List<Pair<String, String>> {
   return getElementsByTagName("*")
     .map { it.attributes }
     // this flatMap looks redundant but isn't!
     .flatMap { it }
     .filterIsInstance<Attr>()
-    .associate { it.name to it.value }
+    .map { it.name to it.value }
 }
 
 internal fun Document.contentReferences(): Map<String, String> {

--- a/src/main/kotlin/com/autonomousapps/model/Source.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Source.kt
@@ -95,12 +95,12 @@ data class AndroidResSource(
        *
        * Will return `null` if the map entry doesn't match an expected pattern.
        */
-      fun from(mapEntry: Map.Entry<String, String>): AttrRef? {
+      fun from(mapEntry: Pair<String, String>): AttrRef? {
         if (mapEntry.isId()) return null
         if (mapEntry.isToolsAttr()) return null
         if (mapEntry.isDataBindingExpression()) return null
 
-        val id = mapEntry.value
+        val id = mapEntry.second
         return when {
           id.startsWith('?') -> AttrRef(
             type = "attr",
@@ -116,7 +116,7 @@ data class AndroidResSource(
           // A consumer may provide a value for this attr:
           //   <item name="swipeRefreshLayoutProgressSpinnerBackgroundColor">...</item>
           // See ResSpec.detects attr usage in res file.
-          mapEntry.key == "name" -> AttrRef(
+          mapEntry.first == "name" -> AttrRef(
             type = "attr",
             id = id.replace('.', '_')
           )
@@ -124,9 +124,9 @@ data class AndroidResSource(
         }
       }
 
-      private fun Map.Entry<String, String>.isId() = value.startsWith("@+") || value.startsWith("@id")
-      private fun Map.Entry<String, String>.isToolsAttr() = key.startsWith("tools:")
-      private fun Map.Entry<String, String>.isDataBindingExpression() = value.startsWith("@{") && value.endsWith("}")
+      private fun Pair<String, String>.isId() = first.startsWith("@+") || second.startsWith("@id")
+      private fun Pair<String, String>.isToolsAttr() = first.startsWith("tools:")
+      private fun Pair<String, String>.isDataBindingExpression() = first.startsWith("@{") && first.endsWith("}")
 
       // @drawable/some_drawable => drawable
       // @android:drawable/some_drawable => drawable

--- a/src/main/kotlin/com/autonomousapps/tasks/XmlSourceExploderTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/XmlSourceExploderTask.kt
@@ -217,11 +217,11 @@ private class AndroidResParser(
     }
 
   private fun extractAttrsFromResourceXml(doc: Document): Set<AndroidResSource.AttrRef> {
-    return doc.attrs().entries.mapNotNullToSet { AndroidResSource.AttrRef.from(it) }
+    return doc.attrs().mapNotNullToSet { AndroidResSource.AttrRef.from(it) }
   }
 
   private fun extractContentReferencesFromResourceXml(doc: Document): Set<AndroidResSource.AttrRef> {
-    return doc.contentReferences().entries.mapNotNullToSet { AndroidResSource.AttrRef.from(it) }
+    return doc.contentReferences().entries.mapNotNullToSet { AndroidResSource.AttrRef.from(it.key to it.value) }
   }
 }
 

--- a/src/test/kotlin/com/autonomousapps/internal/utils/XmlParserTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/utils/XmlParserTest.kt
@@ -34,7 +34,9 @@ class XmlParserTest {
     val attrs = buildDocument(path).attrs()
 
     // then
-    assertThat(attrs["android:fillColor"]).isEqualTo("?themeColor")
+    val fillColor = attrs.find { it.first == "android:fillColor" }
+    assertThat(fillColor).isNotNull()
+    assertThat(fillColor!!.second).isEqualTo("?themeColor")
   }
 
   private fun Path.writeText(text: String) {


### PR DESCRIPTION
Associating to a map was clobbering a lot of key-value pairs that all had the same key ('name' for example).

As a follow-up, I need to figure out how to declare that some res usages make a dependency `api` vs `implementation`.