### PR TITLE
Use the gradle build github action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Cache gradle
@@ -36,7 +36,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
       - name: Execute tests
@@ -45,25 +45,25 @@ jobs:
         with:
           arguments: ':check -s'
       - name: Comment on PR with build scan
-        uses: mshick/add-pr-comment@v1
+        uses: mshick/add-pr-comment@v2
         if: failure()
         with:
           repo-token: ${{ secrets.githubToken }}
           message: Build failed ${{ steps.gradle.outputs.build-scan-url }}
       - name: Store hprof files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: hprofs
           path: ./**/*.hprof
       - name: Store daemon log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: daemon-log
           path: ./**/*.out.log
       - name: Store gc logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: gc-logs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,11 +11,15 @@ on:
         description: 'Reason for manual run'
         required: false
 
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gradle:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,24 +26,15 @@ jobs:
         uses: actions/checkout@v3
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Cache gradle
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Setup java
         uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: Execute tests
-        id: gradle
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
-          arguments: ':check -s'
+          arguments: check -s
       - name: Comment on PR with build scan
         uses: mshick/add-pr-comment@v2
         if: failure()

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,23 +28,15 @@ jobs:
         uses: actions/checkout@v3
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Cache gradle
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Setup java
         uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: Execute tests
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
-          arguments: ':check -s'
+          arguments: check -s
       - name: Store hprof files
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Cache gradle
@@ -38,7 +38,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
       - name: Execute tests
@@ -46,19 +46,19 @@ jobs:
         with:
           arguments: ':check -s'
       - name: Store hprof files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: hprofs
           path: ./**/*.hprof
       - name: Store daemon log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: daemon-log
           path: ./**/*.out.log
       - name: Store gc logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: gc-logs

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,11 +13,15 @@ on:
         description: 'Reason for manual run'
         required: false
 
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gradle:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo


### PR DESCRIPTION
The migrates the project to Gradle's own [gradle-build-action](https://github.com/gradle/gradle-build-action). This plugin would allow running the build with different Gradle versions, and handles caching better than `actions/cache`. Details [here](https://github.com/gradle/gradle-build-action#caching)

The PR is split into 3 commits. The first one configures GH actions to cancel a running build if a newer one is pushed to the same branch to save resources, the second one updates the existing actions to their respective latest versions, and the third one migrates to this particular action. I can split these into different PRs if this one has too many changes.