### PR TITLE
Show classes used dependency for reason task result

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/reason/DependencyAdviceExplainer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/reason/DependencyAdviceExplainer.kt
@@ -143,6 +143,9 @@ internal class DependencyAdviceExplainer(
         append("""* """)
         val prefix = if (variant.kind == SourceSetKind.MAIN) "" else "test"
         appendReproducibleNewLine(reason.reason(prefix, isCompileOnly))
+        if (reason is Reason.Impl && reason.extraInfo.isNotEmpty()) {
+          appendReproducibleNewLine(reason.extraInfo)
+        }
       }
       if (reasons.isEmpty()) {
         appendReproducibleNewLine("(no usages)")

--- a/src/main/kotlin/com/autonomousapps/model/intermediates/Reason.kt
+++ b/src/main/kotlin/com/autonomousapps/model/intermediates/Reason.kt
@@ -86,12 +86,33 @@ internal sealed class Reason(open val reason: String) {
 
   @TypeLabel("impl")
   @JsonClass(generateAdapter = false)
-  data class Impl(override val reason: String) : Reason(reason) {
-    constructor(implClasses: Set<String>) : this(
-      buildReason(implClasses, "Uses", Kind.Class)
+  data class Impl(
+    override val reason: String,
+    val extraInfo: String = ""
+  ) : Reason(reason) {
+
+    /**
+     * @param implClassesUsages a map which a key is an impl class and a value is a set of used classes
+     */
+    constructor(implClassesUsages: Map<String, Set<String>>) : this(
+      buildReason(implClassesUsages.keys, "Uses", Kind.Class),
+      formatExtraInfo(implClassesUsages)
     )
 
     override val configurationName: String = "implementation"
+
+    companion object {
+      private const val MAX_USAGE_LISTING = 3
+      private fun formatExtraInfo(implClassesUsages: Map<String, Set<String>>) = buildString {
+        val occurrences = implClassesUsages.values.flatten().distinct()
+        if (occurrences.size > MAX_USAGE_LISTING) {
+          append("Listing first 3 occurrences:\n")
+        } else {
+          append("Occurrences:\n")
+        }
+        append(occurrences.take(MAX_USAGE_LISTING).joinToString("\n"))
+      }
+    }
   }
 
   @TypeLabel("imported")

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeUsagesTask.kt
@@ -276,8 +276,18 @@ private class GraphVisitor(
       classCapability.classes.contains(implClass)
     }.toSortedSet()
 
+    val classUsages = context.project.implementationClasses.asSequence().filter { implClass ->
+      classCapability.classes.contains(implClass)
+    }.map { implClass ->
+      implClass to context.project.codeSource.filter { source ->
+        source.usedClasses.contains(implClass)
+      }.map { code ->
+        code.className
+      }.toSet()
+    }.toMap()
+
     return if (implClasses.isNotEmpty()) {
-      reportBuilder[coordinates, Kind.DEPENDENCY] = Reason.Impl(implClasses)
+      reportBuilder[coordinates, Kind.DEPENDENCY] = Reason.Impl(classUsages)
       true
     } else {
       false

--- a/src/test/kotlin/com/autonomousapps/internal/reason/DependencyAdviceExplainerTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/reason/DependencyAdviceExplainerTest.kt
@@ -30,7 +30,7 @@ class DependencyAdviceExplainerTest {
         Reason.AnnotationProcessor.classes(setOf("Proc1"), isKapt = false),
         Reason.AnnotationProcessor.imports(setOf("Proc1"), isKapt = false),
         Reason.Constant(setOf("Const1", "Const2")),
-        Reason.Impl(setOf("One", "Two", "Three", "Four", "Five", "Six")),
+        Reason.Impl(mapOf("One" to setOf("com.foo.Bar"), "Two" to setOf("com.foo.Bar"), "Three" to setOf("com.foo.Bar"), "Four" to setOf("com.foo.Bar"), "Five" to setOf("com.foo.Bar"), "Six" to setOf("com.foo.Bar"))),
         Reason.Imported(setOf("One", "Two", "Three", "Four", "Five", "Six")),
         Reason.Inline(setOf("One", "Two", "Three", "Four", "Five", "Six")),
         Reason.LintJar.of("LintRegistry"),
@@ -78,6 +78,8 @@ class DependencyAdviceExplainerTest {
       * Imports 1 annotation: Proc1 (implies annotationProcessor).
       * Imports 2 constants: Const1, Const2 (implies implementation).
       * Uses 6 classes, 5 of which are shown: One, Two, Three, Four, Five (implies implementation).
+      Occurrences:
+      com.foo.Bar
       * Imports 6 classes, 5 of which are shown: One, Two, Three, Four, Five (implies implementation).
       * Imports 6 inline members, 5 of which are shown: One, Two, Three, Four, Five (implies implementation).
       * Provides 1 lint registry: LintRegistry (implies implementation).
@@ -100,7 +102,7 @@ class DependencyAdviceExplainerTest {
       val reasons = setOf(
         Reason.CompileTimeAnnotations(),
         Reason.Constant(setOf("Const1", "Const2")),
-        Reason.Impl(setOf("One", "Two", "Three", "Four", "Five", "Six")),
+        Reason.Impl(mapOf("One" to setOf("com.foo.Bar"), "Two" to setOf("com.foo.Bar"), "Three" to setOf("com.foo.Bar"), "Four" to setOf("com.foo.Bar"), "Five" to setOf("com.foo.Bar"), "Six" to setOf("com.foo.Bar"))),
         Reason.Imported(setOf("One", "Two", "Three", "Four", "Five", "Six")),
       )
       val usages = setOf(
@@ -135,6 +137,8 @@ class DependencyAdviceExplainerTest {
       * Provides compile-time annotations (implies compileOnly).
       * Imports 2 constants: Const1, Const2 (implies compileOnly).
       * Uses 6 classes, 5 of which are shown: One, Two, Three, Four, Five (implies compileOnly).
+      Occurrences:
+      com.foo.Bar
       * Imports 6 classes, 5 of which are shown: One, Two, Three, Four, Five (implies compileOnly).
     """.trimIndent()
       )
@@ -223,7 +227,7 @@ class DependencyAdviceExplainerTest {
     @Test fun `no advice for declared parent`() {
       // Given
       val target = ModuleCoordinates("androidx.lifecycle:lifecycle-common", "2.0.0")
-      val reasons = setOf(Reason.Impl(setOf("impl1")))
+      val reasons = setOf(Reason.Impl(mapOf("impl1" to setOf("com.foo.Bar"))))
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN, reasons = reasons),
       )
@@ -259,6 +263,8 @@ class DependencyAdviceExplainerTest {
           Source: debug, main
           -------------------
           * Uses 1 class: impl1 (implies implementation).
+          Occurrences:
+          com.foo.Bar
         """.trimIndent()
       )
     }
@@ -267,7 +273,7 @@ class DependencyAdviceExplainerTest {
       // TODO for this case, consider updating the graph output to show the path to the used child
       // Given
       val target = ModuleCoordinates("androidx.core:core", "1.1.0")
-      val reasons = setOf(Reason.Impl(setOf("impl1")))
+      val reasons = setOf(Reason.Impl(mapOf("impl1" to setOf("com.foo.Bar"))))
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN, reasons = reasons),
       )
@@ -301,6 +307,8 @@ class DependencyAdviceExplainerTest {
           Source: debug, main
           -------------------
           * Uses 1 class: impl1 (implies implementation).
+          Occurrences:
+          com.foo.Bar
         """.trimIndent()
       )
     }
@@ -308,7 +316,7 @@ class DependencyAdviceExplainerTest {
     @Test fun `advice for primary map`() {
       // Given
       val target = ModuleCoordinates("androidx.core:core", "1.1.0")
-      val reasons = setOf(Reason.Impl(setOf("impl1")))
+      val reasons = setOf(Reason.Impl(mapOf("impl1" to setOf("com.foo.Bar"))))
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN, reasons = reasons),
       )
@@ -342,6 +350,8 @@ class DependencyAdviceExplainerTest {
           Source: debug, main
           -------------------
           * Uses 1 class: impl1 (implies implementation).
+          Occurrences:
+          com.foo.Bar
         """.trimIndent()
       )
     }


### PR DESCRIPTION
addresses #643
I am new to the code base and unsure if this is the best approach. :thinking: 

I am not sure about the messages but these are what I have:

For a lot of usages, limit at 3
```
* Uses 23 classes, 5 of which are shown: retrofit2.http.Multipart, retrofit2.http.POST, retrofit2.http.HTTP, retrofit2.http.Field, retrofit2.Call (implies implementation).
Listing first 3 occurrences:
com.keylesspalace.tusky.network.MastodonApi
com.keylesspalace.tusky.network.MediaUploadApi
com.keylesspalace.tusky.components.account.AccountViewModel
* Imports 1 inline member: retrofit2.create (implies implementation).
```

Fewer than 3
```
* Uses 1 class: io.github.pt2121.common.BouncingBalls (implies implementation).
Occurrences:
io.github.pt2121.android.MainActivity
```

Please let me know what you think.

note: I got some errors when setting up [the composite build](https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/wiki/Contributing-&-Debugging#setting-up-a-composite-build).