### PR TITLE
Fixes #763

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/utils/regex.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/regex.kt
@@ -24,8 +24,14 @@ internal fun List<AnnotationNode>?.annotationTypes(): Set<String> {
 
   forEach { anno ->
     types.add(anno.desc)
-    anno.values.orEmpty().filterIsInstance<Type>().forEach { type ->
-      types.add(type.descriptor)
+
+    anno.values.orEmpty().filter {
+      it is Type || it is ArrayList<*>
+    }.forEach { value ->
+      when (value) {
+        is Type -> types.add(value.descriptor)
+        is ArrayList<*> -> value.filterIsInstance<Type>().forEach { type -> types.add(type.descriptor) }
+      }
     }
   }
 

--- a/src/main/kotlin/com/autonomousapps/internal/utils/regex.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/regex.kt
@@ -26,11 +26,11 @@ internal fun List<AnnotationNode>?.annotationTypes(): Set<String> {
     types.add(anno.desc)
 
     anno.values.orEmpty().filter {
-      it is Type || it is ArrayList<*>
+      it is Type || it is List<*>
     }.forEach { value ->
       when (value) {
         is Type -> types.add(value.descriptor)
-        is ArrayList<*> -> value.filterIsInstance<Type>().forEach { type -> types.add(type.descriptor) }
+        is List<*> -> value.filterIsInstance<Type>().forEach { type -> types.add(type.descriptor) }
       }
     }
   }

--- a/src/test/kotlin/com/autonomousapps/internal/utils/RegexKtTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/utils/RegexKtTest.kt
@@ -3,6 +3,7 @@ package com.autonomousapps.internal.utils
 import com.autonomousapps.internal.asm.Type
 import com.autonomousapps.internal.asm.tree.AnnotationNode
 import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
 
@@ -13,15 +14,15 @@ class AnnotationNodeExtensionTest {
     annotationNode.values = mutableListOf()
     annotationNode.values.add(
       arrayListOf(
-        "a string element that should be filtered",
+        "a string element that should be filtered out",
         Type.getType("Lcom/test/AReferencedClass;"),
         Type.getType("Lcom/test/AnotherOne;")
       )
     )
 
     val annotationTypes = listOf(annotationNode).annotationTypes()
-    Truth.assertThat(annotationTypes).hasSize(3)
-    Truth.assertThat(annotationTypes).containsExactly(
+    assertThat(annotationTypes).hasSize(3)
+    assertThat(annotationTypes).containsExactly(
       "Lcom/test/AnnotationWithMultipleReferences;", "Lcom/test/AReferencedClass;", "Lcom/test/AnotherOne;"
     )
   }
@@ -34,8 +35,8 @@ class AnnotationNodeExtensionTest {
     )
 
     val annotationTypes = listOf(annotationNode).annotationTypes()
-    Truth.assertThat(annotationTypes).hasSize(2)
-    Truth.assertThat(annotationTypes).containsExactly(
+    assertThat(annotationTypes).hasSize(2)
+    assertThat(annotationTypes).containsExactly(
       "Lcom/test/AnnotationWithSingleReference;", "Lcom/test/AReferencedClass;"
     )
   }
@@ -43,8 +44,8 @@ class AnnotationNodeExtensionTest {
   @Test fun `should correctly parse an annotation node with no references`() {
     val annotationNode = AnnotationNode("Lcom/test/AnnotationWithNoReference;")
     val annotationTypes = listOf(annotationNode).annotationTypes()
-    Truth.assertThat(annotationTypes).hasSize(1)
-    Truth.assertThat(annotationTypes).containsExactly(
+    assertThat(annotationTypes).hasSize(1)
+    assertThat(annotationTypes).containsExactly(
       "Lcom/test/AnnotationWithNoReference;"
     )
   }

--- a/src/test/kotlin/com/autonomousapps/internal/utils/RegexKtTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/utils/RegexKtTest.kt
@@ -1,0 +1,52 @@
+package com.autonomousapps.internal.utils
+
+import com.autonomousapps.internal.asm.Type
+import com.autonomousapps.internal.asm.tree.AnnotationNode
+import com.google.common.truth.Truth
+import org.junit.jupiter.api.Test
+
+
+class AnnotationNodeExtensionTest {
+
+  @Test fun `should correctly parse an annotation node that references a list of Types`() {
+    val annotationNode = AnnotationNode("Lcom/test/AnnotationWithMultipleReferences;")
+    annotationNode.values = mutableListOf()
+    annotationNode.values.add(
+      arrayListOf(
+        "a string element that should be filtered",
+        Type.getType("Lcom/test/AReferencedClass;"),
+        Type.getType("Lcom/test/AnotherOne;")
+      )
+    )
+
+    val annotationTypes = listOf(annotationNode).annotationTypes()
+    Truth.assertThat(annotationTypes).hasSize(3)
+    Truth.assertThat(annotationTypes).containsExactly(
+      "Lcom/test/AnnotationWithMultipleReferences;", "Lcom/test/AReferencedClass;", "Lcom/test/AnotherOne;"
+    )
+  }
+
+  @Test fun `should correctly parse an annotation node that references a single Type`() {
+    val annotationNode = AnnotationNode("Lcom/test/AnnotationWithSingleReference;")
+    annotationNode.values = mutableListOf()
+    annotationNode.values.add(
+      Type.getType("Lcom/test/AReferencedClass;")
+    )
+
+    val annotationTypes = listOf(annotationNode).annotationTypes()
+    Truth.assertThat(annotationTypes).hasSize(2)
+    Truth.assertThat(annotationTypes).containsExactly(
+      "Lcom/test/AnnotationWithSingleReference;", "Lcom/test/AReferencedClass;"
+    )
+  }
+
+  @Test fun `should correctly parse an annotation node with no references`() {
+    val annotationNode = AnnotationNode("Lcom/test/AnnotationWithNoReference;")
+    val annotationTypes = listOf(annotationNode).annotationTypes()
+    Truth.assertThat(annotationTypes).hasSize(1)
+    Truth.assertThat(annotationTypes).containsExactly(
+      "Lcom/test/AnnotationWithNoReference;"
+    )
+  }
+}
+


### PR DESCRIPTION
If an annotation references multiple types they are not correctly exposed as part of a module's public ABI. This is because we filter for an annotation values to only include a single `Type`. However annotations may have a value of type `ArrayList<*>` which can contain references to other classes.

This patch updates the `List<AnnotationNode>?.annotationTypes()` method to correctly handle the above scenario and adds some unit tests for it.