### PR TITLE
Fix issues with included builds

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
@@ -55,10 +55,9 @@ final class AdviceHelper {
 
   static Coordinates includedBuildCoordinates(
     String identifier,
-    String requestedVersion,
     ProjectCoordinates resolvedProject
   ) {
-    return new IncludedBuildCoordinates(identifier, requestedVersion, resolvedProject)
+    return new IncludedBuildCoordinates(identifier, resolvedProject)
   }
 
   static Set<ProjectAdvice> emptyProjectAdviceFor(String... projectPaths) {

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/IncludedBuildSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/IncludedBuildSpec.groovy
@@ -1,12 +1,17 @@
 package com.autonomousapps.jvm
 
 import com.autonomousapps.jvm.projects.IncludedBuildProject
+import com.autonomousapps.jvm.projects.IncludedBuildWithSubprojectsProject
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
 
 // https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/565
 final class IncludedBuildSpec extends AbstractJvmSpec {
+
+  private static INCLUDED_BUILD_SUPPORT_GRADLE_VERSIONS = [
+    GRADLE_7_3, GRADLE_7_4, SUPPORTED_GRADLE_VERSIONS.last()
+  ]
 
   def "doesn't crash in presence of an included build (#gradleVersion)"() {
     given:
@@ -20,6 +25,51 @@ final class IncludedBuildSpec extends AbstractJvmSpec {
     assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
 
     where: 'This new feature only works for Gradle 7.3+'
-    gradleVersion << [GRADLE_7_3, GRADLE_7_4]
+    gradleVersion << INCLUDED_BUILD_SUPPORT_GRADLE_VERSIONS
+  }
+
+  def "does not confuse identities of included subprojects depended on by another build"() {
+    given:
+    def project = new IncludedBuildWithSubprojectsProject()
+    gradleProject = project.gradleProject
+
+    when: 'build does not fail'
+    build(gradleVersion, gradleProject.rootDir, ':buildHealth')
+
+    then: 'and there is no advice'
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << INCLUDED_BUILD_SUPPORT_GRADLE_VERSIONS
+  }
+
+  def "does not confuse identities of included subprojects depending on each other by GA dependency notation"() {
+    given:
+    def project = new IncludedBuildWithSubprojectsProject()
+    gradleProject = project.gradleProject
+
+    when: 'build does not fail'
+    build(gradleVersion, gradleProject.rootDir, ':second-build:buildHealth')
+
+    then: 'and there is no advice'
+    assertThat(project.actualIncludedBuildHealth()).containsExactlyElementsIn(project.expectedIncludedBuildHealth)
+
+    where:
+    gradleVersion << INCLUDED_BUILD_SUPPORT_GRADLE_VERSIONS
+  }
+
+  def "does not confuse identities of included subprojects depending on each other by project dependency notation"() {
+    given:
+    def project = new IncludedBuildWithSubprojectsProject(true)
+    gradleProject = project.gradleProject
+
+    when: 'build does not fail'
+    build(gradleVersion, gradleProject.rootDir, ':second-build:buildHealth')
+
+    then: 'and there is no advice'
+    assertThat(project.actualIncludedBuildHealth()).containsExactlyElementsIn(project.expectedIncludedBuildHealth)
+
+    where:
+    gradleVersion << INCLUDED_BUILD_SUPPORT_GRADLE_VERSIONS
   }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildProject.groovy
@@ -68,7 +68,7 @@ final class IncludedBuildProject extends AbstractProject {
   final Set<ProjectAdvice> expectedBuildHealth = [
     projectAdviceForDependencies(':', [
       Advice.ofRemove(
-        includedBuildCoordinates('second:second-build', projectCoordinates(':second-build')),
+        includedBuildCoordinates('second:second-build', projectCoordinates(':')),
         'implementation'
       )
     ] as Set<Advice>)

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildProject.groovy
@@ -68,7 +68,7 @@ final class IncludedBuildProject extends AbstractProject {
   final Set<ProjectAdvice> expectedBuildHealth = [
     projectAdviceForDependencies(':', [
       Advice.ofRemove(
-        includedBuildCoordinates('second:second-build', '1.0', projectCoordinates(':second-build')),
+        includedBuildCoordinates('second:second-build', projectCoordinates(':second-build')),
         'implementation'
       )
     ] as Set<Advice>)

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithSubprojectsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithSubprojectsProject.groovy
@@ -1,0 +1,114 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.*
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+
+final class IncludedBuildWithSubprojectsProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  IncludedBuildWithSubprojectsProject(boolean useProjectDependencyWherePossible = false) {
+    this.gradleProject = build(useProjectDependencyWherePossible)
+  }
+
+  private GradleProject build(boolean useProjectDependencyWherePossible) {
+    def builder = newGradleProjectBuilder()
+    builder.withRootProject { root ->
+      root.withBuildScript { bs ->
+        bs.plugins.add(Plugin.javaLibraryPlugin)
+        bs.dependencies = [new Dependency('implementation', 'second:second-sub2:does-not-matter')]
+      }
+      root.settingsScript.additions = """\
+        includeBuild 'second-build'
+      """.stripIndent()
+      root.sources = [
+        new Source(
+          SourceType.JAVA, 'Main', 'com/example/main',
+          """\
+            package com.example.main;
+      
+            import com.example.included.sub2.SecondSub2;
+      
+            public class Main {
+              SecondSub2 sub2 = new SecondSub2();
+            }
+          """.stripIndent()
+        )
+      ]
+    }
+    builder.withSubprojectInIncludedBuild('second-build', 'second-sub1') { secondSub ->
+      secondSub.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        if (useProjectDependencyWherePossible) {
+          bs.dependencies = [new Dependency('implementation', ':second-sub2')]
+        } else {
+          bs.dependencies = [new Dependency('implementation', 'second:second-sub2')]
+        }
+        bs.additions = """\
+          group = 'second'
+        """.stripIndent()
+      }
+      secondSub.sources = [
+        new Source(
+          SourceType.JAVA, 'SecondSub1', 'com/example/included/sub',
+          """\
+            package com.example.included.sub1;
+                        
+            import com.example.included.sub2.SecondSub2;
+            
+            public class SecondSub1 {
+              SecondSub2 sub2 = new SecondSub2();
+            }
+          """.stripIndent()
+        )
+      ]
+    }
+    builder.withSubprojectInIncludedBuild('second-build', 'second-sub2') { secondSub ->
+      secondSub.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.additions = """\
+          group = 'second'
+        """.stripIndent()
+      }
+      secondSub.sources = [
+        new Source(
+          SourceType.JAVA, 'SecondSub2', 'com/example/included/sub',
+          """\
+            package com.example.included.sub2;
+                        
+            public class SecondSub2 {}
+          """.stripIndent()
+        )
+      ]
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  // Health of the root build (the including one)
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':', [] as Set<Advice>)
+  ]
+
+  // Health of the included build
+  Set<ProjectAdvice> actualIncludedBuildHealth() {
+    def included = gradleProject.includedBuilds[0]
+    def project = new GradleProject(new java.io.File(gradleProject.rootDir, 'second-build'), null, included, [], [])
+    return actualProjectAdvice(project)
+  }
+
+  final Set<ProjectAdvice> expectedIncludedBuildHealth = [
+    projectAdviceForDependencies(':second-sub1', [] as Set<Advice>),
+    projectAdviceForDependencies(':second-sub2', [] as Set<Advice>)
+  ]
+}

--- a/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
@@ -69,7 +69,7 @@ internal fun ResolvedArtifactResult.toCoordinates(): Coordinates {
 
   return IncludedBuildCoordinates.of(
     requested = requested,
-    resolvedProject = identity
+    resolvedProject = resolved
   )
 }
 

--- a/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
@@ -88,15 +88,13 @@ data class FlatCoordinates(
 @JsonClass(generateAdapter = false)
 data class IncludedBuildCoordinates(
   override val identifier: String,
-  val requestedVersion: String,
   val resolvedProject: ProjectCoordinates
 ) : Coordinates(identifier) {
-  override fun gav(): String = "$identifier:$requestedVersion"
+  override fun gav(): String = identifier
 
   companion object {
     fun of(requested: ModuleCoordinates, resolvedProject: ProjectCoordinates) = IncludedBuildCoordinates(
       identifier = requested.identifier,
-      requestedVersion = requested.resolvedVersion,
       resolvedProject = resolvedProject
     )
   }

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
@@ -152,14 +152,14 @@ abstract class SynthesizeDependenciesTask @Inject constructor(
       // A dependency can appear in the graph even though it's just a .pom (.module) file. E.g., kotlinx-coroutines-core.
       // This is a fallback so all such dependencies have a file written to disk.
       graphView.nodes.forEach { node ->
-        // Do not compute (and write to file) dependencies already know
+        // Do not add dependencies that are already known again
         val coordinatesAlreadyKnow = builders.values.any {
           it.coordinates == node ||
           // If the node is pointing at a project, there might already be an artifact
           // stored under matching IncludedBuildCoordinates.
           it.coordinates is IncludedBuildCoordinates && it.coordinates.resolvedProject == node
         }
-        if (coordinatesAlreadyKnow) {
+        if (!coordinatesAlreadyKnow) {
           builders.merge(
             node,
             DependencyBuilder(node),

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -3,6 +3,7 @@ package com.autonomousapps.transform
 import com.autonomousapps.internal.utils.*
 import com.autonomousapps.model.Advice
 import com.autonomousapps.model.Coordinates
+import com.autonomousapps.model.IncludedBuildCoordinates
 import com.autonomousapps.model.declaration.Bucket
 import com.autonomousapps.model.declaration.Declaration
 import com.autonomousapps.model.declaration.SourceSetKind
@@ -250,7 +251,10 @@ internal class StandardTransform(
 
 private fun Set<Declaration>.forCoordinates(coordinates: Coordinates): Set<Declaration> {
   return asSequence()
-    .filter { it.identifier == coordinates.identifier }
+    .filter { it.identifier == coordinates.identifier ||
+      // In the special case of IncludedBuildCoordinates, the declaration might be a 'project(...)' dependency
+      // if subprojects inside an included build depend on each other.
+      (coordinates is IncludedBuildCoordinates) && it.identifier == coordinates.resolvedProject.identifier }
     // For now, we ignore any special dependencies like test fixtures or platforms
     .filter { !it.doesNotPointAtMainVariant }
     .toSet()

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/GradleProjectWriter.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/GradleProjectWriter.kt
@@ -85,7 +85,9 @@ class GradleProjectWriter(private val gradleProject: GradleProject) {
     private val subproject: Subproject
   ) {
 
-    protected val projectPath: Path = rootPath.resolve(subproject.name).also {
+    protected val projectPath: Path = rootPath.resolve(
+      "${subproject.includedBuild?.let { "$it/" } ?: ""}${subproject.name}"
+    ).also {
       it.toFile().mkdirs()
     }
 

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Subproject.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Subproject.kt
@@ -2,6 +2,7 @@ package com.autonomousapps.kit
 
 open class Subproject(
   val name: String,
+  val includedBuild: String? = null,
   val buildScript: BuildScript,
   val sources: List<Source>,
   val files: List<File>,
@@ -15,6 +16,7 @@ open class Subproject(
     if (this === other) return true
     if (other !is Subproject) return false
     if (name != other.name) return false
+    if (includedBuild != other.includedBuild) return false
     return true
   }
 
@@ -25,6 +27,7 @@ open class Subproject(
 
   class Builder {
     var name: String? = null
+    var includedBuild: String? = null
     var variant: String = "main"
     var buildScript: BuildScript = BuildScript()
     var sources: List<Source> = emptyList()
@@ -59,6 +62,7 @@ open class Subproject(
       val name = name ?: error("'name' must not be null")
       return Subproject(
         name = name,
+        includedBuild = includedBuild,
         buildScript = buildScript,
         sources = sources,
         files = files,


### PR DESCRIPTION
This PR adds test coverage and fixes two issues with included builds:

1. The requested version is irrelevant if resolved to an included build (sub)project. The analysis also needs to ignore it. Otherwise, it won't be able to connect the computed dependency information correctly to the declared dependencies.
2. If a build is included, inside that build the projects often still depend on each other using `project("...")` dependencies. This was not working.

See also commit messages and comments in code for more details.

Before the fix, if you would run the example that's part of the new test, you would have three files for the same dependency, where two of them were empty:

<img width="410" alt="s" src="https://user-images.githubusercontent.com/1963746/201925778-49213456-93b9-41bf-9224-e91aad6ad27b.png">

(The empty files were cause by the "fallback for pom-only dependencies" in `SynthesizeDependenciesWorkAction`)