### PR TITLE
Consider moduleAdvice empty if none of it is actionable.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/advice/SeverityHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/SeverityHandler.kt
@@ -31,7 +31,7 @@ internal class SeverityHandler(
   }
 
   fun shouldFailModuleStructure(moduleAdvice: Set<ModuleAdvice>): Boolean {
-    return (moduleStructureBehavior.isFail() || anyBehavior.isFail()) && moduleAdvice.isNotEmpty()
+    return (moduleStructureBehavior.isFail() || anyBehavior.isFail()) && ModuleAdvice.isNotEmpty(moduleAdvice)
   }
 
   private fun Behavior.isFail(): Boolean = this is Fail

--- a/src/main/kotlin/com/autonomousapps/model/ModuleAdvice.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ModuleAdvice.kt
@@ -14,6 +14,17 @@ sealed class ModuleAdvice {
   internal fun shouldIgnore(behavior: Behavior): Boolean {
     return behavior.filter.contains(name)
   }
+
+  internal abstract fun isActionable(): Boolean
+
+  internal companion object {
+    /** Returns `true` if [moduleAdvice] is effectively empty or unactionable. */
+    fun isEmpty(moduleAdvice: Set<ModuleAdvice>) = moduleAdvice.none { it.isActionable() }
+
+
+    /** Returns `true` if [moduleAdvice] is in any way actionable. */
+    fun isNotEmpty(moduleAdvice: Set<ModuleAdvice>) = !isEmpty(moduleAdvice)
+  }
 }
 
 @TypeLabel("android_score")
@@ -43,9 +54,13 @@ data class AndroidScore(
   fun shouldBeJvm(): Boolean = score == 0f
 
   /** True if this project only uses some limited number of Android facilities. */
-  fun couldBeJvm(): Boolean = score < 2f
+  fun couldBeJvm(): Boolean = score < THRESHOLD
+
+  override fun isActionable(): Boolean = couldBeJvm()
 
   internal companion object {
+    private const val THRESHOLD = 2f
+
     fun ofVariants(scores: Collection<AndroidScoreVariant>): AndroidScore? {
       // JVM projects don't have an AndroidScore
       if (scores.isEmpty()) return null

--- a/src/test/groovy/com/autonomousapps/internal/advice/SeverityHandlerSpec.groovy
+++ b/src/test/groovy/com/autonomousapps/internal/advice/SeverityHandlerSpec.groovy
@@ -1,0 +1,37 @@
+package com.autonomousapps.internal.advice
+
+import com.autonomousapps.extension.Fail
+import com.autonomousapps.model.AndroidScore
+import com.autonomousapps.model.ModuleAdvice
+import spock.lang.Specification
+
+final class SeverityHandlerSpec extends Specification {
+
+  private def fail = new Fail()
+
+  def "should not fail on module advice when it's not actionable"() {
+    given:
+    Set<ModuleAdvice> moduleAdvice = [new AndroidScore(
+      true, true, true, true, true
+    )]
+    def severityHandler = new SeverityHandler(
+      fail, fail, fail, fail, fail, fail, fail, fail
+    )
+
+    expect:
+    !severityHandler.shouldFailModuleStructure(moduleAdvice)
+  }
+
+  def "should fail on module advice when it is not actionable"() {
+    given:
+    Set<ModuleAdvice> moduleAdvice = [new AndroidScore(
+      false, false, false, false, false
+    )]
+    def severityHandler = new SeverityHandler(
+      fail, fail, fail, fail, fail, fail, fail, fail
+    )
+
+    expect:
+    severityHandler.shouldFailModuleStructure(moduleAdvice)
+  }
+}


### PR DESCRIPTION
This will prevent the plugin crashing when the console report is empty and severity is set to 'fail' for module health.

Resolves https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/766.