### PR TITLE
bump kotlinx-metadata-jvm to 0.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ kotlin-dokka = { module = "org.jetbrains.dokka:kotlin-as-java-plugin", version.r
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
-kotlinx-metadata-jvm = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.4.2"
+kotlinx-metadata-jvm = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.5.0"
 
 moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }


### PR DESCRIPTION
This supports reading Kotlin 1.8 and 1.9 metadata. The current version only goes until 1.7 and on our branch to update to Kotlin 1.8.0 we are seeing that dependency analysis does not find usages of Kotlin constants or extension methods anymore.

For it to work I also needed to update Kotlin itself.

Full changelog
https://github.com/JetBrains/kotlin/blob/master/libraries/kotlinx-metadata/jvm/ChangeLog.md