### PR TITLE
Use syntax that's Groovy & Kotlin-compatible

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -24,7 +24,7 @@ The simplest approach is to add the following:
 [source,groovy]
 ----
 plugins {
-  id 'com.autonomousapps.dependency-analysis' version "<<latest_version>>"
+  id("com.autonomousapps.dependency-analysis") version "<<latest_version>>"
 }
 ----
 


### PR DESCRIPTION
Only affects the README