### PR TITLE
Analyze dependencies of all source sets in standard JVM projects

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -9,23 +9,36 @@ import static com.google.common.truth.Truth.assertThat
 
 final class CustomSourceSetSpec extends AbstractJvmSpec {
 
-  // Not yet implemented: https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/451
   def "transitive dependency for main but declared on custom source set should not prevent advice (#gradleVersion)"() {
     given:
-    def project = new IntegrationTestProject()
+    def project = new IntegrationTestProject(true)
     gradleProject = project.gradleProject
 
     when:
     build(gradleVersion, gradleProject.rootDir, 'buildHealth')
 
     then:
-    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth(true))
 
     where:
     gradleVersion << gradleVersions()
   }
 
-  // Not yet implemented: https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/451
+  def "advice for custom test source set dependencies pointing to main variant of other component (#gradleVersion)"() {
+    given:
+    def project = new IntegrationTestProject(false)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth(false))
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
   def "dependencies for feature variant do not produce any advice (#gradleVersion)"() {
     given:
     def project = new FeatureVariantTestProject()
@@ -41,7 +54,6 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
     gradleVersion << gradleVersions()
   }
 
-  // Not yet implemented: https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/298
   def "dependencies for test fixtures do not produce any advice (#gradleVersion)"() {
     given:
     def project = new TestFixturesTestProject()

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
@@ -96,6 +96,10 @@ final class FeatureVariantTestProject extends AbstractProject {
     return actualProjectAdvice(gradleProject)
   }
 
+  private final Set<Advice> expectedProducerAdvice = [
+    Advice.ofChange(moduleCoordinates(commonsCollections('')), 'extraFeatureApi', 'extraFeatureImplementation'),
+  ]
+
   // Note: 'producer-extra-feature.jar' is considered part of the 'main variant' of ':producer', which is not correct.
   // This is due to the following:
   // - PhysicalArtifact.coordinates only knows about component IDs, 'Module GA' or 'Project Name', but not capabilities.
@@ -112,9 +116,7 @@ final class FeatureVariantTestProject extends AbstractProject {
     // Not yet implemented:
     // missing advice to move dependency 'consumer' -> 'producer-extra-feature' to implementation
     projectAdviceForDependencies(':consumer', expectedConsumerAdvice),
-    // Not yet implemented:
-    // missing advice to move dependency 'producer-extra' -> 'commons-collections4' to extraFeatureImplementation
-    emptyProjectAdviceFor(':producer')
+    projectAdviceForDependencies(':producer', expectedProducerAdvice)
   ]
 
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject.groovy
@@ -94,13 +94,15 @@ final class TestFixturesTestProject extends AbstractProject {
     return actualProjectAdvice(gradleProject)
   }
 
+  private final Set<Advice> expectedProducerAdvice = [
+    Advice.ofChange(moduleCoordinates(commonsCollections('')), 'testFixturesApi', 'testFixturesImplementation'),
+  ]
+
   final Set<ProjectAdvice> expectedBuildHealth = [
     // Not yet implemented:
     // missing advice to move dependency 'consumer' -> 'producer-testFixtures' to implementation
     emptyProjectAdviceFor(':consumer'),
-    // Not yet implemented:
-    // missing advice to move dependency 'producer-testFixtures' -> 'commons-collections4' to testFixturesImplementation
-    emptyProjectAdviceFor(':producer')
+    projectAdviceForDependencies(':producer', expectedProducerAdvice)
   ]
 
 }

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
@@ -152,6 +152,7 @@ internal abstract class AndroidAnalyzer(
       SourceSetKind.MAIN -> "kapt$variantNameCapitalized"
       SourceSetKind.TEST -> "kaptTest"
       SourceSetKind.ANDROID_TEST -> "kaptAndroidTest"
+      SourceSetKind.CUSTOM_JVM -> error("Custom JVM source sets are not supported in Android context")
     }
   }
 
@@ -161,6 +162,7 @@ internal abstract class AndroidAnalyzer(
       SourceSetKind.MAIN -> project.tasks.namedOrNull("compile${variantNameCapitalized}Kotlin")
       SourceSetKind.TEST -> project.tasks.namedOrNull("compile${variantNameCapitalized}UnitTestKotlin")
       SourceSetKind.ANDROID_TEST -> project.tasks.namedOrNull("compile${variantNameCapitalized}AndroidTestKotlin")
+      SourceSetKind.CUSTOM_JVM -> error("Custom JVM source sets are not supported in Android context")
     }
   }
 
@@ -171,6 +173,7 @@ internal abstract class AndroidAnalyzer(
       SourceSetKind.MAIN -> project.tasks.named("compile${variantNameCapitalized}JavaWithJavac")
       SourceSetKind.TEST -> project.tasks.named("compile${variantNameCapitalized}UnitTestJavaWithJavac")
       SourceSetKind.ANDROID_TEST -> project.tasks.named("compile${variantNameCapitalized}AndroidTestJavaWithJavac")
+      SourceSetKind.CUSTOM_JVM -> error("Custom JVM source sets are not supported in Android context")
     }
   }
 

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -104,7 +104,7 @@ internal abstract class JvmAnalyzer(
   }
 }
 
-internal class JavaAppAnalyzer(
+internal class JavaWithoutAbiAnalyzer(
   project: Project,
   sourceSet: SourceSet,
   kind: SourceSetKind
@@ -114,7 +114,7 @@ internal class JavaAppAnalyzer(
   hasAbi = false
 )
 
-internal class JavaLibAnalyzer(
+internal class JavaWithAbiAnalyzer(
   project: Project,
   sourceSet: SourceSet,
   kind: SourceSetKind,

--- a/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/collections.kt
@@ -227,6 +227,39 @@ internal inline fun <T> Iterable<T>.mutPartitionOf(
   return Triple(first, second, third)
 }
 
+internal inline fun <T> Iterable<T>.mutPartitionOf(
+  predicate1: (T) -> Boolean,
+  predicate2: (T) -> Boolean,
+  predicate3: (T) -> Boolean,
+  predicate4: (T) -> Boolean,
+): Quadruple<MutableSet<T>, MutableSet<T>, MutableSet<T>, MutableSet<T>> {
+  val first = LinkedHashSet<T>()
+  val second = LinkedHashSet<T>()
+  val third = LinkedHashSet<T>()
+  val fourth = LinkedHashSet<T>()
+  for (element in this) {
+    if (predicate1(element)) {
+      first.add(element)
+    } else if (predicate2(element)) {
+      second.add(element)
+    } else if (predicate3(element)) {
+      third.add(element)
+    } else if (predicate4(element)) {
+      fourth.add(element)
+    }
+  }
+  return Quadruple(first, second, third, fourth)
+}
+
+data class Quadruple<out A, out B, out C, out D>(
+  val first: A,
+  val second: B,
+  val third: C,
+  val fourth: D,
+) {
+  override fun toString(): String = "($first, $second, $third, $fourth)"
+}
+
 // standard `all` function returns true if collection is empty!
 internal inline fun <T> Collection<T>.reallyAll(predicate: (T) -> Boolean): Boolean {
   if (isEmpty()) return false

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
@@ -22,6 +22,6 @@ internal data class Declaration(
 ) {
 
   val bucket: Bucket by unsafeLazy { Bucket.of(configurationName) }
-
-  fun variant(supportedSourceSets: Set<String>): Variant? = Variant.of(configurationName, supportedSourceSets)
+  fun variant(supportedSourceSets: Set<String>, hasCustomSourceSets: Boolean): Variant? =
+    Variant.of(configurationName, supportedSourceSets, hasCustomSourceSets)
 }

--- a/src/main/kotlin/com/autonomousapps/model/declaration/SourceSetKind.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/SourceSetKind.kt
@@ -12,7 +12,8 @@ enum class SourceSetKind(
   // TODO V2: these format strings are Android-specific. This enum might be useful for JVM, too
   MAIN("Main", "%sCompileClasspath", "%sRuntimeClasspath"),
   TEST("Test", "%sUnitTestCompileClasspath", "%sUnitTestRuntimeClasspath"),
-  ANDROID_TEST("androidTest", "%sAndroidTestCompileClasspath", "%sAndroidTestRuntimeClasspath")
+  ANDROID_TEST("androidTest", "%sAndroidTestCompileClasspath", "%sAndroidTestRuntimeClasspath"),
+  CUSTOM_JVM("CUSTOM", "%sCompileClasspath", "%sRuntimeClasspath"),
   ;
 
   fun compileClasspathConfigurationName(variantName: String) = String.format(compileClasspathFormatString, variantName)
@@ -26,5 +27,5 @@ enum class SourceSetKind(
    * `src/test` (+ `src/release`, because "unit tests" in the Android world are the combination of TEST source and the
    * variant-specific MAIN source).
    */
-  fun asBaseVariant() = Variant(name.lowercase(), this)
+  fun asBaseVariant(customVariantName: String?) = Variant(customVariantName ?: name.lowercase(), this)
 }

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Variant.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Variant.kt
@@ -19,7 +19,7 @@ data class Variant(
     .compare(this, other)
 
   /** See [SourceSetKind.asBaseVariant]. */
-  fun base(): Variant = kind.asBaseVariant()
+  fun base(): Variant = kind.asBaseVariant(if (kind == SourceSetKind.CUSTOM_JVM) variant else null)
 
   companion object {
     const val MAIN_NAME = "main"
@@ -31,8 +31,8 @@ data class Variant(
     //val ANDROID_TEST = Variant(ANDROID_TEST_NAME, SourceSetKind.ANDROID_TEST)
 
     @JvmStatic
-    fun of(configurationName: String, supportedSourceSets: Set<String>): Variant? =
-      Configurations.variantFrom(configurationName, supportedSourceSets)
+    fun of(configurationName: String, supportedSourceSets: Set<String>, hasCustomSourceSets: Boolean): Variant? =
+      Configurations.variantFrom(configurationName, supportedSourceSets, hasCustomSourceSets)
 
     fun String.toVariant(kind: SourceSetKind) = Variant(this, kind)
   }

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -33,7 +33,6 @@ import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.*
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
-import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 
 private const val ANDROID_APP_PLUGIN = "com.android.application"
@@ -308,27 +307,13 @@ internal class ProjectPlugin(private val project: Project) {
         }
 
         val j = JavaSources(this)
-        j.main?.let { sourceSet ->
+        j.sourceSets.forEach { sourceSet ->
           try {
             analyzeDependencies(
-              JavaAppAnalyzer(
+              JavaWithoutAbiAnalyzer(
                 project = this,
                 sourceSet = sourceSet,
-                kind = SourceSetKind.MAIN
-              )
-            )
-          } catch (_: UnknownTaskException) {
-            logger.warn("Skipping tasks creation for sourceSet `${sourceSet.name}`")
-          }
-        }
-
-        j.test?.let { sourceSet ->
-          try {
-            analyzeDependencies(
-              JavaAppAnalyzer(
-                project = this,
-                sourceSet = sourceSet,
-                kind = SourceSetKind.TEST
+                kind = sourceSet.jvmSourceSetKind()
               )
             )
           } catch (_: UnknownTaskException) {
@@ -359,7 +344,7 @@ internal class ProjectPlugin(private val project: Project) {
         return@afterEvaluate
       }
 
-      j.main?.let { sourceSet ->
+      j.sourceSets.forEach { sourceSet ->
         try {
           // Regardless of the fact that this is a "java-library" project, the presence of Spring
           // Boot indicates an app project.
@@ -368,42 +353,27 @@ internal class ProjectPlugin(private val project: Project) {
               "(dependency analysis) You have both java-library and org.springframework.boot applied. You probably " +
                 "want java, not java-library."
             )
-            JavaAppAnalyzer(
+            JavaWithoutAbiAnalyzer(
               project = this,
               sourceSet = sourceSet,
-              kind = SourceSetKind.MAIN
+              kind = sourceSet.jvmSourceSetKind()
             )
           } else {
-            JavaLibAnalyzer(
-              project = this,
-              sourceSet = sourceSet,
-              kind = SourceSetKind.MAIN,
-              hasAbi = true
-            )
-          }
-          analyzeDependencies(dependencyAnalyzer)
-        } catch (_: UnknownTaskException) {
-          logger.warn("Skipping tasks creation for sourceSet `${sourceSet.name}`")
-        }
-      }
-
-      j.test?.let { sourceSet ->
-        try {
-          // Regardless of the fact that this is a "java-library" project, the presence of Spring
-          // Boot indicates an app project.
-          val dependencyAnalyzer = if (pluginManager.hasPlugin(SPRING_BOOT_PLUGIN)) {
-            JavaAppAnalyzer(
-              project = this,
-              sourceSet = sourceSet,
-              kind = SourceSetKind.TEST
-            )
-          } else {
-            JavaLibAnalyzer(
-              project = this,
-              sourceSet = sourceSet,
-              kind = SourceSetKind.TEST,
-              hasAbi = false
-            )
+            val hasAbi = configurations.findByName(sourceSet.apiConfigurationName) != null
+            if (hasAbi) {
+              JavaWithAbiAnalyzer(
+                project = this,
+                sourceSet = sourceSet,
+                kind = sourceSet.jvmSourceSetKind(),
+                hasAbi = true
+              )
+            } else {
+              JavaWithoutAbiAnalyzer(
+                project = this,
+                sourceSet = sourceSet,
+                kind = sourceSet.jvmSourceSetKind()
+              )
+            }
           }
           analyzeDependencies(dependencyAnalyzer)
         } catch (_: UnknownTaskException) {
@@ -877,8 +847,8 @@ internal class ProjectPlugin(private val project: Project) {
     } else if (pluginManager.hasPlugin(ANDROID_LIBRARY_PLUGIN)) {
       the<LibraryExtension>().libraryVariants.flatMapToSet { sourceSetsForVariant(it) }
     } else {
-      // JVM Plugins - at some point 'the<SourceSetContainer>().names' should be supported for JVM projects
-      setOf(SourceSet.MAIN_SOURCE_SET_NAME, SourceSet.TEST_SOURCE_SET_NAME)
+      // JVM Plugins - support all source sets
+      the<SourceSetContainer>().names
     }
   }
 
@@ -898,6 +868,12 @@ internal class ProjectPlugin(private val project: Project) {
     }
 
     return mainSources + unitTestSources + androidTestSources
+  }
+
+  private fun SourceSet.jvmSourceSetKind() = when(name) {
+    SourceSet.MAIN_SOURCE_SET_NAME -> SourceSetKind.MAIN
+    SourceSet.TEST_SOURCE_SET_NAME -> SourceSetKind.TEST
+    else -> SourceSetKind.CUSTOM_JVM
   }
 
   /** Publishes an artifact for consumption by the root project. */
@@ -936,14 +912,8 @@ internal class ProjectPlugin(private val project: Project) {
 
   private class JavaSources(project: Project) {
 
-    private val sourceSets = project.the<SourceSetContainer>()
-
-    val main: SourceSet? = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-
-    val test: SourceSet? = if (project.shouldAnalyzeTests()) {
-      sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME)
-    } else {
-      null
+    val sourceSets = project.the<SourceSetContainer>().matching {
+      s -> project.shouldAnalyzeTests() || s.name != SourceSet.TEST_SOURCE_SET_NAME
     }
 
     val hasJava: Provider<Boolean> = project.provider { sourceSets.flatMap { it.java() }.isNotEmpty() }

--- a/src/test/groovy/com/autonomousapps/model/declaration/VariantSpec.groovy
+++ b/src/test/groovy/com/autonomousapps/model/declaration/VariantSpec.groovy
@@ -9,7 +9,7 @@ class VariantSpec extends Specification {
     Variant.of(configurationName, [
       'main', 'release', 'debug', 'test', 'testDebug', 'testRelease',
       'flavor', 'flavorRelease', 'flavorDebug', 'testFlavorRelease', 'testFlavorDebug'
-    ] as Set<String>) == variant
+    ] as Set<String>, false) == variant
 
     where:
     configurationName                  | variant
@@ -48,7 +48,7 @@ class VariantSpec extends Specification {
     Variant.of(configurationName, [
       'main', 'release', 'debug', 'test', 'testDebug', 'testRelease',
       'flavor', 'flavorRelease', 'flavorDebug', 'testFlavorRelease', 'testFlavorDebug'
-    ] as Set<String>)
+    ] as Set<String>, false)
 
     then:
     thrown(IllegalArgumentException)

--- a/src/test/kotlin/com/autonomousapps/internal/configuration/ConfigurationsTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/configuration/ConfigurationsTest.kt
@@ -31,7 +31,7 @@ internal class ConfigurationsTest {
     ]
   )
   fun `can get variant from main configuration name`(configuration: String, variant: String) {
-    assertThat(Configurations.variantFrom(configuration, supportedSourceSets))
+    assertThat(Configurations.variantFrom(configuration, supportedSourceSets, false))
       .isEqualTo(Variant(variant, SourceSetKind.MAIN))
   }
 
@@ -49,7 +49,7 @@ internal class ConfigurationsTest {
     ]
   )
   fun `can get variant from test configuration name`(configuration: String, variant: String) {
-    assertThat(Configurations.variantFrom(configuration, supportedSourceSets))
+    assertThat(Configurations.variantFrom(configuration, supportedSourceSets, false))
       .isEqualTo(Variant(variant, SourceSetKind.TEST))
   }
 
@@ -67,7 +67,7 @@ internal class ConfigurationsTest {
     ]
   )
   fun `can get variant from androidTest configuration name`(configuration: String, variant: String) {
-    assertThat(Configurations.variantFrom(configuration, supportedSourceSets))
+    assertThat(Configurations.variantFrom(configuration, supportedSourceSets, false))
       .isEqualTo(Variant(variant, SourceSetKind.ANDROID_TEST))
   }
 


### PR DESCRIPTION
This adds analyzing dependencies **FROM** other source sets (which are not `main` or `test`) in standard Gradle 'java-library' and 'application' projects.

For example: `testFixturesImplementation(...)` or `integrationTestImplementation(...)`

This partially addresses #298 and #451, in particular the first item I listed in this comment: https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/298#issuecomment-1346159435


It is solved as follows:

- All source sets registered in the `SourceSetContainer` are marked as supported for 'java-library' and 'application' projects.
- For each source set, we check if it can have an ABI by checking if the `api...` configuration was created. This happens, if you define a Feature Variant on top of a source set.
- There is a new `SourceSetKind.CUSTOM_JVM` that is used for all source sets which are not 'main' or 'test'. In this case, the internal 'base variant' object is different (different name) depending on the source set's name.

At first, I considered having only one `SourceSetKind` for **all** JVM source sets (including 'main' and 'test'). But there is still the special behavior that **main** dependencies are automatically seen by **test**.

I think it is debatable, if this is really the right behavior. I.e., if I use something directly in my tests, why not also have a 'testImplementation' dependency in addition to 'implementation'. But we probably don't want to change the current behavior. It could be reconsidered in the future though and then I think all source sets in JVM projects could be treated equally (have the same SourceSetKind).

For custom source sets, I think the 'stricter' behavior is right, as they usually can't automatically see dependencies of other source sets.

**NOTE**: This is only the first half of what is described in https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/298#issuecomment-1346159435. When I work on that, I want to add more test cases to cover more scenarios and combinations.

TODO:

- [ ]  More test coverage as part of #854 