### PR TITLE
Duplicated declaration does not lead to wrong analysis result

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/TestDuplicatedDependenciesSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/TestDuplicatedDependenciesSpec.groovy
@@ -1,0 +1,24 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.DuplicatedDependenciesProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class TestDuplicatedDependenciesSpec extends AbstractJvmSpec {
+
+  def "duplicated dependency declaration does not lead to wrong analysis result (#gradleVersion)"() {
+    given:
+    def project = new DuplicatedDependenciesProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/DuplicatedDependenciesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/DuplicatedDependenciesProject.groovy
@@ -1,0 +1,73 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.Dependency.*
+
+final class DuplicatedDependenciesProject extends AbstractProject {
+
+  private static final commonsCollectionsRuntimeOnly = commonsCollections('runtimeOnly')
+  private static final commonsCollectionsImplementation = commonsCollections('implementation')
+
+  final GradleProject gradleProject
+
+  DuplicatedDependenciesProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('proj') { s ->
+      s.sources = sources
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.dependencies = [commonsCollectionsRuntimeOnly, commonsCollectionsImplementation]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private List<Source> sources = [
+    new Source(
+      SourceType.JAVA, "Main", "com/example",
+      """\
+        package com.example;
+        
+        import org.apache.commons.collections4.Bag;
+        import org.apache.commons.collections4.bag.HashBag;
+
+        public class Main {
+          public void compute() {
+            Bag<String> bag = new HashBag<>();
+          }
+        }
+      """.stripIndent()
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> projAdvice = [
+    // This test project makes sure that the 'runtimeOnly' dependency does not shadow the 'implementation'
+    // dependency to the same module during analysis. Which in the past let to a wrong advice
+    // (remove implementation dependency). Reporting duplicated declarations, and recommending removing the ones that
+    // do not add anything, is out of scope right now.
+    // Advice.ofRemove(moduleCoordinates(commonsCollectionsRuntimeOnly), commonsCollectionsRuntimeOnly.configuration)
+  ]
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':proj', projAdvice)
+  ]
+}

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -103,7 +103,7 @@ internal class StandardTransform(
     val usageIter = usages.iterator()
     while (usageIter.hasNext()) {
       val usage = usageIter.next()
-      val declarationsForVariant = declarations.filter { it.variant(supportedSourceSets) == usage.variant }.toSet()
+      val declarationsForVariant = declarations.filterToSet { it.variant(supportedSourceSets) == usage.variant }
 
       // We have a declaration on the same variant as the usage. Remove or change it, if necessary.
       if (declarationsForVariant.isNotEmpty()) {

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -103,38 +103,40 @@ internal class StandardTransform(
     val usageIter = usages.iterator()
     while (usageIter.hasNext()) {
       val usage = usageIter.next()
-      val decl = declarations.find { it.variant(supportedSourceSets) == usage.variant }
+      val declarationsForVariant = declarations.filter { it.variant(supportedSourceSets) == usage.variant }.toSet()
 
       // We have a declaration on the same variant as the usage. Remove or change it, if necessary.
-      if (decl != null) {
+      if (declarationsForVariant.isNotEmpty()) {
         // drain
-        declarations.remove(decl)
+        declarations.removeAll(declarationsForVariant)
         usageIter.remove()
 
-        if (
-          usage.bucket == Bucket.NONE
-          // Don't remove a declaration on compileOnly, compileOnlyApi, providedCompile
-          && decl.bucket != Bucket.COMPILE_ONLY
-          // Don't remove a declaration on runtimeOnly
-          && decl.bucket != Bucket.RUNTIME_ONLY
-        ) {
-          advice += Advice.ofRemove(
-            coordinates = coordinates,
-            declaration = decl
-          )
-        } else if (
-        // Don't change a match, it's correct!
-          !usage.bucket.matches(decl)
-          // Don't change a declaration on compileOnly, compileOnlyApi, providedCompile
-          && decl.bucket != Bucket.COMPILE_ONLY
-          // Don't change a declaration on runtimeOnly
-          && decl.bucket != Bucket.RUNTIME_ONLY
-        ) {
-          advice += Advice.ofChange(
-            coordinates = coordinates,
-            fromConfiguration = decl.configurationName,
-            toConfiguration = usage.toConfiguration()
-          )
+        declarationsForVariant.forEach { decl ->
+          if (
+            usage.bucket == Bucket.NONE
+            // Don't remove a declaration on compileOnly, compileOnlyApi, providedCompile
+            && decl.bucket != Bucket.COMPILE_ONLY
+            // Don't remove a declaration on runtimeOnly
+            && decl.bucket != Bucket.RUNTIME_ONLY
+          ) {
+            advice += Advice.ofRemove(
+              coordinates = coordinates,
+              declaration = decl
+            )
+          } else if (
+          // Don't change a match, it's correct!
+            !usage.bucket.matches(decl)
+            // Don't change a declaration on compileOnly, compileOnlyApi, providedCompile
+            && decl.bucket != Bucket.COMPILE_ONLY
+            // Don't change a declaration on runtimeOnly
+            && decl.bucket != Bucket.RUNTIME_ONLY
+          ) {
+            advice += Advice.ofChange(
+              coordinates = coordinates,
+              fromConfiguration = decl.configurationName,
+              toConfiguration = usage.toConfiguration()
+            )
+          }
         }
       } else {
         // No exact match, so look for a declaration on the same bucket (e.g., usage is 'api' and declaration is


### PR DESCRIPTION
If there are two declarations to the same component with different scopes, e.g.

```
dependencies {
  runtimeOnly("org.apache.commons:commons-collections4:4.4")
  implementation("org.apache.commons:commons-collections4:4.4")
}
```

the analysis discarded one of them by using 'find' instead of 'filter' in StandardTransform.kt. This can lead to a wrong recommendation. In the example provided in the test, the plugin recommended to remove the 'implementation' dependency.

A related feature could be that the plugin also detects the duplication, and recommends to remove the unneeded declaration - in this case `runtimeOnly("...")`. Doing this, would be an additional analysis imo, as the plugin would need to check how the different configurations relate. And maybe this is also not wanted in all cases. The setup is not "wrong" as the classpaths don't change by removing the duplicates. It may be out of scope of this plugin altogether.

This fix is only about not reporting something wrong.