### PR TITLE
Fix NPE in asmUtil.exportedPackages()

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/JavaModulesProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/JavaModulesProject.groovy
@@ -37,6 +37,15 @@ final class JavaModulesProject extends AbstractProject {
         ]
       }
     }
+    builder.withSubproject('empty') { s ->
+      // Check that empty module-info does not cause NPE
+      s.sources = [new Source(
+        SourceType.JAVA, "module-info", "", "module org.example.empty {}"
+      )]
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+      }
+    }
 
     def project = builder.build()
     project.writer().write()
@@ -92,10 +101,12 @@ final class JavaModulesProject extends AbstractProject {
   }
 
   final Set<ProjectAdvice> expectedBuildHealthImplementation = [
+    projectAdviceForDependencies(':empty', [] as Set<Advice>),
     projectAdviceForDependencies(':proj', [] as Set<Advice>)
   ]
 
   final Set<ProjectAdvice> expectedBuildHealthApi = [
+    projectAdviceForDependencies(':empty', [] as Set<Advice>),
     projectAdviceForDependencies(':proj',
       [Advice.ofChange(moduleCoordinates(slf4j('api')), 'api', 'implementation')] as Set<Advice>
     )

--- a/src/main/kotlin/com/autonomousapps/internal/kotlin/asmUtils.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/kotlin/asmUtils.kt
@@ -198,7 +198,7 @@ internal val ClassNode.outerClassName: String? get() = innerClassNode?.outerName
 
 internal fun ClassNode.packageName() = name.split("/").let { it.subList(0, it.size - 1) }.joinToString(".")
 
-internal fun ModuleNode.exportedPackages() = exports.map { canonicalize(it.packaze) }
+internal fun ModuleNode.exportedPackages() = exports?.map { canonicalize(it.packaze) }
 
 
 internal const val publishedApiAnnotationName = "kotlin/PublishedApi"


### PR DESCRIPTION
Although you cannot see this in the Kotlin code, this (coming out of ASM) can be `null`.

Sorry for this follow up, I was tricked by being in Kotlin, not even thinking about that this can be `null`. 😐 

Follow up to #800

