### PR TITLE
Add support for path: in gradle script.

### DIFF
--- a/shadowed/antlr/src/main/antlr/com/autonomousapps/internal/grammar/GradleGroovyScript.g4
+++ b/shadowed/antlr/src/main/antlr/com/autonomousapps/internal/grammar/GradleGroovyScript.g4
@@ -25,7 +25,7 @@ externalDeclaration
     ;
 
 localDeclaration
-    :   configuration '('? 'project(' ('\'' | '"')? dependency ('\'' | '"')? ')' ')'? closure?
+    :   configuration '('? 'project(' ('path:')? ('\'' | '"')? dependency ('\'' | '"')? ')' ')'? closure?
     ;
 
 configuration

--- a/shadowed/antlr/src/test/groovy/com/autonomousapps/GradleGroovyScriptSpec.groovy
+++ b/shadowed/antlr/src/test/groovy/com/autonomousapps/GradleGroovyScriptSpec.groovy
@@ -47,6 +47,7 @@ final class GradleGroovyScriptSpec extends Specification {
       dependencies {
         implementation 'heart:of-gold:1.0'
         api project(":marvin")
+        implementation project(path: ':ftl-travel')
         
         testImplementation("pan-galactic:gargle-blaster:2.0-SNAPSHOT") {
           because "life's too short not to"
@@ -59,8 +60,8 @@ final class GradleGroovyScriptSpec extends Specification {
     when:
     def list = parseGroovyGradleScript(sourceFile)
 
-    then:
-    assertThat(list).containsExactly('heart:of-gold:1.0', ':marvin', 'pan-galactic:gargle-blaster:2.0-SNAPSHOT')
+    then:    assertThat(list).containsExactly('heart:of-gold:1.0', ':marvin', ':ftl-travel', 'pan-galactic:gargle-blaster:2.0-SNAPSHOT')
+
   }
 
   private static parseGroovyGradleScript(File file) {


### PR DESCRIPTION
This is the default way a project is auto added if you utilize Android Studio's "Add dependency on module" auto fix so it seems to be very prevalent in build scripts.

<img width="707" alt="CleanShot 2022-08-21 at 10 43 52@2x" src="https://user-images.githubusercontent.com/3654470/185796642-b2d9ec04-7b10-4ffe-a78c-36bad6545e27.png">

Results in:
<img width="482" alt="CleanShot 2022-08-21 at 10 44 04@2x" src="https://user-images.githubusercontent.com/3654470/185796655-8c9a3be3-f39b-4255-96ac-7bff1918fc52.png">

