### PR TITLE
Support dependencies to other Feature Variants (including Test Fixtures)

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
@@ -32,36 +32,29 @@ final class AdviceHelper {
   }
 
   static ModuleCoordinates moduleCoordinates(com.autonomousapps.kit.Dependency dep) {
-    return moduleCoordinates(dep.identifier, dep.version,
-      dep.capability != null ? dep.capability : dep.identifier)
+    return moduleCoordinates(dep.identifier, dep.version)
   }
 
   static ModuleCoordinates moduleCoordinates(String gav) {
     def identifier = gav.substring(0, gav.lastIndexOf(':'))
     def version = gav.substring(gav.lastIndexOf(':') + 1, gav.length())
-    return new ModuleCoordinates(identifier, version, identifier)
+    return moduleCoordinates(identifier, version)
   }
 
-  static ModuleCoordinates moduleCoordinates(String identifier, String version,
-                                             String capability = identifier) {
-    return new ModuleCoordinates(identifier, version, capability)
+  static ModuleCoordinates moduleCoordinates(String identifier, String version, String capability = null) {
+    return new ModuleCoordinates(identifier, version, defaultGVI(capability))
   }
 
   static ProjectCoordinates projectCoordinates(com.autonomousapps.kit.Dependency dep) {
     return projectCoordinates(dep.identifier)
   }
 
-  static ProjectCoordinates projectCoordinates(String projectPath,
-                                               String capability = "the-project$projectPath") {
-    return new ProjectCoordinates(projectPath, capability)
+  static ProjectCoordinates projectCoordinates(String projectPath, String capability = null) {
+    return new ProjectCoordinates(projectPath, defaultGVI(capability))
   }
 
-  static Coordinates includedBuildCoordinates(
-    String identifier,
-    ProjectCoordinates resolvedProject,
-    String capability = identifier
-  ) {
-    return new IncludedBuildCoordinates(identifier, resolvedProject, capability)
+  static Coordinates includedBuildCoordinates(String identifier, ProjectCoordinates resolvedProject, String capability = null) {
+    return new IncludedBuildCoordinates(identifier, resolvedProject, defaultGVI(capability))
   }
 
   static Set<ProjectAdvice> emptyProjectAdviceFor(String... projectPaths) {
@@ -96,6 +89,10 @@ final class AdviceHelper {
     boolean shouldFail
   ) {
     return new ProjectAdvice(projectPath, advice, pluginAdvice, moduleAdvice, shouldFail)
+  }
+
+  private static GradleVariantIdentification defaultGVI(String capability) {
+    new GradleVariantIdentification(capability ? [capability] as Set : [] as Set, [:])
   }
 
   static final Set<ModuleAdvice> emptyModuleAdvice = []

--- a/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
@@ -32,7 +32,8 @@ final class AdviceHelper {
   }
 
   static ModuleCoordinates moduleCoordinates(com.autonomousapps.kit.Dependency dep) {
-    return moduleCoordinates(dep.identifier, dep.version)
+    return moduleCoordinates(dep.identifier, dep.version,
+      dep.capability != null ? dep.capability : dep.identifier)
   }
 
   static ModuleCoordinates moduleCoordinates(String gav) {

--- a/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
@@ -38,27 +38,29 @@ final class AdviceHelper {
   static ModuleCoordinates moduleCoordinates(String gav) {
     def identifier = gav.substring(0, gav.lastIndexOf(':'))
     def version = gav.substring(gav.lastIndexOf(':') + 1, gav.length())
-    return new ModuleCoordinates(identifier, version, '')
+    return new ModuleCoordinates(identifier, version, identifier)
   }
 
-  static ModuleCoordinates moduleCoordinates(String identifier, String version, String featureVariantName = "") {
-    return new ModuleCoordinates(identifier, version, featureVariantName)
+  static ModuleCoordinates moduleCoordinates(String identifier, String version,
+                                             String capability = identifier) {
+    return new ModuleCoordinates(identifier, version, capability)
   }
 
   static ProjectCoordinates projectCoordinates(com.autonomousapps.kit.Dependency dep) {
     return projectCoordinates(dep.identifier)
   }
 
-  static ProjectCoordinates projectCoordinates(String projectPath, String featureVariantName = "") {
-    return new ProjectCoordinates(projectPath, featureVariantName)
+  static ProjectCoordinates projectCoordinates(String projectPath,
+                                               String capability = "the-project$projectPath") {
+    return new ProjectCoordinates(projectPath, capability)
   }
 
   static Coordinates includedBuildCoordinates(
     String identifier,
     ProjectCoordinates resolvedProject,
-    String featureVariantName = ""
+    String capability = identifier
   ) {
-    return new IncludedBuildCoordinates(identifier, resolvedProject, featureVariantName)
+    return new IncludedBuildCoordinates(identifier, resolvedProject, capability)
   }
 
   static Set<ProjectAdvice> emptyProjectAdviceFor(String... projectPaths) {

--- a/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
@@ -41,23 +41,24 @@ final class AdviceHelper {
     return new ModuleCoordinates(identifier, version)
   }
 
-  static ModuleCoordinates moduleCoordinates(String identifier, String version) {
-    return new ModuleCoordinates(identifier, version)
+  static ModuleCoordinates moduleCoordinates(String identifier, String version, String featureVariantName = "") {
+    return new ModuleCoordinates(identifier, version, featureVariantName)
   }
 
   static ProjectCoordinates projectCoordinates(com.autonomousapps.kit.Dependency dep) {
     return projectCoordinates(dep.identifier)
   }
 
-  static ProjectCoordinates projectCoordinates(String projectPath) {
-    return new ProjectCoordinates(projectPath)
+  static ProjectCoordinates projectCoordinates(String projectPath, String featureVariantName = "") {
+    return new ProjectCoordinates(projectPath, featureVariantName)
   }
 
   static Coordinates includedBuildCoordinates(
     String identifier,
-    ProjectCoordinates resolvedProject
+    ProjectCoordinates resolvedProject,
+    String featureVariantName = ""
   ) {
-    return new IncludedBuildCoordinates(identifier, resolvedProject)
+    return new IncludedBuildCoordinates(identifier, resolvedProject, featureVariantName)
   }
 
   static Set<ProjectAdvice> emptyProjectAdviceFor(String... projectPaths) {

--- a/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
@@ -38,7 +38,7 @@ final class AdviceHelper {
   static ModuleCoordinates moduleCoordinates(String gav) {
     def identifier = gav.substring(0, gav.lastIndexOf(':'))
     def version = gav.substring(gav.lastIndexOf(':') + 1, gav.length())
-    return new ModuleCoordinates(identifier, version)
+    return new ModuleCoordinates(identifier, version, '')
   }
 
   static ModuleCoordinates moduleCoordinates(String identifier, String version, String featureVariantName = "") {

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ClassifiersSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ClassifiersSpec.groovy
@@ -24,11 +24,11 @@ final class ClassifiersSpec extends AbstractJvmSpec {
       gradleVersions(), ClassifierTestProject.TestProjectVariant.values().toList())
   }
 
-  def "transitive classifier dependencies do not lead to wrong advice (#gradleVersion withDependencyWithClassifier=#withDependencyWithClassifier)"() {
+  def "transitive classifier dependencies do not lead to wrong advice (#gradleVersion #variant)"() {
     shouldClean = false
 
     given:
-    def project = new TransitiveClassifierTestProject(withDependencyWithClassifier)
+    def project = new TransitiveClassifierTestProject(variant)
     gradleProject = project.gradleProject
 
     when:
@@ -38,6 +38,7 @@ final class ClassifiersSpec extends AbstractJvmSpec {
     assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth())
 
     where:
-    [gradleVersion, withDependencyWithClassifier] << multivariableDataPipe(gradleVersions(), [false, true])
+    [gradleVersion, variant] << multivariableDataPipe(
+      gradleVersions(), TransitiveClassifierTestProject.TestProjectVariant.values().toList())
   }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ClassifiersSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ClassifiersSpec.groovy
@@ -1,0 +1,25 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.ClassifierTestProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.google.common.truth.Truth.assertThat
+
+final class ClassifiersSpec extends AbstractJvmSpec {
+
+  def "dependencies with classifier does not lead to wrong advice (#gradleVersion #variant)"() {
+    given:
+    def project = new ClassifierTestProject(variant)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth())
+
+    where:
+    [gradleVersion, variant] << multivariableDataPipe(
+      gradleVersions(), ClassifierTestProject.TestProjectVariant.values().toList())
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ClassifiersSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ClassifiersSpec.groovy
@@ -1,6 +1,7 @@
 package com.autonomousapps.jvm
 
 import com.autonomousapps.jvm.projects.ClassifierTestProject
+import com.autonomousapps.jvm.projects.TransitiveClassifierTestProject
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
@@ -21,5 +22,22 @@ final class ClassifiersSpec extends AbstractJvmSpec {
     where:
     [gradleVersion, variant] << multivariableDataPipe(
       gradleVersions(), ClassifierTestProject.TestProjectVariant.values().toList())
+  }
+
+  def "transitive classifier dependencies do not lead to wrong advice (#gradleVersion withDependencyWithClassifier=#withDependencyWithClassifier)"() {
+    shouldClean = false
+
+    given:
+    def project = new TransitiveClassifierTestProject(withDependencyWithClassifier)
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth())
+
+    where:
+    [gradleVersion, withDependencyWithClassifier] << multivariableDataPipe(gradleVersions(), [false, true])
   }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/ClassifiersSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/ClassifiersSpec.groovy
@@ -25,8 +25,6 @@ final class ClassifiersSpec extends AbstractJvmSpec {
   }
 
   def "transitive classifier dependencies do not lead to wrong advice (#gradleVersion #variant)"() {
-    shouldClean = false
-
     given:
     def project = new TransitiveClassifierTestProject(variant)
     gradleProject = project.gradleProject

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -39,7 +39,7 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
     gradleVersion << gradleVersions()
   }
 
-  def "dependencies for feature variant do not produce any advice (#gradleVersion producerCodeInFeature=#producerCodeInFeature additionalCapabilities=#additionalCapabilities)"() {
+  def "dependencies to feature variants (#gradleVersion producerCodeInFeature=#producerCodeInFeature additionalCapabilities=#additionalCapabilities)"() {
     given:
     def project = new FeatureVariantTestProject(producerCodeInFeature, additionalCapabilities)
     gradleProject = project.gradleProject
@@ -55,7 +55,7 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
       gradleVersions(), [true, false], [true, false])
   }
 
-  def "dependencies for test fixtures do not produce any advice (#gradleVersion)"() {
+  def "dependencies to test fixtures (#gradleVersion)"() {
     given:
     def project = new TestFixturesTestProject()
     gradleProject = project.gradleProject

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -18,7 +18,7 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
     build(gradleVersion, gradleProject.rootDir, 'buildHealth')
 
     then:
-    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth(true))
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth())
 
     where:
     gradleVersion << gradleVersions()
@@ -33,7 +33,7 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
     build(gradleVersion, gradleProject.rootDir, 'buildHealth')
 
     then:
-    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth(false))
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth())
 
     where:
     gradleVersion << gradleVersions()

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -1,5 +1,6 @@
 package com.autonomousapps.jvm
 
+import com.autonomousapps.jvm.projects.FeatureVariantInSameProjectTestProject
 import com.autonomousapps.jvm.projects.FeatureVariantTestProject
 import com.autonomousapps.jvm.projects.IntegrationTestProject
 import com.autonomousapps.jvm.projects.TestFixturesTestProject
@@ -74,6 +75,21 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
   def "dependencies to main and test fixtures of another project are analysed correctly (#gradleVersion)"() {
     given:
     def project = new TestFixturesTestProject2()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "dependencies to different variants of the same project are analysed correctly (#gradleVersion)"() {
+    given:
+    def project = new FeatureVariantInSameProjectTestProject()
     gradleProject = project.gradleProject
 
     when:

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -3,6 +3,7 @@ package com.autonomousapps.jvm
 import com.autonomousapps.jvm.projects.FeatureVariantTestProject
 import com.autonomousapps.jvm.projects.IntegrationTestProject
 import com.autonomousapps.jvm.projects.TestFixturesTestProject
+import com.autonomousapps.jvm.projects.TestFixturesTestProject2
 
 import static com.autonomousapps.utils.Runner.build
 import static com.google.common.truth.Truth.assertThat
@@ -58,6 +59,21 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
   def "dependencies to test fixtures (#gradleVersion)"() {
     given:
     def project = new TestFixturesTestProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "dependencies to main and test fixtures of another project are analysed correctly (#gradleVersion)"() {
+    given:
+    def project = new TestFixturesTestProject2()
     gradleProject = project.gradleProject
 
     when:

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -72,19 +72,19 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
     gradleVersion << gradleVersions()
   }
 
-  def "dependencies to main and test fixtures of another project are analysed correctly (#gradleVersion)"() {
+  def "dependencies to main and test fixtures of another project are analysed correctly (#gradleVersion nestedProjects=#withNestedProjects)"() {
     given:
-    def project = new TestFixturesTestProject2()
+    def project = new TestFixturesTestProject2(withNestedProjects)
     gradleProject = project.gradleProject
 
     when:
     build(gradleVersion, gradleProject.rootDir, 'buildHealth')
 
     then:
-    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth())
 
     where:
-    gradleVersion << gradleVersions()
+    [gradleVersion, withNestedProjects] << multivariableDataPipe(gradleVersions(), [true, false])
   }
 
   def "dependencies to different variants of the same project are analysed correctly (#gradleVersion)"() {

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -39,9 +39,9 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
     gradleVersion << gradleVersions()
   }
 
-  def "dependencies for feature variant do not produce any advice (#gradleVersion)"() {
+  def "dependencies for feature variant do not produce any advice (#gradleVersion producerCodeInFeature=#producerCodeInFeature additionalCapabilities=#additionalCapabilities)"() {
     given:
-    def project = new FeatureVariantTestProject()
+    def project = new FeatureVariantTestProject(producerCodeInFeature, additionalCapabilities)
     gradleProject = project.gradleProject
 
     when:
@@ -51,7 +51,8 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
     assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
 
     where:
-    gradleVersion << gradleVersions()
+    [gradleVersion, producerCodeInFeature, additionalCapabilities] << multivariableDataPipe(
+      gradleVersions(), [true, false], [true, false])
   }
 
   def "dependencies for test fixtures do not produce any advice (#gradleVersion)"() {

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiAnnotationsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiAnnotationsProject.groovy
@@ -250,7 +250,7 @@ final class AbiAnnotationsProject extends AbstractProject {
   )
 
   private final Set<Advice> toCompileOnly = [Advice.ofChange(
-    new ProjectCoordinates(':annos', ""),
+    new ProjectCoordinates(':annos', 'the-project:annos'),
     'api',
     'compileOnly'
   )] as Set<Advice>

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiAnnotationsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiAnnotationsProject.groovy
@@ -8,7 +8,6 @@ import com.autonomousapps.kit.Source
 import com.autonomousapps.kit.SourceType
 import com.autonomousapps.model.Advice
 import com.autonomousapps.model.ProjectAdvice
-import com.autonomousapps.model.ProjectCoordinates
 
 import static com.autonomousapps.AdviceHelper.*
 import static com.autonomousapps.kit.Dependency.kotlinStdLib
@@ -250,7 +249,7 @@ final class AbiAnnotationsProject extends AbstractProject {
   )
 
   private final Set<Advice> toCompileOnly = [Advice.ofChange(
-    new ProjectCoordinates(':annos', 'the-project:annos'),
+    projectCoordinates(':annos'),
     'api',
     'compileOnly'
   )] as Set<Advice>

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiAnnotationsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiAnnotationsProject.groovy
@@ -250,7 +250,7 @@ final class AbiAnnotationsProject extends AbstractProject {
   )
 
   private final Set<Advice> toCompileOnly = [Advice.ofChange(
-    new ProjectCoordinates(':annos'),
+    new ProjectCoordinates(':annos', ""),
     'api',
     'compileOnly'
   )] as Set<Advice>

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiProject.groovy
@@ -10,6 +10,7 @@ import com.autonomousapps.model.ModuleCoordinates
 import com.autonomousapps.model.ProjectAdvice
 
 import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.moduleCoordinates
 import static com.autonomousapps.AdviceHelper.projectAdviceForDependencies
 import static com.autonomousapps.kit.Dependency.commonsCollections
 import static com.autonomousapps.kit.Dependency.kotlinStdLib
@@ -58,7 +59,7 @@ final class AbiProject extends AbstractProject {
   }
 
   private final projAdvice2 = [Advice.ofChange(
-    new ModuleCoordinates('org.apache.commons:commons-collections4', '4.4', 'org.apache.commons:commons-collections4'),
+    moduleCoordinates('org.apache.commons:commons-collections4', '4.4'),
     'api', 'implementation'
   )] as Set<Advice>
 

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiProject.groovy
@@ -58,7 +58,7 @@ final class AbiProject extends AbstractProject {
   }
 
   private final projAdvice2 = [Advice.ofChange(
-    new ModuleCoordinates('org.apache.commons:commons-collections4', '4.4', ''),
+    new ModuleCoordinates('org.apache.commons:commons-collections4', '4.4', 'org.apache.commons:commons-collections4'),
     'api', 'implementation'
   )] as Set<Advice>
 

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/AbiProject.groovy
@@ -58,7 +58,7 @@ final class AbiProject extends AbstractProject {
   }
 
   private final projAdvice2 = [Advice.ofChange(
-    new ModuleCoordinates('org.apache.commons:commons-collections4', '4.4'),
+    new ModuleCoordinates('org.apache.commons:commons-collections4', '4.4', ''),
     'api', 'implementation'
   )] as Set<Advice>
 

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ClassifierTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/ClassifierTestProject.groovy
@@ -1,0 +1,93 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.Dependency.slf4j
+import static com.autonomousapps.kit.Dependency.slf4jTests
+
+final class ClassifierTestProject extends AbstractProject {
+
+  final String variantCode
+  final boolean nothingUsed
+  final GradleProject gradleProject
+
+  enum TestProjectVariant {
+    ONLY_MAIN_NEEDED,
+    ONLY_CLASSIFIED_NEEDED,
+    BOTH_NEEDED,
+    NON_NEEDED
+  }
+
+  ClassifierTestProject(TestProjectVariant variant) {
+    switch (variant) {
+      case TestProjectVariant.ONLY_MAIN_NEEDED: variantCode = '''
+          public org.slf4j.Logger testLogger;
+        '''
+        break
+      case TestProjectVariant.ONLY_CLASSIFIED_NEEDED: variantCode ='''
+          private org.slf4j.basicTests.BasicMarkerTest basicMarkerTest;
+        '''
+        break
+      case TestProjectVariant.BOTH_NEEDED: variantCode ='''
+          public org.slf4j.Logger testLogger;
+          private org.slf4j.basicTests.BasicMarkerTest basicMarkerTest;
+        '''
+        break
+      case TestProjectVariant.NON_NEEDED: variantCode = ''
+        break
+    }
+    this.nothingUsed = variant == TestProjectVariant.NON_NEEDED
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('consumer') { s ->
+      s.sources = consumerTestSources()
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.dependencies = [
+          slf4j('testImplementation'),
+          slf4jTests('testImplementation'),
+        ]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private consumerTestSources() {[
+    new Source(
+      SourceType.JAVA, "ConsumerTest", "com/example/consumer/test",
+      """\
+        package com.example.consumer.test;
+
+        public class ConsumerTest {
+          $variantCode
+        }
+      """.stripIndent(),
+      "test"
+    )
+  ]}
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth() {[
+    nothingUsed
+      ? projectAdviceForDependencies(':consumer', [
+        Advice.ofRemove(moduleCoordinates(slf4j('')), 'testImplementation'),
+      ] as Set)
+      : emptyProjectAdviceFor(':consumer')
+  ]}
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantInSameProjectTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantInSameProjectTestProject.groovy
@@ -1,0 +1,77 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.Dependency.project
+
+final class FeatureVariantInSameProjectTestProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  FeatureVariantInSameProjectTestProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('single') { s ->
+      s.sources = sources
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.featureVariants = ['extraFeature']
+        bs.dependencies = [
+          project('extraFeatureApi', ':single')
+        ]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private sources = [
+    new Source(
+      SourceType.JAVA, "Example", "com/example",
+      """\
+        package com.example;
+        
+        public class Example {
+        }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.JAVA, "ExtraFeature", "com/example/extra",
+      """\
+        package com.example.extra;
+        
+        import com.example.Example;
+        
+        public class ExtraFeature {
+          private Example e;
+        }
+      """.stripIndent(),
+      "extraFeature"
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  private final Set<Advice> expectedAdvice = [
+    Advice.ofChange(projectCoordinates(':single'), 'extraFeatureApi', 'extraFeatureImplementation')
+  ]
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':single', expectedAdvice),
+  ]
+
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
@@ -101,7 +101,7 @@ final class FeatureVariantTestProject extends AbstractProject {
   ]
 
   private final Set<Advice> expectedConsumerAdvice = [
-    Advice.ofChange(projectCoordinates(':producer', 'extra-feature'), 'api', 'implementation'),
+    Advice.ofChange(projectCoordinates(':producer', 'examplegroup:producer-extra-feature'), 'api', 'implementation'),
   ]
 
   final Set<ProjectAdvice> expectedBuildHealth = [

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
@@ -129,7 +129,7 @@ final class FeatureVariantTestProject extends AbstractProject {
   private final Set<Advice> expectedConsumerAdvice = [
     Advice.ofChange(producerCodeInFeature
       ? projectCoordinates(':producer', 'examplegroup:producer-extra-feature')
-      : projectCoordinates(':producer', 'examplegroup:producer'),
+      : projectCoordinates(':producer'),
       'api', 'implementation')
   ]
 

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
@@ -13,9 +13,33 @@ import static com.autonomousapps.kit.Dependency.*
 
 final class FeatureVariantTestProject extends AbstractProject {
 
+  boolean producerCodeInFeature
+  String additionalCapabilities
+
   final GradleProject gradleProject
 
-  FeatureVariantTestProject() {
+  FeatureVariantTestProject(boolean producerCodeInFeature, boolean additionalCapabilities) {
+    this.producerCodeInFeature = producerCodeInFeature
+    this.additionalCapabilities = additionalCapabilities ? """
+      configurations.apiElements.outgoing {
+        capability("something.else:main:1")
+        capability("\${group}:\${name}:\${version}")
+        capability("something.else:mainB:2")
+      }
+      configurations.runtimeElements.outgoing {
+        capability("something.else:mainA:1")
+        capability("\${group}:\${name}:\${version}")
+        capability("something.else:mainB:2")
+      }
+      configurations.extraFeatureApiElements.outgoing {
+        capability("something.else:featureA:1")
+        capability("something.else:featureB:1")
+      }
+      configurations.extraFeatureRuntimeElements.outgoing {
+        capability("something.else:featureA:1")
+        capability("something.else:featureB:1")
+      }
+    """ : ""
     this.gradleProject = build()
   }
 
@@ -30,7 +54,7 @@ final class FeatureVariantTestProject extends AbstractProject {
           commonsCollections('api'),
           commonsCollections('extraFeatureApi')
         ]
-        bs.additions = 'group = "examplegroup"'
+        bs.additions = 'group = "examplegroup"' + additionalCapabilities
       }
     }
     builder.withSubproject('consumer') { s ->
@@ -38,7 +62,9 @@ final class FeatureVariantTestProject extends AbstractProject {
       s.withBuildScript { bs ->
         bs.plugins = [Plugin.javaLibraryPlugin]
         bs.dependencies = [
-          project('api', ':producer', 'examplegroup:producer-extra-feature')
+          producerCodeInFeature
+            ? project('api', ':producer', 'examplegroup:producer-extra-feature')
+            : project('api', ':producer')
         ]
       }
     }
@@ -72,7 +98,7 @@ final class FeatureVariantTestProject extends AbstractProject {
           private HashBag<String> internalBag;
         }
       """.stripIndent(),
-      "extraFeature"
+      producerCodeInFeature ? "extraFeature" : "main"
     )
   ]
 
@@ -95,12 +121,16 @@ final class FeatureVariantTestProject extends AbstractProject {
     return actualProjectAdvice(gradleProject)
   }
 
-  private final Set<Advice> expectedProducerAdvice = [
-    Advice.ofChange(moduleCoordinates(commonsCollections('')), 'extraFeatureApi', 'extraFeatureImplementation'),
+  private final Set<Advice> expectedProducerAdvice = [producerCodeInFeature
+    ? Advice.ofChange(moduleCoordinates(commonsCollections('')), 'extraFeatureApi', 'extraFeatureImplementation')
+    : Advice.ofRemove(moduleCoordinates(commonsCollections('')), 'extraFeatureApi'),
   ]
 
   private final Set<Advice> expectedConsumerAdvice = [
-    Advice.ofChange(projectCoordinates(':producer', 'examplegroup:producer-extra-feature'), 'api', 'implementation'),
+    Advice.ofChange(producerCodeInFeature
+      ? projectCoordinates(':producer', 'examplegroup:producer-extra-feature')
+      : projectCoordinates(':producer', 'examplegroup:producer'),
+      'api', 'implementation')
   ]
 
   final Set<ProjectAdvice> expectedBuildHealth = [

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
@@ -100,16 +100,8 @@ final class FeatureVariantTestProject extends AbstractProject {
     Advice.ofChange(moduleCoordinates(commonsCollections('')), 'extraFeatureApi', 'extraFeatureImplementation'),
   ]
 
-  // Note: 'producer-extra-feature.jar' is considered part of the 'main variant' of ':producer', which is not correct.
-  // This is due to the following:
-  // - PhysicalArtifact.coordinates only knows about component IDs, 'Module GA' or 'Project Name', but not capabilities.
-  //   This should probably be improved by adding the Capabilities GA coordinates to the 'Coordinates' data classes.
-  // - Right now, the plugin thinks that the 'producer-extra-feature.jar' artifact belongs to
-  //   'ProjectCoordinates(identifier=:producer)'. It finds classes in that Jar that are used.
-  //   But there is no dependency (without requires capabilities) to the producer project.
-  //   It gives the advice to add it.
   private final Set<Advice> expectedConsumerAdvice = [
-    Advice.ofAdd(projectCoordinates(':producer'), 'implementation'),
+    Advice.ofChange(projectCoordinates(':producer:extra-feature'), 'api', 'implementation'),
   ]
 
   final Set<ProjectAdvice> expectedBuildHealth = [

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
@@ -25,8 +25,7 @@ final class FeatureVariantTestProject extends AbstractProject {
       s.sources = sources
       s.withBuildScript { bs ->
         bs.plugins = [Plugin.javaLibraryPlugin]
-        bs.sourceSets = ['extraFeature',
-                         'java.registerFeature("extraFeature") { usingSourceSet(sourceSets.extraFeature) }']
+        bs.featureVariants = ['extraFeature']
         bs.dependencies = [
           commonsCollections('api'),
           commonsCollections('extraFeatureApi')

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/FeatureVariantTestProject.groovy
@@ -101,12 +101,10 @@ final class FeatureVariantTestProject extends AbstractProject {
   ]
 
   private final Set<Advice> expectedConsumerAdvice = [
-    Advice.ofChange(projectCoordinates(':producer:extra-feature'), 'api', 'implementation'),
+    Advice.ofChange(projectCoordinates(':producer', 'extra-feature'), 'api', 'implementation'),
   ]
 
   final Set<ProjectAdvice> expectedBuildHealth = [
-    // Not yet implemented:
-    // missing advice to move dependency 'consumer' -> 'producer-extra-feature' to implementation
     projectAdviceForDependencies(':consumer', expectedConsumerAdvice),
     projectAdviceForDependencies(':producer', expectedProducerAdvice)
   ]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildProject.groovy
@@ -68,7 +68,7 @@ final class IncludedBuildProject extends AbstractProject {
   final Set<ProjectAdvice> expectedBuildHealth = [
     projectAdviceForDependencies(':', [
       Advice.ofRemove(
-        includedBuildCoordinates('second:second-build', projectCoordinates(':')),
+        includedBuildCoordinates('second:second-build', projectCoordinates(':', 'second:second-build')),
         'implementation'
       )
     ] as Set<Advice>)

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IntegrationTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IntegrationTestProject.groovy
@@ -19,7 +19,7 @@ final class IntegrationTestProject extends AbstractProject {
     this.gradleProject = build(withCorrectIntegrationTestDependencies)
   }
 
-  private GradleProject build(boolean correctIntegrationTestDependencies) {
+  private GradleProject build(boolean withCorrectIntegrationTestDependencies) {
     def builder = newGradleProjectBuilder()
     builder.withSubproject('proj') { s ->
       s.sources = PROJ_SOURCES
@@ -28,7 +28,7 @@ final class IntegrationTestProject extends AbstractProject {
         bs.sourceSets = ['integrationTest']
         bs.dependencies = [
           project('implementation', ':lib'),
-          project('integrationTestImplementation', correctIntegrationTestDependencies ? ':core' : ':lib')
+          project('integrationTestImplementation', withCorrectIntegrationTestDependencies ? ':core' : ':lib')
         ]
       }
     }
@@ -123,8 +123,8 @@ final class IntegrationTestProject extends AbstractProject {
     return actualProjectAdvice(gradleProject)
   }
 
-  static Set<ProjectAdvice> expectedBuildHealth(boolean correctIntegrationTestDependencies) {
-    if (correctIntegrationTestDependencies) {
+  static Set<ProjectAdvice> expectedBuildHealth(boolean withCorrectIntegrationTestDependencies) {
+    if (withCorrectIntegrationTestDependencies) {
       [
         emptyProjectAdviceFor(':lib'),
         emptyProjectAdviceFor(':core'),

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IntegrationTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IntegrationTestProject.groovy
@@ -15,11 +15,14 @@ final class IntegrationTestProject extends AbstractProject {
 
   final GradleProject gradleProject
 
+  final boolean withCorrectIntegrationTestDependencies
+
   IntegrationTestProject(boolean withCorrectIntegrationTestDependencies) {
-    this.gradleProject = build(withCorrectIntegrationTestDependencies)
+    this.withCorrectIntegrationTestDependencies = withCorrectIntegrationTestDependencies
+    this.gradleProject = build()
   }
 
-  private GradleProject build(boolean withCorrectIntegrationTestDependencies) {
+  private GradleProject build() {
     def builder = newGradleProjectBuilder()
     builder.withSubproject('proj') { s ->
       s.sources = PROJ_SOURCES
@@ -123,7 +126,7 @@ final class IntegrationTestProject extends AbstractProject {
     return actualProjectAdvice(gradleProject)
   }
 
-  static Set<ProjectAdvice> expectedBuildHealth(boolean withCorrectIntegrationTestDependencies) {
+  Set<ProjectAdvice> expectedBuildHealth() {
     if (withCorrectIntegrationTestDependencies) {
       [
         emptyProjectAdviceFor(':lib'),

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject.groovy
@@ -99,8 +99,6 @@ final class TestFixturesTestProject extends AbstractProject {
   ]
 
   final Set<ProjectAdvice> expectedBuildHealth = [
-    // Not yet implemented:
-    // missing advice to move dependency 'consumer' -> 'producer-testFixtures' to implementation
     emptyProjectAdviceFor(':consumer'),
     projectAdviceForDependencies(':producer', expectedProducerAdvice)
   ]

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject2.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject2.groovy
@@ -1,0 +1,109 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.Dependency.project
+
+final class TestFixturesTestProject2 extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  TestFixturesTestProject2() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('producer') { s ->
+      s.sources = producerSources
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin, Plugin.javaTestFixturesPlugin]
+      }
+    }
+    builder.withSubproject('consumer') { s ->
+      s.sources = consumerSources
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.dependencies = [
+          project('implementation', ':producer'),
+          project('testImplementation', ':producer', 'test-fixtures')
+        ]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private producerSources = [
+    new Source(
+      SourceType.JAVA, "Example", "com/example",
+      """\
+        package com.example;
+        
+        public class Example {
+        }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.JAVA, "ExampleFixture", "com/example/fixtures",
+      """\
+        package com.example.fixtures;
+        
+        import com.example.Example;
+        
+        public class ExampleFixture {
+          private Example internalExample;
+        }
+      """.stripIndent(),
+      "testFixtures"
+    )
+  ]
+
+  private consumerSources = [
+    new Source(
+      SourceType.JAVA, "Consumer", "com/example",
+      """\
+        package com.example.consumer;
+        
+        import com.example.Example;
+        
+        public class Consumer {
+          private Example internalExample;
+        }
+      """.stripIndent()
+    ),
+    new Source(
+      SourceType.JAVA, "ConsumerTest", "com/example/consumer/test",
+      """\
+        package com.example.consumer.test;
+        
+        import com.example.consumer.Consumer;
+        import com.example.fixtures.ExampleFixture;
+        
+        public class ConsumerTest {
+          private ExampleFixture fixture;
+          private Consumer consumer;
+        }
+      """.stripIndent(),
+      "test"
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    emptyProjectAdviceFor(':consumer'),
+    emptyProjectAdviceFor(':producer')
+  ]
+
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject2.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject2.groovy
@@ -5,6 +5,7 @@ import com.autonomousapps.kit.GradleProject
 import com.autonomousapps.kit.Plugin
 import com.autonomousapps.kit.Source
 import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.Advice
 import com.autonomousapps.model.ProjectAdvice
 
 import static com.autonomousapps.AdviceHelper.*
@@ -31,7 +32,8 @@ final class TestFixturesTestProject2 extends AbstractProject {
       s.withBuildScript { bs ->
         bs.plugins = [Plugin.javaLibraryPlugin]
         bs.dependencies = [
-          project('implementation', ':producer'),
+          project('api', ':producer'),
+          project('api', ':producer', 'test-fixtures'),
           project('testImplementation', ':producer', 'test-fixtures')
         ]
       }
@@ -101,8 +103,13 @@ final class TestFixturesTestProject2 extends AbstractProject {
     return actualProjectAdvice(gradleProject)
   }
 
+  private final Set<Advice> expectedConsumerAdvice = [
+    Advice.ofChange(projectCoordinates(':producer'), 'api', 'implementation'),
+    Advice.ofRemove(projectCoordinates(':producer', 'the-project:producer-test-fixtures'), 'api'),
+  ]
+
   final Set<ProjectAdvice> expectedBuildHealth = [
-    emptyProjectAdviceFor(':consumer'),
+    projectAdviceForDependencies(':consumer', expectedConsumerAdvice),
     emptyProjectAdviceFor(':producer')
   ]
 

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TransitiveClassifierTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TransitiveClassifierTestProject.groovy
@@ -11,14 +11,47 @@ import com.autonomousapps.model.ProjectAdvice
 import static com.autonomousapps.AdviceHelper.*
 import static com.autonomousapps.kit.Dependency.androidJoda
 import static com.autonomousapps.kit.Dependency.jodaTimeNoTzdbClassifier
+import static com.autonomousapps.kit.Dependency.jodaTimeNoTzdbFeature
+import static com.autonomousapps.kit.Dependency.project
 
 final class TransitiveClassifierTestProject extends AbstractProject {
 
-  final boolean withDependencyWithCapability
+  enum TestProjectVariant {
+    DEPENDENCY_WITH_CLASSIFIER_EXISTS,
+    ADVICE_DEPENDENCY_WITH_CLASSIFIER,
+    ADVICE_DEPENDENCY_WITH_CAPABILITY
+  }
+
+  static fixJodaTimeVariantsMetadataRule = '''
+    dependencies.components.withModule('joda-time:joda-time') {
+        addVariant('noTzdbCompile', 'compile') {
+            withCapabilities {
+                removeCapability('joda-time', 'joda-time')
+                addCapability('joda-time', 'joda-time-no-tzdb', id.version)
+            }
+            withFiles {
+                removeAllFiles()
+                addFile("joda-time-${id.version}-no-tzdb.jar")
+            }
+        }
+        addVariant('noTzdbRuntime', 'runtime') {
+            withCapabilities {
+                removeCapability('joda-time', 'joda-time')
+                addCapability('joda-time', 'joda-time-no-tzdb', id.version)
+            }
+            withFiles {
+                removeAllFiles()
+                addFile("joda-time-${id.version}-no-tzdb.jar")
+            }
+        }
+    }
+  '''.stripIndent()
+
+  final TestProjectVariant variant
   final GradleProject gradleProject
 
-  TransitiveClassifierTestProject(boolean withDependencyWithClassifier) {
-    this.withDependencyWithCapability = withDependencyWithClassifier
+  TransitiveClassifierTestProject(TestProjectVariant variant) {
+    this.variant = variant
     this.gradleProject = build()
   }
 
@@ -28,18 +61,38 @@ final class TransitiveClassifierTestProject extends AbstractProject {
       s.sources = consumerSources
       s.withBuildScript { bs ->
         bs.plugins = [Plugin.javaLibraryPlugin]
-        bs.dependencies = withDependencyWithCapability
-        ? [
-          androidJoda('implementation'),
-          jodaTimeNoTzdbClassifier('implementation')
-        ]
-        : [
-          androidJoda('implementation')
+        bs.additions = fixJodaTimeVariantsMetadataRule
+        switch (variant) {
+          case TestProjectVariant.DEPENDENCY_WITH_CLASSIFIER_EXISTS:
+            bs.dependencies = [
+              androidJoda('implementation'),
+              jodaTimeNoTzdbClassifier('implementation')
+            ]
+            break
+          case TestProjectVariant.ADVICE_DEPENDENCY_WITH_CLASSIFIER:
+            bs.dependencies = [
+              androidJoda('implementation')
+            ]
+            break
+          case TestProjectVariant.ADVICE_DEPENDENCY_WITH_CAPABILITY:
+            bs.dependencies = [
+              // Use the local 'android.joda' that has a proper dependency with capability to 'joda-time-no-tzdb'
+              project('implementation', ':android.joda')
+            ]
+            break
+        }
+      }
+    }
+    builder.withSubproject('android.joda') { s ->
+      s.sources = androidJodaSources
+      s.withBuildScript { bs ->
+        bs.additions = 'group = "local.test"\n' + fixJodaTimeVariantsMetadataRule
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.dependencies = [
+          jodaTimeNoTzdbFeature('api')
         ]
       }
     }
-    // TODO Add subproject which mimics android.joda's transitive dependency setup but with 'requiresCapability'.
-    //      Then add a another case to the test that shows that everything is correct if feature variants would be used.
 
     def project = builder.build()
     project.writer().write()
@@ -61,21 +114,44 @@ final class TransitiveClassifierTestProject extends AbstractProject {
     )
   ]
 
+  private androidJodaSources = [
+    new Source(
+      SourceType.JAVA, "DateUtils", "com/example/android/joda",
+      """\
+        package com.example.consumer.test;
+
+        import org.joda.time.DateMidnight;
+
+        public class DateUtils {
+          public DateMidnight midnight;
+        }
+      """.stripIndent()
+    )
+  ]
+
   Set<ProjectAdvice> actualBuildHealth() {
     return actualProjectAdvice(gradleProject)
   }
 
+  private final Set<Advice> expectedConsumerAdvice() {
+    switch (variant) {
+      case TestProjectVariant.DEPENDENCY_WITH_CLASSIFIER_EXISTS:
+        return [Advice.ofRemove(moduleCoordinates(androidJoda('')), 'implementation')]
+      case TestProjectVariant.ADVICE_DEPENDENCY_WITH_CLASSIFIER:
+        return [Advice.ofRemove(moduleCoordinates(androidJoda('')), 'implementation'),
+                // TODO https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/342
+                //      This suggests adding the dependency without the classifier, as there is not way we can say with
+                //      certainty that a classifier is needed.
+                Advice.ofAdd(moduleCoordinates('joda-time:joda-time', '2.10.7'), 'implementation')]
+      case TestProjectVariant.ADVICE_DEPENDENCY_WITH_CAPABILITY:
+        return [Advice.ofRemove(projectCoordinates(':android.joda', 'local.test:android.joda'), 'implementation'),
+                Advice.ofAdd(moduleCoordinates('joda-time:joda-time', '2.10.7', 'joda-time:joda-time-no-tzdb'), 'implementation')]
+    }
+    return []
+  }
+
   final Set<ProjectAdvice> expectedBuildHealth() {[
-    withDependencyWithCapability
-    ? projectAdviceForDependencies(':consumer', [
-      Advice.ofRemove(moduleCoordinates(androidJoda('')), 'implementation')
-    ] as Set)
-    : projectAdviceForDependencies(':consumer', [
-      // TODO https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/342
-      //      This suggests adding the dependency without the classifier, as there is not way we can say with
-      //      certainty that a classifier is needed.
-      Advice.ofAdd(moduleCoordinates('joda-time:joda-time', '2.10.7'), 'implementation'),
-      Advice.ofRemove(moduleCoordinates(androidJoda('')), 'implementation')
-    ] as Set)
+    emptyProjectAdviceFor(':android.joda'),
+    projectAdviceForDependencies(':consumer', expectedConsumerAdvice())
   ]}
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TransitiveClassifierTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TransitiveClassifierTestProject.groovy
@@ -140,11 +140,11 @@ final class TransitiveClassifierTestProject extends AbstractProject {
       case TestProjectVariant.ADVICE_DEPENDENCY_WITH_CLASSIFIER:
         return [Advice.ofRemove(moduleCoordinates(androidJoda('')), 'implementation'),
                 // TODO https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/342
-                //      This suggests adding the dependency without the classifier, as there is not way we can say with
-                //      certainty that a classifier is needed.
+                //      Currently, we suggest adding the dependency without the classifier, as there is no way we
+                //      can say with certainty that a classifier is needed.
                 Advice.ofAdd(moduleCoordinates('joda-time:joda-time', '2.10.7'), 'implementation')]
       case TestProjectVariant.ADVICE_DEPENDENCY_WITH_CAPABILITY:
-        return [Advice.ofRemove(projectCoordinates(':android.joda', 'local.test:android.joda'), 'implementation'),
+        return [Advice.ofRemove(projectCoordinates(':android.joda'), 'implementation'),
                 Advice.ofAdd(moduleCoordinates('joda-time:joda-time', '2.10.7', 'joda-time:joda-time-no-tzdb'), 'implementation')]
     }
     return []

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TransitiveClassifierTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TransitiveClassifierTestProject.groovy
@@ -1,0 +1,81 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.Dependency.androidJoda
+import static com.autonomousapps.kit.Dependency.jodaTimeNoTzdbClassifier
+
+final class TransitiveClassifierTestProject extends AbstractProject {
+
+  final boolean withDependencyWithCapability
+  final GradleProject gradleProject
+
+  TransitiveClassifierTestProject(boolean withDependencyWithClassifier) {
+    this.withDependencyWithCapability = withDependencyWithClassifier
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('consumer') { s ->
+      s.sources = consumerSources
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.dependencies = withDependencyWithCapability
+        ? [
+          androidJoda('implementation'),
+          jodaTimeNoTzdbClassifier('implementation')
+        ]
+        : [
+          androidJoda('implementation')
+        ]
+      }
+    }
+    // TODO Add subproject which mimics android.joda's transitive dependency setup but with 'requiresCapability'.
+    //      Then add a another case to the test that shows that everything is correct if feature variants would be used.
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private consumerSources = [
+    new Source(
+      SourceType.JAVA, "Consumer", "com/example/consumer",
+      """\
+        package com.example.consumer.test;
+
+        import org.joda.time.DateMidnight;
+
+        public class Consumer {
+          DateMidnight midnight;
+        }
+      """.stripIndent()
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth() {[
+    withDependencyWithCapability
+    ? projectAdviceForDependencies(':consumer', [
+      Advice.ofRemove(moduleCoordinates(androidJoda('')), 'implementation')
+    ] as Set)
+    : projectAdviceForDependencies(':consumer', [
+      // TODO https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/342
+      //      This suggests adding the dependency without the classifier, as there is not way we can say with
+      //      certainty that a classifier is needed.
+      Advice.ofAdd(moduleCoordinates('joda-time:joda-time', '2.10.7'), 'implementation'),
+      Advice.ofRemove(moduleCoordinates(androidJoda('')), 'implementation')
+    ] as Set)
+  ]}
+}

--- a/src/functionalTest/kotlin/com/autonomousapps/fixtures/CompileOnlyTestProject.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/fixtures/CompileOnlyTestProject.kt
@@ -76,14 +76,14 @@ class CompileOnlyTestProject(
   )
 
   val expectedAdviceForApp =
-    """[{"coordinates":{"type":"module","identifier":"androidx.annotation:annotation","resolvedVersion":"1.1.0"},"fromConfiguration":"implementation","toConfiguration":"compileOnly"}]"""
+    """[{"coordinates":{"type":"module","identifier":"androidx.annotation:annotation","resolvedVersion":"1.1.0","gradleVariantIdentification":{"capabilities":[],"attributes":{}}},"fromConfiguration":"implementation","toConfiguration":"compileOnly"}]"""
       .fromJsonSet<Advice>()
 
   val expectedAdviceForAndroidKotlinLib =
-    """[{"coordinates":{"type":"module","identifier":"com.google.auto.value:auto-value-annotations","resolvedVersion":"1.6"},"fromConfiguration":"implementation","toConfiguration":"compileOnly"}]"""
+    """[{"coordinates":{"type":"module","identifier":"com.google.auto.value:auto-value-annotations","resolvedVersion":"1.6","gradleVariantIdentification":{"capabilities":[],"attributes":{}}},"fromConfiguration":"implementation","toConfiguration":"compileOnly"}]"""
       .fromJsonSet<Advice>()
 
   val expectedAdviceForJavaJvmLib =
-    """[{"coordinates":{"type":"module","identifier":"com.google.auto.value:auto-value-annotations","resolvedVersion":"1.6"},"fromConfiguration":"implementation","toConfiguration":"compileOnly"}]"""
+    """[{"coordinates":{"type":"module","identifier":"com.google.auto.value:auto-value-annotations","resolvedVersion":"1.6","gradleVariantIdentification":{"capabilities":[],"attributes":{}}},"fromConfiguration":"implementation","toConfiguration":"compileOnly"}]"""
       .fromJsonSet<Advice>()
 }

--- a/src/functionalTest/kotlin/com/autonomousapps/fixtures/JvmDaggerProject.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/fixtures/JvmDaggerProject.kt
@@ -1,6 +1,7 @@
 package com.autonomousapps.fixtures
 
 import com.autonomousapps.model.Advice
+import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.ModuleCoordinates
 import java.io.File
 
@@ -47,8 +48,14 @@ class JvmDaggerProject : ProjectDirProvider {
 
     @JvmStatic
     fun expectedAdvice() = setOf(
-      Advice.ofRemove(ModuleCoordinates("com.google.dagger:dagger", "2.24"), "implementation"),
-      Advice.ofRemove(ModuleCoordinates("com.google.dagger:dagger-compiler", "2.24"), "annotationProcessor")
+      Advice.ofRemove(
+        ModuleCoordinates("com.google.dagger:dagger", "2.24", GradleVariantIdentification(emptySet(), emptyMap())),
+        "implementation"
+      ),
+      Advice.ofRemove(
+        ModuleCoordinates("com.google.dagger:dagger-compiler", "2.24", GradleVariantIdentification(emptySet(), emptyMap())),
+        "annotationProcessor"
+      ),
     )
   }
 }

--- a/src/functionalTest/kotlin/com/autonomousapps/fixtures/KtxProject.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/fixtures/KtxProject.kt
@@ -2,6 +2,7 @@ package com.autonomousapps.fixtures
 
 import com.autonomousapps.kit.Plugin
 import com.autonomousapps.model.Advice
+import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.ModuleCoordinates
 
 /**
@@ -77,7 +78,7 @@ class KtxProject(
         // contributed by the -ktx dependency.
         if (useKtx) {
           // Suggest changing if being used
-          setOf(removeUsedKtx, addTransitive)
+          setOf(removeKtx, addTransitive)
         } else {
           // Suggest removing unused dependencies
           setOf(removeKtx)
@@ -86,15 +87,12 @@ class KtxProject(
     }
 
   private val removeKtx = Advice.ofRemove(
-    ModuleCoordinates("androidx.preference:preference-ktx", "1.1.0"), "implementation"
-  )
-
-  private val removeUsedKtx = Advice.ofRemove(
-    ModuleCoordinates("androidx.preference:preference-ktx", "1.1.0"), "implementation"
+    ModuleCoordinates("androidx.preference:preference-ktx", "1.1.0", GradleVariantIdentification(emptySet(), emptyMap())),
+    "implementation"
   )
 
   private val addTransitive = Advice.ofAdd(
-    ModuleCoordinates("androidx.preference:preference", "1.1.0"),
+    ModuleCoordinates("androidx.preference:preference", "1.1.0", GradleVariantIdentification(emptySet(), emptyMap())),
     toConfiguration = "implementation"
   )
 }

--- a/src/functionalTest/kotlin/com/autonomousapps/fixtures/LeakCanaryProject.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/fixtures/LeakCanaryProject.kt
@@ -2,6 +2,7 @@ package com.autonomousapps.fixtures
 
 import com.autonomousapps.kit.Plugin
 import com.autonomousapps.model.Advice
+import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.ModuleCoordinates
 
 class LeakCanaryProject(private val agpVersion: String) {
@@ -33,7 +34,8 @@ class LeakCanaryProject(private val agpVersion: String) {
 
   val expectedAdviceForApp = setOf(
     Advice.ofChange(
-      ModuleCoordinates("com.squareup.leakcanary:leakcanary-android", "2.2"), "debugImplementation", "debugRuntimeOnly"
+      ModuleCoordinates("com.squareup.leakcanary:leakcanary-android", "2.2", GradleVariantIdentification(emptySet(), emptyMap())),
+      "debugImplementation", "debugRuntimeOnly"
     )
   )
 }

--- a/src/functionalTest/kotlin/com/autonomousapps/fixtures/SingleProject.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/fixtures/SingleProject.kt
@@ -1,6 +1,7 @@
 package com.autonomousapps.fixtures
 
 import com.autonomousapps.model.Advice
+import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.ModuleCoordinates
 import java.io.File
 
@@ -46,8 +47,14 @@ class SingleProject : ProjectDirProvider {
 
     @JvmStatic
     fun expectedAdvice() = setOf(
-      Advice.ofRemove(ModuleCoordinates("com.google.guava:guava", "28.2-jre"), "implementation"),
-      Advice.ofRemove(ModuleCoordinates("org.apache.commons:commons-math3", "3.6.1"), "api")
+      Advice.ofRemove(
+        ModuleCoordinates("com.google.guava:guava", "28.2-jre", GradleVariantIdentification(emptySet(), emptyMap())),
+        "implementation"
+      ),
+      Advice.ofRemove(
+        ModuleCoordinates("org.apache.commons:commons-math3", "3.6.1", GradleVariantIdentification(emptySet(), emptyMap())),
+        "api"
+      )
     )
   }
 }

--- a/src/functionalTest/kotlin/com/autonomousapps/fixtures/annotationProcessorProjects.kt
+++ b/src/functionalTest/kotlin/com/autonomousapps/fixtures/annotationProcessorProjects.kt
@@ -3,6 +3,7 @@ package com.autonomousapps.fixtures
 import com.autonomousapps.advice.PluginAdvice
 import com.autonomousapps.kit.Plugin
 import com.autonomousapps.model.Advice
+import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.ModuleCoordinates
 
 class DaggerProjectUsedByAnnotationProcessorForMethod(private val agpVersion: String) {
@@ -103,7 +104,8 @@ class DaggerProjectUnusedByAnnotationProcessor(private val agpVersion: String) {
 
   val expectedAdviceForApp = setOf(
     Advice.ofRemove(
-      ModuleCoordinates("com.google.dagger:dagger-compiler", "2.24"),
+      ModuleCoordinates(
+        "com.google.dagger:dagger-compiler", "2.24", GradleVariantIdentification(emptySet(), emptyMap())),
       fromConfiguration = "annotationProcessor"
     )
   )
@@ -206,7 +208,10 @@ class DaggerProjectUnusedByKapt(private val agpVersion: String) {
   )
 
   val expectedAdviceForApp = setOf(
-    Advice.ofRemove(ModuleCoordinates("com.google.dagger:dagger-compiler", "2.24"), "kapt")
+    Advice.ofRemove(
+      ModuleCoordinates(
+        "com.google.dagger:dagger-compiler", "2.24", GradleVariantIdentification(emptySet(), emptyMap())),
+      "kapt")
   )
 }
 
@@ -314,7 +319,7 @@ class KaptIsRedundantWithUnusedProcsProject(agpVersion: String) {
   val expectedAdvice = setOf(PluginAdvice.redundantKapt())
 }
 
-private val transitiveDagger = ModuleCoordinates("com.google.dagger:dagger", "2.24")
-private val transitiveInject = ModuleCoordinates("javax.inject:javax.inject", "1")
-private val transitiveInject2 = ModuleCoordinates("javax.inject:javax.inject", "1")
-private val daggerAndroidComponent = ModuleCoordinates("com.google.dagger:dagger-android", "2.24")
+private val transitiveDagger = ModuleCoordinates("com.google.dagger:dagger", "2.24", GradleVariantIdentification(emptySet(), emptyMap()))
+private val transitiveInject = ModuleCoordinates("javax.inject:javax.inject", "1", GradleVariantIdentification(emptySet(), emptyMap()))
+private val transitiveInject2 = ModuleCoordinates("javax.inject:javax.inject", "1", GradleVariantIdentification(emptySet(), emptyMap()))
+private val daggerAndroidComponent = ModuleCoordinates("com.google.dagger:dagger-android", "2.24", GradleVariantIdentification(emptySet(), emptyMap()))

--- a/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
@@ -132,7 +132,8 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
         view.graph.nodes()
           .filter { it.identifier.endsWith("-jvm") }
           .mapNotNull { jvm ->
-            val kmp = jvm.copy(identifier = jvm.identifier.substringBeforeLast("-jvm"))
+            val kmpIdentifier = jvm.identifier.substringBeforeLast("-jvm")
+            val kmp = jvm.copy(identifier = kmpIdentifier, capability = kmpIdentifier)
             if (view.graph.hasEdgeConnecting(kmp, jvm)) {
               kmp to jvm
             } else {

--- a/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
@@ -3,11 +3,8 @@ package com.autonomousapps.internal
 import com.autonomousapps.extension.DependenciesHandler.SerializableBundles
 import com.autonomousapps.graph.Graphs.children
 import com.autonomousapps.graph.Graphs.reachableNodes
-import com.autonomousapps.model.Advice
-import com.autonomousapps.model.Coordinates
+import com.autonomousapps.model.*
 import com.autonomousapps.model.Coordinates.Companion.copy
-import com.autonomousapps.model.DependencyGraphView
-import com.autonomousapps.model.ProjectCoordinates
 import com.autonomousapps.model.declaration.Bucket
 import com.autonomousapps.model.intermediates.Usage
 
@@ -59,10 +56,10 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
     }
   }
 
-  fun maybePrimary(addAdvice: Advice): Advice {
+  fun maybePrimary(addAdvice: Advice, originalCoordinates: Coordinates): Advice {
     check(addAdvice.isAdd()) { "Must be add-advice" }
-    return primaryPointers[addAdvice.coordinates]?.let { primary ->
-      addAdvice.copy(coordinates = primary)
+    return primaryPointers[originalCoordinates]?.let { primary ->
+      addAdvice.copy(coordinates = primary.withoutDefaultCapability())
     } ?: addAdvice
   }
 
@@ -133,7 +130,7 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
           .filter { it.identifier.endsWith("-jvm") }
           .mapNotNull { jvm ->
             val kmpIdentifier = jvm.identifier.substringBeforeLast("-jvm")
-            val kmp = jvm.copy(identifier = kmpIdentifier, capability = kmpIdentifier)
+            val kmp = jvm.copy(kmpIdentifier, GradleVariantIdentification(setOf(kmpIdentifier), jvm.gradleVariantIdentification.attributes))
             if (view.graph.hasEdgeConnecting(kmp, jvm)) {
               kmp to jvm
             } else {

--- a/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
@@ -2,6 +2,7 @@ package com.autonomousapps.internal.advice
 
 import com.autonomousapps.model.Advice
 import com.autonomousapps.model.Coordinates
+import com.autonomousapps.model.ModuleCoordinates
 import com.autonomousapps.model.ProjectCoordinates
 
 internal class AdvicePrinter(
@@ -10,21 +11,41 @@ internal class AdvicePrinter(
   private val dependencyMap: (String) -> String = { it },
 ) {
 
-  fun line(configuration: String, printableIdentifier: String, was: String = ""): String = when (dslKind) {
-    DslKind.KOTLIN -> "  $configuration($printableIdentifier)$was"
-    DslKind.GROOVY -> "  $configuration $printableIdentifier$was"
-  }
+  fun line(configuration: String, printableIdentifier: String, was: String = ""): String =
+    "  $configuration$printableIdentifier$was"
 
-  fun toDeclaration(advice: Advice): String = when (dslKind) {
-    DslKind.KOTLIN -> "  ${advice.toConfiguration}(${gav(advice.coordinates)})"
-    DslKind.GROOVY -> "  ${advice.toConfiguration} ${gav(advice.coordinates)}"
-  }
+  fun toDeclaration(advice: Advice): String =
+    "  ${advice.toConfiguration}${gav(advice.coordinates)}"
 
   fun gav(coordinates: Coordinates): String {
     val quotedDep = coordinates.mapped()
     return when (coordinates) {
       is ProjectCoordinates -> if (dslKind == DslKind.KOTLIN) "project(${quotedDep})" else "project(${quotedDep})"
       else -> if (dslKind == DslKind.KOTLIN) quotedDep else quotedDep
+    }.let {
+      if (coordinates.featureVariantName.isEmpty()) {
+        when (dslKind) {
+          DslKind.KOTLIN -> "($it)"
+          DslKind.GROOVY -> " $it"
+        }
+      } else if (coordinates.featureVariantName == "test-fixtures") {
+        when (dslKind) {
+          DslKind.KOTLIN -> "(testFixtures($it))"
+          DslKind.GROOVY -> " testFixtures($it)"
+        }
+      } else {
+        val capability = when (coordinates) {
+          // TODO could probably pass the group around in ProjectCoordinates
+          is ProjectCoordinates -> "[group]${coordinates.identifier}-${coordinates.featureVariantName}"
+          is ModuleCoordinates -> "${coordinates.identifier}-${coordinates.featureVariantName}"
+          else -> "[group]:${coordinates.identifier}-${coordinates.featureVariantName}"
+        }
+        val quote = when (dslKind) {
+          DslKind.KOTLIN -> "\""
+          DslKind.GROOVY -> "'"
+        }
+        "($it) { capabilities { requireCapabilities($quote$capability$quote) } }"
+      }
     }
   }
 

--- a/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
@@ -27,7 +27,7 @@ internal class AdvicePrinter(
           DslKind.KOTLIN -> "($id)"
           DslKind.GROOVY -> " $id"
         }
-      } else if (coordinates.gradleVariantIdentification.capabilities.any { it.endsWith(":test-fixtures") }) {
+      } else if (coordinates.gradleVariantIdentification.capabilities.any { it.endsWith("-test-fixtures") }) {
         when (dslKind) {
           DslKind.KOTLIN -> "(testFixtures($id))"
           DslKind.GROOVY -> " testFixtures($id)"

--- a/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/advice/AdvicePrinter.kt
@@ -23,28 +23,23 @@ internal class AdvicePrinter(
       is ProjectCoordinates -> if (dslKind == DslKind.KOTLIN) "project(${quotedDep})" else "project(${quotedDep})"
       else -> if (dslKind == DslKind.KOTLIN) quotedDep else quotedDep
     }.let {
-      if (coordinates.featureVariantName.isEmpty()) {
+      // Used 'endsWith' instead of '==' as project coordinates do not include their group right now
+      if (coordinates.capability.endsWith(coordinates.identifier)) {
         when (dslKind) {
           DslKind.KOTLIN -> "($it)"
           DslKind.GROOVY -> " $it"
         }
-      } else if (coordinates.featureVariantName == "test-fixtures") {
+      } else if (coordinates.capability.endsWith(":test-fixtures")) {
         when (dslKind) {
           DslKind.KOTLIN -> "(testFixtures($it))"
           DslKind.GROOVY -> " testFixtures($it)"
         }
       } else {
-        val capability = when (coordinates) {
-          // TODO could probably pass the group around in ProjectCoordinates
-          is ProjectCoordinates -> "[group]${coordinates.identifier}-${coordinates.featureVariantName}"
-          is ModuleCoordinates -> "${coordinates.identifier}-${coordinates.featureVariantName}"
-          else -> "[group]:${coordinates.identifier}-${coordinates.featureVariantName}"
-        }
         val quote = when (dslKind) {
           DslKind.KOTLIN -> "\""
           DslKind.GROOVY -> "'"
         }
-        "($it) { capabilities { requireCapabilities($quote$capability$quote) } }"
+        "($it) { capabilities { requireCapabilities($quote${coordinates.capability}$quote) } }"
       }
     }
   }

--- a/src/main/kotlin/com/autonomousapps/internal/graph/GraphViewBuilder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/graph/GraphViewBuilder.kt
@@ -14,7 +14,7 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult
 
 /** Walks the resolved dependency graph to create a dependency graph rooted on the current project. */
 @Suppress("UnstableApiUsage") // Guava Graph
-internal class GraphViewBuilder(conf: Configuration, projectName: String) {
+internal class GraphViewBuilder(conf: Configuration) {
 
   val graph: Graph<Coordinates>
 
@@ -30,19 +30,19 @@ internal class GraphViewBuilder(conf: Configuration, projectName: String) {
 
     val rootId = conf.rootCoordinates()
 
-    walkFileDeps(conf, rootId, projectName)
+    walkFileDeps(conf, rootId)
     walk(root, rootId)
 
     graph = graphBuilder.build()
   }
 
-  private fun walkFileDeps(conf: Configuration, rootId: Coordinates, projectName: String) {
+  private fun walkFileDeps(conf: Configuration, rootId: Coordinates) {
     graphBuilder.addNode(rootId)
 
     // the only way to get flat jar file dependencies
     conf.allDependencies
       .filterIsInstance<FileCollectionDependency>()
-      .mapNotNullToSet { it.toCoordinates(projectName) }
+      .mapNotNullToSet { it.toCoordinates() }
       .forEach { id ->
         graphBuilder.putEdge(rootId, id)
       }

--- a/src/main/kotlin/com/autonomousapps/internal/graph/GraphViewBuilder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/graph/GraphViewBuilder.kt
@@ -14,7 +14,7 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult
 
 /** Walks the resolved dependency graph to create a dependency graph rooted on the current project. */
 @Suppress("UnstableApiUsage") // Guava Graph
-internal class GraphViewBuilder(conf: Configuration) {
+internal class GraphViewBuilder(conf: Configuration, projectName: String) {
 
   val graph: Graph<Coordinates>
 
@@ -30,19 +30,19 @@ internal class GraphViewBuilder(conf: Configuration) {
 
     val rootId = conf.rootCoordinates()
 
-    walkFileDeps(conf, rootId)
+    walkFileDeps(conf, rootId, projectName)
     walk(root, rootId)
 
     graph = graphBuilder.build()
   }
 
-  private fun walkFileDeps(conf: Configuration, rootId: Coordinates) {
+  private fun walkFileDeps(conf: Configuration, rootId: Coordinates, projectName: String) {
     graphBuilder.addNode(rootId)
 
     // the only way to get flat jar file dependencies
     conf.allDependencies
       .filterIsInstance<FileCollectionDependency>()
-      .mapNotNullToSet { it.toCoordinates() }
+      .mapNotNullToSet { it.toCoordinates(projectName) }
       .forEach { id ->
         graphBuilder.putEdge(rootId, id)
       }

--- a/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
@@ -252,12 +252,12 @@ internal fun ResolvedVariantResult.toCapability(componentGA: String) = when(capa
   }
 }
 
-private fun Capability.toGA() = "$group:$name"
-private fun ModuleIdentifier.toGA() = "$group:$name"
-private fun Dependency.toGA() = "$group:$name"
+private fun Capability.toGA() = "$group:$name".intern()
+private fun ModuleIdentifier.toGA() = "$group:$name".intern()
+private fun Dependency.toGA() = "$group:$name".intern()
 private fun ComponentIdentifier.toGA() = when(this) {
-  is ModuleComponentIdentifier -> "$group:$module"
-  is ProjectComponentIdentifier -> "*:$projectName"
+  is ModuleComponentIdentifier -> "$group:$module".intern()
+  is ProjectComponentIdentifier -> "*:$projectName".intern()
   is OpaqueComponentArtifactIdentifier -> "" // file dependencies do not have a capability
   else -> error("Unexpected identifier type: ${this::class.simpleName}")
 }

--- a/src/main/kotlin/com/autonomousapps/model/Capability.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Capability.kt
@@ -7,6 +7,12 @@ import dev.zacsweers.moshix.sealed.annotations.TypeLabel
 @JsonClass(generateAdapter = false, generator = "sealed:type")
 sealed class Capability : Comparable<Capability> {
   override fun compareTo(other: Capability): Int = javaClass.simpleName.compareTo(other.javaClass.simpleName)
+  /**
+   * This is for the JVM world, where sometimes multiple Jar files make up one component.
+   * Subclasses implement this to merge details in a useful name.
+   * It's implemented in all subclasses for completeness, although some situations might never occur in Android.
+   **/
+  abstract fun merge(other: Capability): Capability
 }
 
 @TypeLabel("linter")
@@ -15,7 +21,12 @@ data class AndroidLinterCapability(
   val lintRegistry: String,
   /** True if this dependency contains _only_ an Android lint jar/registry. */
   val isLintJar: Boolean
-) : Capability()
+) : Capability() {
+
+  override fun merge(other: Capability): Capability {
+    return AndroidLinterCapability(lintRegistry, isLintJar && (other as AndroidLinterCapability).isLintJar)
+  }
+}
 
 @TypeLabel("manifest")
 @JsonClass(generateAdapter = false)
@@ -37,13 +48,21 @@ data class AndroidManifestCapability(
       }
     }
   }
+
+  override fun merge(other: Capability): Capability {
+    return AndroidManifestCapability(componentMap + (other as AndroidManifestCapability).componentMap)
+  }
 }
 
 @TypeLabel("asset")
 @JsonClass(generateAdapter = false)
 data class AndroidAssetCapability(
   val assets: List<String>
-) : Capability()
+) : Capability() {
+  override fun merge(other: Capability): Capability {
+    return AndroidAssetCapability(assets + (other as AndroidAssetCapability).assets)
+  }
+}
 
 @TypeLabel("res")
 @JsonClass(generateAdapter = false)
@@ -54,6 +73,13 @@ data class AndroidResCapability(
 
   @JsonClass(generateAdapter = false)
   data class Line(val type: String, val value: String)
+
+  override fun merge(other: Capability): Capability {
+    return AndroidResCapability(
+      rImport + (other as AndroidResCapability).rImport,
+      lines + other.lines
+    )
+  }
 }
 
 @TypeLabel("proc")
@@ -61,13 +87,24 @@ data class AndroidResCapability(
 data class AnnotationProcessorCapability(
   val processor: String,
   val supportedAnnotationTypes: Set<String>
-) : Capability()
+) : Capability() {
+  override fun merge(other: Capability): Capability {
+    return AnnotationProcessorCapability(
+      processor, // other.processor ?
+      supportedAnnotationTypes + (other as AnnotationProcessorCapability).supportedAnnotationTypes
+    )
+  }
+}
 
 @TypeLabel("class")
 @JsonClass(generateAdapter = false)
 data class ClassCapability(
   val classes: Set<String>
-) : Capability()
+) : Capability() {
+  override fun merge(other: Capability): Capability {
+    return ClassCapability(classes + (other as ClassCapability).classes)
+  }
+}
 
 @TypeLabel("const")
 @JsonClass(generateAdapter = false)
@@ -76,7 +113,14 @@ data class ConstantCapability(
   val constants: Map<String, Set<String>>,
   /** Kotlin classes with top-level declarations. */
   val ktFiles: Set<KtFile>
-) : Capability()
+) : Capability() {
+  override fun merge(other: Capability): Capability {
+    return ConstantCapability(
+      constants + (other as ConstantCapability).constants,
+      ktFiles + other.ktFiles
+    )
+  }
+}
 
 @TypeLabel("inferred")
 @JsonClass(generateAdapter = false)
@@ -86,7 +130,11 @@ data class InferredCapability(
    * retention policies). False otherwise.
    */
   val isCompileOnlyAnnotations: Boolean
-) : Capability()
+) : Capability() {
+  override fun merge(other: Capability): Capability {
+    return InferredCapability(isCompileOnlyAnnotations && (other as InferredCapability).isCompileOnlyAnnotations)
+  }
+}
 
 @TypeLabel("inline")
 @JsonClass(generateAdapter = false)
@@ -103,23 +151,41 @@ data class InlineMemberCapability(
       .thenBy(LexicographicIterableComparator()) { it.inlineMembers }
       .compare(this, other)
   }
+
+  override fun merge(other: Capability): Capability {
+    return InlineMemberCapability(inlineMembers + (other as InlineMemberCapability).inlineMembers)
+  }
 }
 
 @TypeLabel("native")
 @JsonClass(generateAdapter = false)
 data class NativeLibCapability(
   val fileNames: Set<String>
-) : Capability()
+) : Capability() {
+  override fun merge(other: Capability): Capability {
+    return NativeLibCapability(fileNames + (other as NativeLibCapability).fileNames)
+  }
+}
 
 @TypeLabel("service_loader")
 @JsonClass(generateAdapter = false)
 data class ServiceLoaderCapability(
   val providerFile: String,
   val providerClasses: Set<String>
-) : Capability()
+) : Capability() {
+  override fun merge(other: Capability): Capability {
+    return ServiceLoaderCapability(
+      providerFile + (other as ServiceLoaderCapability).providerFile, providerClasses + other.providerClasses
+    )
+  }
+}
 
 @TypeLabel("security_provider")
 @JsonClass(generateAdapter = false)
 data class SecurityProviderCapability(
   val securityProviders: Set<String>
-) : Capability()
+) : Capability() {
+  override fun merge(other: Capability): Capability {
+    return SecurityProviderCapability(securityProviders + (other as SecurityProviderCapability).securityProviders)
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/model/Capability.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Capability.kt
@@ -9,7 +9,7 @@ sealed class Capability : Comparable<Capability> {
   override fun compareTo(other: Capability): Int = javaClass.simpleName.compareTo(other.javaClass.simpleName)
   /**
    * This is for the JVM world, where sometimes multiple Jar files make up one component.
-   * Subclasses implement this to merge details in a useful name.
+   * Subclasses implement this to merge details in a useful way.
    * It's implemented in all subclasses for completeness, although some situations might never occur in Android.
    **/
   abstract fun merge(other: Capability): Capability

--- a/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
@@ -38,7 +38,14 @@ sealed class Coordinates(
   /** Group-artifact-version (GAV) string representation, as used in Gradle dependency declarations. */
   abstract fun gav(): String
 
-  fun toFileName() = gav().replace(":", "__") + ".json"
+  fun toFileName() = "${gav()}${
+    capabilitiesWithoutDefault().joinToString("") { "__$it" }
+  }.json".replace(":", "__")
+
+  private fun capabilitiesWithoutDefault() =
+    gradleVariantIdentification.capabilities.filter {
+      !it.endsWith(identifier) // If empty, needs to contain the 'default' capability
+    }.sorted()
 
   /**
    * In case of an 'ADD' advice, the GradleVariantIdentification is directly sourced from the selected node

--- a/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
@@ -6,7 +6,7 @@ import dev.zacsweers.moshix.sealed.annotations.TypeLabel
 @JsonClass(generateAdapter = false, generator = "sealed:type")
 sealed class Coordinates(
   open val identifier: String,
-  open val capability: String
+  open val gradleVariantIdentification: GradleVariantIdentification
 ) : Comparable<Coordinates> {
 
   /**
@@ -29,7 +29,7 @@ sealed class Coordinates(
       }).let {
         // after identifiers, compare capabilities
         if (it == 0) {
-          capability.compareTo(other.capability)
+          gradleVariantIdentification.compareTo(other.gradleVariantIdentification)
         } else
           it
       }
@@ -40,12 +40,48 @@ sealed class Coordinates(
 
   fun toFileName() = gav().replace(":", "__") + ".json"
 
+  /**
+   * In case of an 'ADD' advice, the GradleVariantIdentification is directly sourced from the selected node
+   * in the dependency graph. It's hard (or impossible with Gradle's current APIs) to find the exact declaration that
+   * let to selecting that node. If we could find that declaration, we could use it for the ADD advice.
+   * Right now, we use the details from the node in the Graph which may contain more capabilities as you need
+   * to declare. In particular, it also contains the 'default capability', which makes it conceptually equal to
+   * Coordinates without capability.
+   * In order to correctly reduce advices (e.g. merge a REMOVE and an ADD to a CHANGE), we need the same Coordinates
+   * on both. So this method should be used to 'minify' the GradleVariantIdentification for ADD advices.
+   *
+   * @return A copy of this Coordinates without the 'default capability'
+   */
+  fun withoutDefaultCapability(): Coordinates {
+    return gradleVariantIdentification.capabilities.let { capabilities ->
+      when {
+        capabilities.size == 1 && isDefaultCapability(capabilities.single(), identifier) -> {
+          // Only one capability that is the default -> remove it
+          copy(identifier, GradleVariantIdentification(emptySet(), emptyMap()))
+        }
+        capabilities.size > 1 && capabilities.any { isDefaultCapability(it, identifier) } -> {
+          // The default capability is in the list, we assume that the others are not important for selection -> remove them all
+          copy(identifier, GradleVariantIdentification(emptySet(), emptyMap()))
+        }
+        else -> {
+          this
+        }
+      }
+    } ?: this
+  }
+
+  private fun isDefaultCapability(capability: String, identifier: String) =
+    when(this) {
+      // For projects, we don't know the 'group' here. We only match the 'name' part and assume that the group fits.
+      is ProjectCoordinates -> capability.endsWith(identifier.substring(identifier.lastIndexOf(":")))
+      else -> capability == identifier
+    }
+
   companion object {
     /** Convert a raw string into [Coordinates]. */
     fun of(raw: String): Coordinates {
       return if (raw.startsWith(':')) {
-        // Note: the second argument (capability) is wrong like this. Where is this code path needed?
-        ProjectCoordinates(raw, raw)
+        ProjectCoordinates(raw, GradleVariantIdentification(emptySet(), emptyMap()))
       } else {
         val c = raw.split(':')
         if (c.size == 3) {
@@ -53,17 +89,17 @@ sealed class Coordinates(
           ModuleCoordinates(
             identifier = identifier,
             resolvedVersion = c[2],
-            capability = identifier
+            gradleVariantIdentification = GradleVariantIdentification(emptySet(), emptyMap())
           )
         } else FlatCoordinates(raw)
       }
     }
 
-    internal fun Coordinates.copy(identifier: String, capability: String): Coordinates = when (this) {
-      is ProjectCoordinates -> copy(identifier = identifier, capability = capability)
-      is ModuleCoordinates -> copy(identifier = identifier, capability = capability)
-      is FlatCoordinates -> copy(identifier = identifier, capability = capability)
-      is IncludedBuildCoordinates -> copy(identifier = identifier, capability = capability)
+    internal fun Coordinates.copy(identifier: String, gradleVariantIdentification: GradleVariantIdentification): Coordinates = when (this) {
+      is ProjectCoordinates -> copy(identifier = identifier, gradleVariantIdentification = gradleVariantIdentification)
+      is ModuleCoordinates -> copy(identifier = identifier, gradleVariantIdentification = gradleVariantIdentification)
+      is FlatCoordinates -> copy(identifier = identifier)
+      is IncludedBuildCoordinates -> copy(identifier = identifier, gradleVariantIdentification = gradleVariantIdentification)
     }
   }
 }
@@ -72,8 +108,8 @@ sealed class Coordinates(
 @JsonClass(generateAdapter = false)
 data class ProjectCoordinates(
   override val identifier: String,
-  override val capability: String
-) : Coordinates(identifier, capability) {
+  override val gradleVariantIdentification: GradleVariantIdentification
+) : Coordinates(identifier, gradleVariantIdentification) {
 
   init {
     check(identifier.startsWith(':')) { "Project coordinates must start with a ':'" }
@@ -87,8 +123,8 @@ data class ProjectCoordinates(
 data class ModuleCoordinates(
   override val identifier: String,
   val resolvedVersion: String,
-  override val capability: String = identifier
-) : Coordinates(identifier, capability) {
+  override val gradleVariantIdentification: GradleVariantIdentification
+) : Coordinates(identifier, gradleVariantIdentification) {
   override fun gav(): String = "$identifier:$resolvedVersion"
 }
 
@@ -97,7 +133,7 @@ data class ModuleCoordinates(
 @JsonClass(generateAdapter = false)
 data class FlatCoordinates(
   override val identifier: String
-) : Coordinates(identifier, "") { // flat (file) coordinates do not have a capability - it's the empty string
+) : Coordinates(identifier, GradleVariantIdentification(emptySet(), emptyMap())) {
   override fun gav(): String = identifier
 }
 
@@ -106,15 +142,15 @@ data class FlatCoordinates(
 data class IncludedBuildCoordinates(
   override val identifier: String,
   val resolvedProject: ProjectCoordinates,
-  override val capability: String
-) : Coordinates(identifier, capability) {
+  override val gradleVariantIdentification: GradleVariantIdentification
+) : Coordinates(identifier, gradleVariantIdentification) {
   override fun gav(): String = identifier
 
   companion object {
     fun of(requested: ModuleCoordinates, resolvedProject: ProjectCoordinates) = IncludedBuildCoordinates(
       identifier = requested.identifier,
       resolvedProject = resolvedProject,
-      capability = requested.capability
+      gradleVariantIdentification = requested.gradleVariantIdentification
     )
   }
 }

--- a/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
@@ -14,24 +14,25 @@ sealed class Coordinates(
    * before [FlatCoordinates].
    */
   override fun compareTo(other: Coordinates): Int {
-    return if (this is ProjectCoordinates) {
-      if (other is ProjectCoordinates) identifier.compareTo(other.identifier) else 1
-    } else if (this is FlatCoordinates) {
-      if (other is ProjectCoordinates) -1 else if (other is FlatCoordinates) gav().compareTo(other.gav()) else 1
-    } else {
-      when (other) {
-        is ProjectCoordinates -> -1
-        is FlatCoordinates -> -1
-        is ModuleCoordinates -> identifier.compareTo(other.identifier)
-        is IncludedBuildCoordinates -> identifier.compareTo(other.identifier)
+    return (
+      if (this is ProjectCoordinates) {
+        if (other is ProjectCoordinates) identifier.compareTo(other.identifier) else 1
+      } else if (this is FlatCoordinates) {
+        if (other is ProjectCoordinates) -1 else if (other is FlatCoordinates) gav().compareTo(other.gav()) else 1
+      } else {
+        when (other) {
+          is ProjectCoordinates -> -1
+          is FlatCoordinates -> -1
+          is ModuleCoordinates -> identifier.compareTo(other.identifier)
+          is IncludedBuildCoordinates -> identifier.compareTo(other.identifier)
+        }
+      }).let {
+        // after identifiers, compare variants
+        if (it == 0) {
+          featureVariantName.compareTo(other.featureVariantName)
+        } else
+          it
       }
-    }.let {
-      // after identifiers, compare variants
-      if (it == 0) {
-        featureVariantName.compareTo(other.featureVariantName)
-      } else
-        it
-    }
   }
 
   /** Group-artifact-version (GAV) string representation, as used in Gradle dependency declarations. */

--- a/src/main/kotlin/com/autonomousapps/model/GradleVariantIdentification.kt
+++ b/src/main/kotlin/com/autonomousapps/model/GradleVariantIdentification.kt
@@ -14,5 +14,5 @@ data class GradleVariantIdentification(
   }
 
   private fun toSingleString() =
-    capabilities.joinToString() + attributes.map { (k, v) -> "$k=$v" }.joinToString()
+    capabilities.sorted().joinToString() + attributes.map { (k, v) -> "$k=$v" }.sorted().joinToString()
 }

--- a/src/main/kotlin/com/autonomousapps/model/GradleVariantIdentification.kt
+++ b/src/main/kotlin/com/autonomousapps/model/GradleVariantIdentification.kt
@@ -1,0 +1,18 @@
+package com.autonomousapps.model
+
+import com.squareup.moshi.JsonClass
+import java.io.Serializable
+
+@JsonClass(generateAdapter = false)
+data class GradleVariantIdentification(
+  val capabilities: Set<String>,
+  val attributes: Map<String, String>
+  // classifier: String
+): Serializable, Comparable<GradleVariantIdentification> {
+  override fun compareTo(other: GradleVariantIdentification): Int {
+    return toSingleString().compareTo(other.toSingleString())
+  }
+
+  private fun toSingleString() =
+    capabilities.joinToString() + attributes.map { (k, v) -> "$k=$v" }.joinToString()
+}

--- a/src/main/kotlin/com/autonomousapps/model/ProjectVariant.kt
+++ b/src/main/kotlin/com/autonomousapps/model/ProjectVariant.kt
@@ -92,7 +92,7 @@ data class ProjectVariant(
         if (file.asFile.exists()) {
           file.fromJson<Dependency>()
         } else {
-          error("No file for ${coordinates.gav()}")
+          error("No file ${it.toFileName()}")
         }
       }
       .toSet()

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
@@ -18,7 +18,7 @@ import com.squareup.moshi.JsonClass
 internal data class Declaration(
   val identifier: String,
   val configurationName: String,
-  val targetFeatureVariantName: String = ""
+  val targetCapability: String
 ) {
 
   val bucket: Bucket by unsafeLazy { Bucket.of(configurationName) }

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
@@ -1,6 +1,7 @@
 package com.autonomousapps.model.declaration
 
 import com.autonomousapps.internal.unsafeLazy
+import com.autonomousapps.model.GradleVariantIdentification
 import com.squareup.moshi.JsonClass
 
 /**
@@ -18,7 +19,7 @@ import com.squareup.moshi.JsonClass
 internal data class Declaration(
   val identifier: String,
   val configurationName: String,
-  val targetCapability: String
+  val gradleVariantIdentification: GradleVariantIdentification
 ) {
 
   val bucket: Bucket by unsafeLazy { Bucket.of(configurationName) }

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
@@ -1,7 +1,6 @@
 package com.autonomousapps.model.declaration
 
 import com.autonomousapps.internal.unsafeLazy
-import com.autonomousapps.internal.utils.toIdentifierWithFeatureVariant
 import com.squareup.moshi.JsonClass
 
 /**
@@ -19,12 +18,10 @@ import com.squareup.moshi.JsonClass
 internal data class Declaration(
   val identifier: String,
   val configurationName: String,
-  val targetFeatureVariant: String = ""
+  val targetFeatureVariantName: String = ""
 ) {
 
   val bucket: Bucket by unsafeLazy { Bucket.of(configurationName) }
   fun variant(supportedSourceSets: Set<String>, hasCustomSourceSets: Boolean): Variant? =
     Variant.of(configurationName, supportedSourceSets, hasCustomSourceSets)
-
-  fun identifierWithFeatureVariant() = identifier.toIdentifierWithFeatureVariant(targetFeatureVariant)
 }

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Declaration.kt
@@ -1,6 +1,7 @@
 package com.autonomousapps.model.declaration
 
 import com.autonomousapps.internal.unsafeLazy
+import com.autonomousapps.internal.utils.toIdentifierWithFeatureVariant
 import com.squareup.moshi.JsonClass
 
 /**
@@ -18,10 +19,12 @@ import com.squareup.moshi.JsonClass
 internal data class Declaration(
   val identifier: String,
   val configurationName: String,
-  val doesNotPointAtMainVariant: Boolean = false
+  val targetFeatureVariant: String = ""
 ) {
 
   val bucket: Bucket by unsafeLazy { Bucket.of(configurationName) }
   fun variant(supportedSourceSets: Set<String>, hasCustomSourceSets: Boolean): Variant? =
     Variant.of(configurationName, supportedSourceSets, hasCustomSourceSets)
+
+  fun identifierWithFeatureVariant() = identifier.toIdentifierWithFeatureVariant(targetFeatureVariant)
 }

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -541,6 +541,7 @@ internal class ProjectPlugin(private val project: Project) {
 
     val computeDominatorTask = tasks.register<ComputeDominatorTreeTask>("computeDominatorTree$taskNameSuffix") {
       projectPath.set(thisProjectPath)
+      projectGA.set(thisProjectGA)
       physicalArtifacts.set(artifactsReportTask.flatMap { it.output })
       graphView.set(graphViewTask.flatMap { it.output })
       outputTxt.set(outputPaths.dominatorConsolePath)

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -488,6 +488,7 @@ internal class ProjectPlugin(private val project: Project) {
     configureAggregationTasks()
 
     val thisProjectPath = path
+    val thisProjectGA = "$group:$name"
     val variantName = dependencyAnalyzer.variantName
     val taskNameSuffix = dependencyAnalyzer.taskNameSuffix
     val outputPaths = dependencyAnalyzer.outputPaths
@@ -688,6 +689,7 @@ internal class ProjectPlugin(private val project: Project) {
     // Synthesizes the above into a single view of this project's usages.
     val synthesizeProjectViewTask = tasks.register<SynthesizeProjectViewTask>("synthesizeProjectView$taskNameSuffix") {
       projectPath.set(thisProjectPath)
+      projectGA.set(thisProjectGA)
       buildType.set(dependencyAnalyzer.buildType)
       flavor.set(dependencyAnalyzer.flavorName)
       variant.set(variantName)
@@ -737,6 +739,7 @@ internal class ProjectPlugin(private val project: Project) {
 
     val project = this
     val theProjectPath = path
+    val theProjectGA = "$group:$name"
     val paths = NoVariantOutputPaths(this)
 
     findDeclarationsTask = tasks.register<FindDeclarationsTask>("findDeclarations") {
@@ -748,6 +751,7 @@ internal class ProjectPlugin(private val project: Project) {
     }
     computeAdviceTask = tasks.register<ComputeAdviceTask>("computeAdvice") {
       projectPath.set(theProjectPath)
+      projectGA.set(theProjectGA)
       declarations.set(findDeclarationsTask.flatMap { it.output })
       bundles.set(getExtension().dependenciesHandler.serializableBundles())
       supportedSourceSets.set(supportedSourceSetNames())
@@ -797,6 +801,7 @@ internal class ProjectPlugin(private val project: Project) {
 
     reasonTask = tasks.register<ReasonTask>("reason") {
       projectPath.set(theProjectPath)
+      projectGA.set(theProjectGA)
       dependencyMap.set(getExtension().dependenciesHandler.map)
       dependencyUsageReport.set(computeAdviceTask.flatMap { it.dependencyUsages })
       annotationProcessorUsageReport.set(computeAdviceTask.flatMap { it.annotationProcessorUsages })

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -488,7 +488,6 @@ internal class ProjectPlugin(private val project: Project) {
     configureAggregationTasks()
 
     val thisProjectPath = path
-    val thisProjectGA = "$group:$name"
     val variantName = dependencyAnalyzer.variantName
     val taskNameSuffix = dependencyAnalyzer.taskNameSuffix
     val outputPaths = dependencyAnalyzer.outputPaths
@@ -541,7 +540,6 @@ internal class ProjectPlugin(private val project: Project) {
 
     val computeDominatorTask = tasks.register<ComputeDominatorTreeTask>("computeDominatorTree$taskNameSuffix") {
       projectPath.set(thisProjectPath)
-      projectGA.set(thisProjectGA)
       physicalArtifacts.set(artifactsReportTask.flatMap { it.output })
       graphView.set(graphViewTask.flatMap { it.output })
       outputTxt.set(outputPaths.dominatorConsolePath)
@@ -690,7 +688,6 @@ internal class ProjectPlugin(private val project: Project) {
     // Synthesizes the above into a single view of this project's usages.
     val synthesizeProjectViewTask = tasks.register<SynthesizeProjectViewTask>("synthesizeProjectView$taskNameSuffix") {
       projectPath.set(thisProjectPath)
-      projectGA.set(thisProjectGA)
       buildType.set(dependencyAnalyzer.buildType)
       flavor.set(dependencyAnalyzer.flavorName)
       variant.set(variantName)
@@ -740,7 +737,6 @@ internal class ProjectPlugin(private val project: Project) {
 
     val project = this
     val theProjectPath = path
-    val theProjectGA = "$group:$name"
     val paths = NoVariantOutputPaths(this)
 
     findDeclarationsTask = tasks.register<FindDeclarationsTask>("findDeclarations") {
@@ -752,7 +748,6 @@ internal class ProjectPlugin(private val project: Project) {
     }
     computeAdviceTask = tasks.register<ComputeAdviceTask>("computeAdvice") {
       projectPath.set(theProjectPath)
-      projectGA.set(theProjectGA)
       declarations.set(findDeclarationsTask.flatMap { it.output })
       bundles.set(getExtension().dependenciesHandler.serializableBundles())
       supportedSourceSets.set(supportedSourceSetNames())
@@ -802,7 +797,6 @@ internal class ProjectPlugin(private val project: Project) {
 
     reasonTask = tasks.register<ReasonTask>("reason") {
       projectPath.set(theProjectPath)
-      projectGA.set(theProjectGA)
       dependencyMap.set(getExtension().dependenciesHandler.map)
       dependencyUsageReport.set(computeAdviceTask.flatMap { it.dependencyUsages })
       annotationProcessorUsageReport.set(computeAdviceTask.flatMap { it.annotationProcessorUsages })

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
@@ -130,7 +130,7 @@ abstract class ComputeAdviceTask @Inject constructor(
       val bundleTraces = parameters.bundledTraces.getAndDelete()
 
       val projectPath = parameters.projectPath.get()
-      val projectNode = ProjectCoordinates(projectPath)
+      val projectNode = ProjectCoordinates(projectPath, "")
       val declarations = parameters.declarations.fromJsonSet<Declaration>()
       val dependencyGraph = parameters.dependencyGraphViews.get()
         .map { it.fromJson<DependencyGraphView>() }

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
@@ -40,6 +40,9 @@ abstract class ComputeAdviceTask @Inject constructor(
   @get:Input
   abstract val projectPath: Property<String>
 
+  @get:Input
+  abstract val projectGA: Property<String>
+
   @get:PathSensitive(PathSensitivity.RELATIVE)
   @get:InputFiles
   abstract val dependencyUsageReports: ListProperty<RegularFile>
@@ -88,6 +91,7 @@ abstract class ComputeAdviceTask @Inject constructor(
   @TaskAction fun action() {
     workerExecutor.noIsolation().submit(ComputeAdviceAction::class.java) {
       projectPath.set(this@ComputeAdviceTask.projectPath)
+      projectGA.set(this@ComputeAdviceTask.projectGA)
       dependencyUsageReports.set(this@ComputeAdviceTask.dependencyUsageReports)
       dependencyGraphViews.set(this@ComputeAdviceTask.dependencyGraphViews)
       androidScoreReports.set(this@ComputeAdviceTask.androidScoreReports)
@@ -106,6 +110,7 @@ abstract class ComputeAdviceTask @Inject constructor(
 
   interface ComputeAdviceParameters : WorkParameters {
     val projectPath: Property<String>
+    val projectGA: Property<String>
     val dependencyUsageReports: ListProperty<RegularFile>
     val dependencyGraphViews: ListProperty<RegularFile>
     val androidScoreReports: ListProperty<RegularFile>
@@ -130,7 +135,8 @@ abstract class ComputeAdviceTask @Inject constructor(
       val bundleTraces = parameters.bundledTraces.getAndDelete()
 
       val projectPath = parameters.projectPath.get()
-      val projectNode = ProjectCoordinates(projectPath, "")
+      val projectGA = parameters.projectGA.get()
+      val projectNode = ProjectCoordinates(projectPath, projectGA)
       val declarations = parameters.declarations.fromJsonSet<Declaration>()
       val dependencyGraph = parameters.dependencyGraphViews.get()
         .map { it.fromJson<DependencyGraphView>() }

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeAdviceTask.kt
@@ -224,7 +224,7 @@ internal class PluginAdviceBuilder(
 }
 
 internal class DependencyAdviceBuilder(
-  private val projectPath: String,
+  projectPath: String,
   private val bundles: Bundles,
   private val dependencyUsages: Map<Coordinates, Set<Usage>>,
   private val annotationProcessorUsages: Map<Coordinates, Set<Usage>>,

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeDominatorTreeTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeDominatorTreeTask.kt
@@ -32,6 +32,9 @@ abstract class ComputeDominatorTreeTask : DefaultTask() {
   @get:Input
   abstract val projectPath: Property<String>
 
+  @get:Input
+  abstract val projectGA: Property<String>
+
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
   abstract val physicalArtifacts: RegularFileProperty
@@ -54,7 +57,7 @@ abstract class ComputeDominatorTreeTask : DefaultTask() {
       coord to file
     }
     val graphView = graphView.fromJson<DependencyGraphView>()
-    val project = ProjectCoordinates(projectPath.get(), "")
+    val project = ProjectCoordinates(projectPath.get(), projectGA.get())
 
     val tree = DominanceTree(graphView.graph, project)
     val nodeWriter = BySize(

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeDominatorTreeTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeDominatorTreeTask.kt
@@ -11,10 +11,8 @@ import com.autonomousapps.internal.utils.FileUtils
 import com.autonomousapps.internal.utils.fromJson
 import com.autonomousapps.internal.utils.fromJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
-import com.autonomousapps.model.Coordinates
-import com.autonomousapps.model.DependencyGraphView
+import com.autonomousapps.model.*
 import com.autonomousapps.model.PhysicalArtifact
-import com.autonomousapps.model.ProjectCoordinates
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
@@ -31,9 +29,6 @@ abstract class ComputeDominatorTreeTask : DefaultTask() {
 
   @get:Input
   abstract val projectPath: Property<String>
-
-  @get:Input
-  abstract val projectGA: Property<String>
 
   @get:PathSensitive(PathSensitivity.NONE)
   @get:InputFile
@@ -57,7 +52,7 @@ abstract class ComputeDominatorTreeTask : DefaultTask() {
       coord to file
     }
     val graphView = graphView.fromJson<DependencyGraphView>()
-    val project = ProjectCoordinates(projectPath.get(), projectGA.get())
+    val project = ProjectCoordinates(projectPath.get(), GradleVariantIdentification(emptySet(), emptyMap()))
 
     val tree = DominanceTree(graphView.graph, project)
     val nodeWriter = BySize(

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeDominatorTreeTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeDominatorTreeTask.kt
@@ -54,7 +54,7 @@ abstract class ComputeDominatorTreeTask : DefaultTask() {
       coord to file
     }
     val graphView = graphView.fromJson<DependencyGraphView>()
-    val project = ProjectCoordinates(projectPath.get())
+    val project = ProjectCoordinates(projectPath.get(), "")
 
     val tree = DominanceTree(graphView.graph, project)
     val nodeWriter = BySize(

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
@@ -101,7 +101,7 @@ abstract class FindDeclarationsTask : DefaultTask() {
             Declaration(
               identifier = id.first,
               configurationName = conf,
-              targetFeatureVariant = id.second
+              targetFeatureVariantName = id.second
             )
           }
         }

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
@@ -6,6 +6,7 @@ import com.autonomousapps.internal.NoVariantOutputPaths
 import com.autonomousapps.internal.utils.bufferWriteJsonSet
 import com.autonomousapps.internal.utils.getAndDelete
 import com.autonomousapps.internal.utils.toIdentifiers
+import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.declaration.Configurations.isForAnnotationProcessor
 import com.autonomousapps.model.declaration.Configurations.isForRegularDependency
 import com.autonomousapps.model.declaration.Declaration
@@ -84,11 +85,11 @@ abstract class FindDeclarationsTask : DefaultTask() {
     }
   }
 
-  class DeclarationContainer(@get:Input val mapping: Map<String, Set<Pair<String, String>>>) {
+  class DeclarationContainer(@get:Input val mapping: Map<String, Set<Pair<String, GradleVariantIdentification>>>) {
 
     companion object {
       internal fun of(
-        mapping: Map<String, Set<Pair<String, String>>>
+        mapping: Map<String, Set<Pair<String, GradleVariantIdentification>>>
       ): DeclarationContainer = DeclarationContainer(mapping)
     }
   }
@@ -101,7 +102,7 @@ abstract class FindDeclarationsTask : DefaultTask() {
             Declaration(
               identifier = id.first,
               configurationName = conf,
-              targetCapability = id.second
+              gradleVariantIdentification = id.second
             )
           }
         }

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
@@ -65,7 +65,7 @@ abstract class FindDeclarationsTask : DefaultTask() {
           mapping = getDependencyBuckets(configurations, shouldAnalyzeTests)
             .associateBy { it.name }
             .map { (name, conf) ->
-              name to conf.dependencies.toIdentifiers()
+              name to conf.dependencies.toIdentifiers(project.name)
             }
             .toMap()
         )
@@ -84,11 +84,11 @@ abstract class FindDeclarationsTask : DefaultTask() {
     }
   }
 
-  class DeclarationContainer(@get:Input val mapping: Map<String, Set<Pair<String, Boolean>>>) {
+  class DeclarationContainer(@get:Input val mapping: Map<String, Set<Pair<String, String>>>) {
 
     companion object {
       internal fun of(
-        mapping: Map<String, Set<Pair<String, Boolean>>>
+        mapping: Map<String, Set<Pair<String, String>>>
       ): DeclarationContainer = DeclarationContainer(mapping)
     }
   }
@@ -101,7 +101,7 @@ abstract class FindDeclarationsTask : DefaultTask() {
             Declaration(
               identifier = id.first,
               configurationName = conf,
-              doesNotPointAtMainVariant = id.second
+              targetFeatureVariant = id.second
             )
           }
         }

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclarationsTask.kt
@@ -65,7 +65,7 @@ abstract class FindDeclarationsTask : DefaultTask() {
           mapping = getDependencyBuckets(configurations, shouldAnalyzeTests)
             .associateBy { it.name }
             .map { (name, conf) ->
-              name to conf.dependencies.toIdentifiers(project.name)
+              name to conf.dependencies.toIdentifiers()
             }
             .toMap()
         )
@@ -101,7 +101,7 @@ abstract class FindDeclarationsTask : DefaultTask() {
             Declaration(
               identifier = id.first,
               configurationName = conf,
-              targetFeatureVariantName = id.second
+              targetCapability = id.second
             )
           }
         }

--- a/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
@@ -105,14 +105,15 @@ abstract class GraphViewTask : DefaultTask() {
     val outputRuntime = outputRuntime.getAndDelete()
     val outputRuntimeDot = outputRuntimeDot.getAndDelete()
 
-    val compileGraph = GraphViewBuilder(compileClasspath).graph
+    val projectName = projectPath.get().substring(projectPath.get().lastIndexOf(":") + 1)
+    val compileGraph = GraphViewBuilder(compileClasspath, projectName).graph
     val compileGraphView = DependencyGraphView(
       variant = Variant(variant.get(), kind.get()),
       configurationName = compileClasspath.name,
       graph = compileGraph
     )
 
-    val runtimeGraph = GraphViewBuilder(runtimeClasspath).graph
+    val runtimeGraph = GraphViewBuilder(runtimeClasspath, projectName).graph
     val runtimeGraphView = DependencyGraphView(
       variant = Variant(variant.get(), kind.get()),
       configurationName = runtimeClasspath.name,

--- a/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
@@ -105,15 +105,14 @@ abstract class GraphViewTask : DefaultTask() {
     val outputRuntime = outputRuntime.getAndDelete()
     val outputRuntimeDot = outputRuntimeDot.getAndDelete()
 
-    val projectName = projectPath.get().substring(projectPath.get().lastIndexOf(":") + 1)
-    val compileGraph = GraphViewBuilder(compileClasspath, projectName).graph
+    val compileGraph = GraphViewBuilder(compileClasspath).graph
     val compileGraphView = DependencyGraphView(
       variant = Variant(variant.get(), kind.get()),
       configurationName = compileClasspath.name,
       graph = compileGraph
     )
 
-    val runtimeGraph = GraphViewBuilder(runtimeClasspath, projectName).graph
+    val runtimeGraph = GraphViewBuilder(runtimeClasspath).graph
     val runtimeGraphView = DependencyGraphView(
       variant = Variant(variant.get(), kind.get()),
       configurationName = runtimeClasspath.name,

--- a/src/main/kotlin/com/autonomousapps/tasks/ReasonTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ReasonTask.kt
@@ -35,6 +35,9 @@ abstract class ReasonTask @Inject constructor(
   @get:Input
   abstract val projectPath: Property<String>
 
+  @get:Input
+  abstract val projectGA: Property<String>
+
   /**
    * The dependency identifier or GAV coordinates being queried.
    *
@@ -98,6 +101,7 @@ abstract class ReasonTask @Inject constructor(
       workerExecutor.noIsolation().submit(ExplainDependencyAdviceAction::class.java) {
         id.set(dependency)
         projectPath.set(this@ReasonTask.projectPath)
+        projectGA.set(this@ReasonTask.projectGA)
         dependencyMap.set(this@ReasonTask.dependencyMap)
         dependencyUsageReport.set(this@ReasonTask.dependencyUsageReport)
         annotationProcessorUsageReport.set(this@ReasonTask.annotationProcessorUsageReport)
@@ -149,6 +153,7 @@ abstract class ReasonTask @Inject constructor(
   interface ExplainDependencyAdviceParams : WorkParameters {
     val id: Property<String>
     val projectPath: Property<String>
+    val projectGA: Property<String>
     val dependencyMap: MapProperty<String, String>
     val dependencyUsageReport: RegularFileProperty
     val annotationProcessorUsageReport: RegularFileProperty
@@ -163,6 +168,7 @@ abstract class ReasonTask @Inject constructor(
     private val logger = getLogger<ReasonTask>()
 
     private val projectPath = parameters.projectPath.get()
+    private val projectGA = parameters.projectGA.get()
     private val dependencyGraph = parameters.dependencyGraphViews.get()
       .map { it.fromJson<DependencyGraphView>() }
       .associateBy { "${it.name},${it.configurationName}" }
@@ -180,7 +186,7 @@ abstract class ReasonTask @Inject constructor(
 
     override fun execute() {
       val reason = DependencyAdviceExplainer(
-        project = ProjectCoordinates(projectPath, ""),
+        project = ProjectCoordinates(projectPath, projectGA),
         target = coord,
         usages = usages,
         advice = finalAdvice,

--- a/src/main/kotlin/com/autonomousapps/tasks/ReasonTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ReasonTask.kt
@@ -180,7 +180,7 @@ abstract class ReasonTask @Inject constructor(
 
     override fun execute() {
       val reason = DependencyAdviceExplainer(
-        project = ProjectCoordinates(projectPath),
+        project = ProjectCoordinates(projectPath, ""),
         target = coord,
         usages = usages,
         advice = finalAdvice,
@@ -263,7 +263,7 @@ abstract class ReasonTask @Inject constructor(
     override fun execute() {
       validateModuleOption()
       val reason = ModuleAdviceExplainer(
-        project = ProjectCoordinates(projectPath),
+        project = ProjectCoordinates(projectPath, ""),
         unfilteredAndroidScore = unfilteredAndroidScore,
         finalAndroidScore = finalAndroidScore,
       ).computeReason()

--- a/src/main/kotlin/com/autonomousapps/tasks/ReasonTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ReasonTask.kt
@@ -35,9 +35,6 @@ abstract class ReasonTask @Inject constructor(
   @get:Input
   abstract val projectPath: Property<String>
 
-  @get:Input
-  abstract val projectGA: Property<String>
-
   /**
    * The dependency identifier or GAV coordinates being queried.
    *
@@ -101,7 +98,6 @@ abstract class ReasonTask @Inject constructor(
       workerExecutor.noIsolation().submit(ExplainDependencyAdviceAction::class.java) {
         id.set(dependency)
         projectPath.set(this@ReasonTask.projectPath)
-        projectGA.set(this@ReasonTask.projectGA)
         dependencyMap.set(this@ReasonTask.dependencyMap)
         dependencyUsageReport.set(this@ReasonTask.dependencyUsageReport)
         annotationProcessorUsageReport.set(this@ReasonTask.annotationProcessorUsageReport)
@@ -153,7 +149,6 @@ abstract class ReasonTask @Inject constructor(
   interface ExplainDependencyAdviceParams : WorkParameters {
     val id: Property<String>
     val projectPath: Property<String>
-    val projectGA: Property<String>
     val dependencyMap: MapProperty<String, String>
     val dependencyUsageReport: RegularFileProperty
     val annotationProcessorUsageReport: RegularFileProperty
@@ -168,7 +163,6 @@ abstract class ReasonTask @Inject constructor(
     private val logger = getLogger<ReasonTask>()
 
     private val projectPath = parameters.projectPath.get()
-    private val projectGA = parameters.projectGA.get()
     private val dependencyGraph = parameters.dependencyGraphViews.get()
       .map { it.fromJson<DependencyGraphView>() }
       .associateBy { "${it.name},${it.configurationName}" }
@@ -186,7 +180,7 @@ abstract class ReasonTask @Inject constructor(
 
     override fun execute() {
       val reason = DependencyAdviceExplainer(
-        project = ProjectCoordinates(projectPath, projectGA),
+        project = ProjectCoordinates(projectPath, GradleVariantIdentification(emptySet(), emptyMap())),
         target = coord,
         usages = usages,
         advice = finalAdvice,
@@ -269,7 +263,7 @@ abstract class ReasonTask @Inject constructor(
     override fun execute() {
       validateModuleOption()
       val reason = ModuleAdviceExplainer(
-        project = ProjectCoordinates(projectPath, ""),
+        project = ProjectCoordinates(projectPath, GradleVariantIdentification(emptySet(), emptyMap())),
         unfilteredAndroidScore = unfilteredAndroidScore,
         finalAndroidScore = finalAndroidScore,
       ).computeReason()

--- a/src/main/kotlin/com/autonomousapps/tasks/ResolveExternalDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ResolveExternalDependenciesTask.kt
@@ -42,9 +42,6 @@ abstract class ResolveExternalDependenciesTask : DefaultTask() {
   @get:InputFiles
   abstract val runtimeFiles: ConfigurableFileCollection
 
-  @get:Input
-  abstract val projectName: Property<String>
-
   /** Output in json format for compile classpath graph. */
   @get:OutputFile
   abstract val output: RegularFileProperty
@@ -59,14 +56,13 @@ abstract class ResolveExternalDependenciesTask : DefaultTask() {
     this.runtimeClasspath = runtimeClasspath
     compileFiles.setFrom(project.provider { compileClasspath.externalArtifactsFor(jarAttr).artifactFiles })
     runtimeFiles.setFrom(project.provider { runtimeClasspath.externalArtifactsFor(jarAttr).artifactFiles })
-    projectName.set(project.name)
   }
 
   @TaskAction fun action() {
     val output = output.getAndDelete()
 
-    val compileGraph = GraphViewBuilder(compileClasspath, projectName.get()).graph
-    val runtimeGraph = GraphViewBuilder(runtimeClasspath, projectName.get()).graph
+    val compileGraph = GraphViewBuilder(compileClasspath).graph
+    val runtimeGraph = GraphViewBuilder(runtimeClasspath).graph
 
     val dependencies = compileGraph.nodes().asSequence().plus(runtimeGraph.nodes().asSequence())
       .filterIsInstance<ModuleCoordinates>()

--- a/src/main/kotlin/com/autonomousapps/tasks/ResolveExternalDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ResolveExternalDependenciesTask.kt
@@ -11,7 +11,6 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 
 @Suppress("UnstableApiUsage") // Guava graphs

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeDependenciesTask.kt
@@ -205,7 +205,16 @@ abstract class SynthesizeDependenciesTask @Inject constructor(
 
     fun concat(other: DependencyBuilder): DependencyBuilder {
       files.addAll(other.files)
-      capabilities.addAll(other.capabilities)
+      other.capabilities.forEach { otherCapability ->
+        val existing = capabilities.find { it.javaClass.canonicalName == otherCapability.javaClass.canonicalName }
+        if (existing != null) {
+          val merged = existing.merge(otherCapability)
+          capabilities.remove(existing)
+          capabilities.add(merged)
+        } else {
+          capabilities.add(otherCapability)
+        }
+      }
       return this
     }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
@@ -190,7 +190,7 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
         .map { it.build() }
         .toSet()
 
-      val projectCoordinates = ProjectCoordinates(parameters.projectPath.get())
+      val projectCoordinates = ProjectCoordinates(parameters.projectPath.get(), "")
       val classpath = graph.graph.nodes().asSequence().filterNot {
         it == projectCoordinates
       }.toSortedSet()

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
@@ -33,6 +33,9 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
   @get:Input
   abstract val projectPath: Property<String>
 
+  @get:Input
+  abstract val projectGA: Property<String>
+
   /** May be null. */
   @get:Optional
   @get:Input
@@ -98,6 +101,7 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
   @TaskAction fun action() {
     workerExecutor.noIsolation().submit(SynthesizeProjectViewWorkAction::class.java) {
       projectPath.set(this@SynthesizeProjectViewTask.projectPath)
+      projectGA.set(this@SynthesizeProjectViewTask.projectGA)
       buildType.set(this@SynthesizeProjectViewTask.buildType)
       flavor.set(this@SynthesizeProjectViewTask.flavor)
       variant.set(this@SynthesizeProjectViewTask.variant)
@@ -116,6 +120,7 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
 
   interface SynthesizeProjectViewParameters : WorkParameters {
     val projectPath: Property<String>
+    val projectGA: Property<String> // group:version
 
     /** May be null. */
     val buildType: Property<String>
@@ -190,7 +195,7 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
         .map { it.build() }
         .toSet()
 
-      val projectCoordinates = ProjectCoordinates(parameters.projectPath.get(), "")
+      val projectCoordinates = ProjectCoordinates(parameters.projectPath.get(), parameters.projectGA.get())
       val classpath = graph.graph.nodes().asSequence().filterNot {
         it == projectCoordinates
       }.toSortedSet()

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
@@ -192,7 +192,10 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
 
       val projectCoordinates = ProjectCoordinates(parameters.projectPath.get(),
         GradleVariantIdentification(emptySet(), emptyMap()))
-      val classpath = graph.graph.nodes().toSortedSet()
+      val ignoreSelfDependencies = parameters.buildType.isPresent // ignore on Android
+      val classpath = graph.graph.nodes().asSequence().filterNot {
+        ignoreSelfDependencies && it == projectCoordinates
+      }.toSortedSet()
       val annotationProcessors = parameters.annotationProcessors.fromJsonSet<AnnotationProcessorDependency>()
         .mapToSet { it.coordinates }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
@@ -33,9 +33,6 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
   @get:Input
   abstract val projectPath: Property<String>
 
-  @get:Input
-  abstract val projectGA: Property<String>
-
   /** May be null. */
   @get:Optional
   @get:Input
@@ -101,7 +98,6 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
   @TaskAction fun action() {
     workerExecutor.noIsolation().submit(SynthesizeProjectViewWorkAction::class.java) {
       projectPath.set(this@SynthesizeProjectViewTask.projectPath)
-      projectGA.set(this@SynthesizeProjectViewTask.projectGA)
       buildType.set(this@SynthesizeProjectViewTask.buildType)
       flavor.set(this@SynthesizeProjectViewTask.flavor)
       variant.set(this@SynthesizeProjectViewTask.variant)
@@ -120,7 +116,6 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
 
   interface SynthesizeProjectViewParameters : WorkParameters {
     val projectPath: Property<String>
-    val projectGA: Property<String> // group:version
 
     /** May be null. */
     val buildType: Property<String>
@@ -195,7 +190,8 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
         .map { it.build() }
         .toSet()
 
-      val projectCoordinates = ProjectCoordinates(parameters.projectPath.get(), parameters.projectGA.get())
+      val projectCoordinates = ProjectCoordinates(parameters.projectPath.get(),
+        GradleVariantIdentification(emptySet(), emptyMap()))
       val classpath = graph.graph.nodes().asSequence().filterNot {
         it == projectCoordinates
       }.toSortedSet()

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
@@ -192,9 +192,7 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
 
       val projectCoordinates = ProjectCoordinates(parameters.projectPath.get(),
         GradleVariantIdentification(emptySet(), emptyMap()))
-      val classpath = graph.graph.nodes().asSequence().filterNot {
-        it == projectCoordinates
-      }.toSortedSet()
+      val classpath = graph.graph.nodes().toSortedSet()
       val annotationProcessors = parameters.annotationProcessors.fromJsonSet<AnnotationProcessorDependency>()
         .mapToSet { it.coordinates }
 

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -353,5 +353,9 @@ private fun Declaration.isJarDependency() =
  * Check that all the requested capabilities are declared in the 'target'. Otherwise, the target can't be a target
  * of the given declarations. The requested capabilities ALWAYS have to exist in a target to be selected.
  */
-private fun Declaration.gradleVariantMatches(target: Coordinates): Boolean =
-  target.gradleVariantIdentification.capabilities.containsAll(gradleVariantIdentification.capabilities)
+private fun Declaration.gradleVariantMatches(target: Coordinates): Boolean = when {
+  gradleVariantIdentification.capabilities.isEmpty() -> target.gradleVariantIdentification.capabilities.any {
+    it.endsWith(target.identifier) // If empty, needs to contain the 'default' capability
+  }
+  else -> target.gradleVariantIdentification.capabilities.containsAll(gradleVariantIdentification.capabilities)
+}

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -319,14 +319,15 @@ internal class StandardTransform(
 private fun Set<Declaration>.forCoordinates(coordinates: Coordinates): Set<Declaration> {
   return asSequence()
     .filter {
-      it.identifierWithFeatureVariant() == coordinates.identifier ||
+      it.identifier == coordinates.identifier ||
         // In the special case of IncludedBuildCoordinates, the declaration might be a 'project(...)' dependency
         // if subprojects inside an included build depend on each other.
         (coordinates is IncludedBuildCoordinates) && it.identifier == coordinates.resolvedProject.identifier
     }
     // We ignore dependencies that do not point as Jar files but still server a purpose.
     // This is currently only used for platform() or enforcedPlatform() dependencies (see usages of NON_JAR_VARIANT).
-    .filter { it.targetFeatureVariant != NON_JAR_VARIANT }
+    .filter { it.targetFeatureVariantName == coordinates.featureVariantName }
+    .filter { it.targetFeatureVariantName != NON_JAR_VARIANT }
     .toSet()
 }
 

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -353,9 +353,12 @@ private fun Declaration.isJarDependency() =
  * Check that all the requested capabilities are declared in the 'target'. Otherwise, the target can't be a target
  * of the given declarations. The requested capabilities ALWAYS have to exist in a target to be selected.
  */
-private fun Declaration.gradleVariantMatches(target: Coordinates): Boolean = when {
-  gradleVariantIdentification.capabilities.isEmpty() -> target.gradleVariantIdentification.capabilities.any {
-    it.endsWith(target.identifier) // If empty, needs to contain the 'default' capability
-  }
-  else -> target.gradleVariantIdentification.capabilities.containsAll(gradleVariantIdentification.capabilities)
+private fun Declaration.gradleVariantMatches(target: Coordinates): Boolean = when(target) {
+  is FlatCoordinates -> true
+  is ProjectCoordinates -> if (gradleVariantIdentification.capabilities.isEmpty()) target.gradleVariantIdentification.capabilities.any {
+    it.endsWith(target.identifier) // If empty, needs to contain the 'default' capability (for projects we need to check with endsWith)
+  } else target.gradleVariantIdentification.capabilities.containsAll(gradleVariantIdentification.capabilities)
+  else -> if (gradleVariantIdentification.capabilities.isEmpty()) target.gradleVariantIdentification.capabilities.any {
+    it == target.identifier // If empty, needs to contain the 'default' capability
+  } else target.gradleVariantIdentification.capabilities.containsAll(gradleVariantIdentification.capabilities)
 }

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -98,13 +98,13 @@ internal class StandardTransform(
         bucket = usage.bucket,
         reasons = usage.reasons
       ).intoMutableSet()
-    } else if (!isSingleBucket(usages)) {
+    } else if (!isSingleBucketForSingleVariant(usages)) {
       // More than one usage _and_ multiple buckets: in a variant situation (Android), there are no "main" usages, by
       // definition. Everything is debugImplementation, releaseApi, etc. If each variant has a different usage, we
-      // respect that.
+      // respect that. In JVM, each variant is distinct (feature variant).
       usages
     } else {
-      // More than one usage, but all in the same bucket. So, we reduce the usages to a single usage.
+      // More than one usage, but all in the same bucket wit the same variant. We reduce the usages to a single usage.
       val usage = usages.first()
       Usage(
         buildType = null,
@@ -333,9 +333,9 @@ private fun Set<Declaration>.forCoordinates(coordinates: Coordinates): Set<Decla
     .toSet()
 }
 
-private fun isSingleBucket(usages: Set<Usage>): Boolean {
+private fun isSingleBucketForSingleVariant(usages: Set<Usage>): Boolean {
   return if (usages.size == 1) true
-  else usages.mapToSet { it.bucket }.size == 1
+  else usages.mapToSet { it.bucket }.size == 1 && usages.mapToSet { it.variant.base() }.size == 1
 }
 
 private fun Sequence<Usage>.filterUsed() = filterNot { it.bucket == Bucket.NONE }

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -356,7 +356,7 @@ private fun Declaration.isJarDependency() =
 private fun Declaration.gradleVariantMatches(target: Coordinates): Boolean = when(target) {
   is FlatCoordinates -> true
   is ProjectCoordinates -> if (gradleVariantIdentification.capabilities.isEmpty()) target.gradleVariantIdentification.capabilities.any {
-    it.endsWith(target.identifier) // If empty, needs to contain the 'default' capability (for projects we need to check with endsWith)
+    it.endsWith(target.identifier.substring(target.identifier.lastIndexOf(":"))) // If empty, needs to contain the 'default' capability (for projects we need to check with endsWith)
   } else target.gradleVariantIdentification.capabilities.containsAll(gradleVariantIdentification.capabilities)
   else -> if (gradleVariantIdentification.capabilities.isEmpty()) target.gradleVariantIdentification.capabilities.any {
     it == target.identifier // If empty, needs to contain the 'default' capability

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -319,13 +319,14 @@ internal class StandardTransform(
 private fun Set<Declaration>.forCoordinates(coordinates: Coordinates): Set<Declaration> {
   return asSequence()
     .filter {
-      it.identifier == coordinates.identifier ||
+      it.identifierWithFeatureVariant() == coordinates.identifier ||
         // In the special case of IncludedBuildCoordinates, the declaration might be a 'project(...)' dependency
         // if subprojects inside an included build depend on each other.
         (coordinates is IncludedBuildCoordinates) && it.identifier == coordinates.resolvedProject.identifier
     }
-    // For now, we ignore any special dependencies like test fixtures or platforms
-    .filter { !it.doesNotPointAtMainVariant }
+    // We ignore dependencies that do not point as Jar files but still server a purpose.
+    // This is currently only used for platform() or enforcedPlatform() dependencies (see usages of NON_JAR_VARIANT).
+    .filter { it.targetFeatureVariant != NON_JAR_VARIANT }
     .toSet()
 }
 

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -326,8 +326,8 @@ private fun Set<Declaration>.forCoordinates(coordinates: Coordinates): Set<Decla
     }
     // We ignore dependencies that do not point as Jar files but still server a purpose.
     // This is currently only used for platform() or enforcedPlatform() dependencies (see usages of NON_JAR_VARIANT).
-    .filter { it.targetFeatureVariantName == coordinates.featureVariantName }
-    .filter { it.targetFeatureVariantName != NON_JAR_VARIANT }
+    .filter { it.targetCapability == coordinates.capability }
+    .filter { it.targetCapability != NON_JAR_VARIANT }
     .toSet()
 }
 

--- a/src/test/kotlin/com/autonomousapps/internal/BundlesTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/BundlesTest.kt
@@ -21,7 +21,7 @@ class BundlesTest {
 
   @Nested inner class DefaultBundles {
     @Test fun `kotlin stdlib is a default bundle`() {
-      val consumer = ProjectCoordinates(":consumer")
+      val consumer = ProjectCoordinates(":consumer", "some.group:consumer")
       val stdlibJdk8 = ModuleCoordinates("org.jetbrains.kotlin:kotlin-stdlib-jdk8", "1")
       val stdlib = ModuleCoordinates("org.jetbrains.kotlin:kotlin-stdlib", "1")
 
@@ -38,7 +38,7 @@ class BundlesTest {
 
       // the thing under test
       val bundles = Bundles.of(
-        projectNode = ProjectCoordinates(":consumer"),
+        projectNode = ProjectCoordinates(":consumer", "some.group:consumer"),
         dependencyGraph = graph,
         bundleRules = dependenciesHandler.serializableBundles(),
         dependencyUsages = dependencyUsages,
@@ -60,8 +60,8 @@ class BundlesTest {
       }
       val bundles = buildBundles()
 
-      val badAdvice = Advice.ofAdd(ProjectCoordinates(":used"), "implementation")
-      val expectedAdvice = Advice.ofAdd(ProjectCoordinates(":entry-point"), "implementation")
+      val badAdvice = Advice.ofAdd(ProjectCoordinates(":used", "some.group:unused"), "implementation")
+      val expectedAdvice = Advice.ofAdd(ProjectCoordinates(":entry-point", "some.group:entry-point"), "implementation")
       assertThat(bundles.maybePrimary(badAdvice)).isEqualTo(expectedAdvice)
     }
 
@@ -74,16 +74,16 @@ class BundlesTest {
       val bundles = buildBundles()
 
       // Advice is unchanged
-      val advice = Advice.ofAdd(ProjectCoordinates(":used"), "implementation")
+      val advice = Advice.ofAdd(ProjectCoordinates(":used", "some.group:used"), "implementation")
       assertThat(bundles.maybePrimary(advice)).isEqualTo(advice)
     }
 
     private fun buildBundles(): Bundles {
       // Coordinates
-      val consumer = ProjectCoordinates(":consumer")
-      val unused = ProjectCoordinates(":unused")
-      val entryPoint = ProjectCoordinates(":entry-point")
-      val used = ProjectCoordinates(":used")
+      val consumer = ProjectCoordinates(":consumer", "some.group:consumer")
+      val unused = ProjectCoordinates(":unused", "some.group:unused")
+      val entryPoint = ProjectCoordinates(":entry-point", "some.group:entry-point")
+      val used = ProjectCoordinates(":used", "some.group:unused")
 
       // Usages of project :consumer
       val unusedUsages = unused to usage(Bucket.NONE, "main").intoSet()
@@ -98,7 +98,7 @@ class BundlesTest {
       )
 
       return Bundles.of(
-        projectNode = ProjectCoordinates(":consumer"),
+        projectNode = ProjectCoordinates(":consumer", "some.group:consumer"),
         dependencyGraph = graph,
         bundleRules = dependenciesHandler.serializableBundles(),
         dependencyUsages = dependencyUsages,

--- a/src/test/kotlin/com/autonomousapps/internal/BundlesTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/BundlesTest.kt
@@ -18,12 +18,13 @@ class BundlesTest {
   private val project = ProjectBuilder.builder().build()
   private val objects = project.objects
   private val dependenciesHandler = DependenciesHandler(objects)
+  private val gvi = GradleVariantIdentification(emptySet(), emptyMap())
 
   @Nested inner class DefaultBundles {
     @Test fun `kotlin stdlib is a default bundle`() {
-      val consumer = ProjectCoordinates(":consumer", "some.group:consumer")
-      val stdlibJdk8 = ModuleCoordinates("org.jetbrains.kotlin:kotlin-stdlib-jdk8", "1")
-      val stdlib = ModuleCoordinates("org.jetbrains.kotlin:kotlin-stdlib", "1")
+      val consumer = ProjectCoordinates(":consumer", gvi)
+      val stdlibJdk8 = ModuleCoordinates("org.jetbrains.kotlin:kotlin-stdlib-jdk8", "1", gvi)
+      val stdlib = ModuleCoordinates("org.jetbrains.kotlin:kotlin-stdlib", "1", gvi)
 
       // Usages of project :consumer
       val stdlibJdk8Usages = stdlibJdk8 to usage(Bucket.NONE, "main").intoSet()
@@ -38,7 +39,7 @@ class BundlesTest {
 
       // the thing under test
       val bundles = Bundles.of(
-        projectNode = ProjectCoordinates(":consumer", "some.group:consumer"),
+        projectNode = ProjectCoordinates(":consumer", gvi),
         dependencyGraph = graph,
         bundleRules = dependenciesHandler.serializableBundles(),
         dependencyUsages = dependencyUsages,
@@ -60,9 +61,9 @@ class BundlesTest {
       }
       val bundles = buildBundles()
 
-      val badAdvice = Advice.ofAdd(ProjectCoordinates(":used", "some.group:unused"), "implementation")
-      val expectedAdvice = Advice.ofAdd(ProjectCoordinates(":entry-point", "some.group:entry-point"), "implementation")
-      assertThat(bundles.maybePrimary(badAdvice)).isEqualTo(expectedAdvice)
+      val badAdvice = Advice.ofAdd(ProjectCoordinates(":used", gvi), "implementation")
+      val expectedAdvice = Advice.ofAdd(ProjectCoordinates(":entry-point", gvi), "implementation")
+      assertThat(bundles.maybePrimary(badAdvice, badAdvice.coordinates)).isEqualTo(expectedAdvice)
     }
 
     @Test fun `without a primary, bundle ignored`() {
@@ -74,16 +75,16 @@ class BundlesTest {
       val bundles = buildBundles()
 
       // Advice is unchanged
-      val advice = Advice.ofAdd(ProjectCoordinates(":used", "some.group:used"), "implementation")
-      assertThat(bundles.maybePrimary(advice)).isEqualTo(advice)
+      val advice = Advice.ofAdd(ProjectCoordinates(":used", gvi), "implementation")
+      assertThat(bundles.maybePrimary(advice, advice.coordinates)).isEqualTo(advice)
     }
 
     private fun buildBundles(): Bundles {
       // Coordinates
-      val consumer = ProjectCoordinates(":consumer", "some.group:consumer")
-      val unused = ProjectCoordinates(":unused", "some.group:unused")
-      val entryPoint = ProjectCoordinates(":entry-point", "some.group:entry-point")
-      val used = ProjectCoordinates(":used", "some.group:unused")
+      val consumer = ProjectCoordinates(":consumer", gvi)
+      val unused = ProjectCoordinates(":unused", gvi)
+      val entryPoint = ProjectCoordinates(":entry-point", gvi)
+      val used = ProjectCoordinates(":used", gvi)
 
       // Usages of project :consumer
       val unusedUsages = unused to usage(Bucket.NONE, "main").intoSet()
@@ -98,7 +99,7 @@ class BundlesTest {
       )
 
       return Bundles.of(
-        projectNode = ProjectCoordinates(":consumer", "some.group:consumer"),
+        projectNode = ProjectCoordinates(":consumer", gvi),
         dependencyGraph = graph,
         bundleRules = dependenciesHandler.serializableBundles(),
         dependencyUsages = dependencyUsages,

--- a/src/test/kotlin/com/autonomousapps/internal/advice/ProjectHealthConsoleReportBuilderTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/advice/ProjectHealthConsoleReportBuilderTest.kt
@@ -1,6 +1,7 @@
 package com.autonomousapps.internal.advice
 
 import com.autonomousapps.model.Advice
+import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.ModuleCoordinates
 import com.autonomousapps.model.ProjectAdvice
 import com.google.common.truth.Truth.assertThat
@@ -8,12 +9,14 @@ import org.junit.jupiter.api.Test
 
 internal class ProjectHealthConsoleReportBuilderTest {
 
+  private val gvi = GradleVariantIdentification(emptySet(), emptyMap())
+
   @Test
   fun adviceOfRemoveShouldBeSorted() {
     val dependencyAdvice = setOf(
-      Advice.ofRemove(ModuleCoordinates("com.project.a", "1.0"), "implementation"),
-      Advice.ofRemove(ModuleCoordinates("com.project.c", "1.0"), "api"),
-      Advice.ofRemove(ModuleCoordinates("com.project.b", "1.0"), "api"),
+      Advice.ofRemove(ModuleCoordinates("com.project.a", "1.0", gvi), "implementation"),
+      Advice.ofRemove(ModuleCoordinates("com.project.c", "1.0", gvi), "api"),
+      Advice.ofRemove(ModuleCoordinates("com.project.b", "1.0", gvi), "api"),
     )
     val projectAdvice = ProjectAdvice("dummy", dependencyAdvice, emptySet())
 
@@ -31,9 +34,9 @@ internal class ProjectHealthConsoleReportBuilderTest {
   @Test
   fun adviceOfChangeShouldBeSorted() {
     val dependencyAdvice = setOf(
-      Advice.ofChange(ModuleCoordinates("com.project.a", "1.0"), "implementation", "api"),
-      Advice.ofChange(ModuleCoordinates("com.project.c", "1.0"), "api", "implementation"),
-      Advice.ofChange(ModuleCoordinates("com.project.b", "1.0"), "api", "implementation"),
+      Advice.ofChange(ModuleCoordinates("com.project.a", "1.0", gvi), "implementation", "api"),
+      Advice.ofChange(ModuleCoordinates("com.project.c", "1.0", gvi), "api", "implementation"),
+      Advice.ofChange(ModuleCoordinates("com.project.b", "1.0", gvi), "api", "implementation"),
     )
     val projectAdvice = ProjectAdvice("dummy", dependencyAdvice, emptySet())
 
@@ -51,9 +54,9 @@ internal class ProjectHealthConsoleReportBuilderTest {
   @Test
   fun adviceOfAddShouldBeSorted() {
     val dependencyAdvice = setOf(
-      Advice.ofAdd(ModuleCoordinates("com.project.a", "1.0"), "implementation"),
-      Advice.ofAdd(ModuleCoordinates("com.project.c", "1.0"), "api"),
-      Advice.ofAdd(ModuleCoordinates("com.project.b", "1.0"), "api"),
+      Advice.ofAdd(ModuleCoordinates("com.project.a", "1.0", gvi), "implementation"),
+      Advice.ofAdd(ModuleCoordinates("com.project.c", "1.0", gvi), "api"),
+      Advice.ofAdd(ModuleCoordinates("com.project.b", "1.0", gvi), "api"),
     )
     val projectAdvice = ProjectAdvice("dummy", dependencyAdvice, emptySet())
 

--- a/src/test/kotlin/com/autonomousapps/internal/reason/DependencyAdviceExplainerTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/reason/DependencyAdviceExplainerTest.kt
@@ -21,10 +21,12 @@ import org.junit.jupiter.api.Test
  */
 class DependencyAdviceExplainerTest {
 
+  private val gvi = GradleVariantIdentification(emptySet(), emptyMap())
+
   @Nested inner class NonBundle {
     @Test fun `has expected output`() {
       // Given
-      val target = ModuleCoordinates("androidx.lifecycle:lifecycle-common", "2.0.0")
+      val target = ModuleCoordinates("androidx.lifecycle:lifecycle-common", "2.0.0", gvi)
       val reasons = setOf(
         Reason.Abi(setOf("One", "Two", "Three", "Four", "Five")),
         Reason.AnnotationProcessor.classes(setOf("Proc1"), isKapt = false),
@@ -96,7 +98,7 @@ class DependencyAdviceExplainerTest {
 
     @Test fun `is expected for compileOnly`() {
       // Given
-      val target = ModuleCoordinates("androidx.lifecycle:lifecycle-common", "2.0.0")
+      val target = ModuleCoordinates("androidx.lifecycle:lifecycle-common", "2.0.0", gvi)
       val reasons = setOf(
         Reason.CompileTimeAnnotations(),
         Reason.Constant(setOf("Const1", "Const2")),
@@ -142,7 +144,7 @@ class DependencyAdviceExplainerTest {
 
     @Test fun `is expected for undeclared`() {
       // Given
-      val target = ModuleCoordinates("androidx.lifecycle:lifecycle-common", "2.0.0")
+      val target = ModuleCoordinates("androidx.lifecycle:lifecycle-common", "2.0.0", gvi)
       val debugReasons = setOf(Reason.Abi(setOf("One", "Two", "Three", "Four", "Five")))
       val releaseReasons = setOf(Reason.Undeclared)
       val usages = setOf(
@@ -182,7 +184,7 @@ class DependencyAdviceExplainerTest {
 
     @Test fun `is expected for unused`() {
       // Given
-      val target = ModuleCoordinates("androidx.lifecycle:lifecycle-common", "2.0.0")
+      val target = ModuleCoordinates("androidx.lifecycle:lifecycle-common", "2.0.0", gvi)
       val reasons = setOf(Reason.Unused)
       val usages = setOf(
         usage(bucket = Bucket.NONE, variant = "debug", kind = SourceSetKind.MAIN, reasons = reasons),
@@ -222,7 +224,7 @@ class DependencyAdviceExplainerTest {
   @Nested inner class Bundle {
     @Test fun `no advice for declared parent`() {
       // Given
-      val target = ModuleCoordinates("androidx.lifecycle:lifecycle-common", "2.0.0")
+      val target = ModuleCoordinates("androidx.lifecycle:lifecycle-common", "2.0.0", gvi)
       val reasons = setOf(Reason.Impl(setOf("impl1")))
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN, reasons = reasons),
@@ -266,7 +268,7 @@ class DependencyAdviceExplainerTest {
     @Test fun `no advice for used child`() {
       // TODO for this case, consider updating the graph output to show the path to the used child
       // Given
-      val target = ModuleCoordinates("androidx.core:core", "1.1.0")
+      val target = ModuleCoordinates("androidx.core:core", "1.1.0", gvi)
       val reasons = setOf(Reason.Impl(setOf("impl1")))
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN, reasons = reasons),
@@ -307,7 +309,7 @@ class DependencyAdviceExplainerTest {
 
     @Test fun `advice for primary map`() {
       // Given
-      val target = ModuleCoordinates("androidx.core:core", "1.1.0")
+      val target = ModuleCoordinates("androidx.core:core", "1.1.0", gvi)
       val reasons = setOf(Reason.Impl(setOf("impl1")))
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN, reasons = reasons),
@@ -348,7 +350,7 @@ class DependencyAdviceExplainerTest {
   }
 
   private object Fixture {
-    private val root = ProjectCoordinates(":root", ":root")
+    private val root = ProjectCoordinates(":root", GradleVariantIdentification(emptySet(), emptyMap()))
     private val graph = graphOf(
       (root.identifier to ":lib").asCoordinates(),
       (root.identifier to "androidx.core:core:1.1.0").asCoordinates(),

--- a/src/test/kotlin/com/autonomousapps/internal/reason/DependencyAdviceExplainerTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/reason/DependencyAdviceExplainerTest.kt
@@ -348,7 +348,7 @@ class DependencyAdviceExplainerTest {
   }
 
   private object Fixture {
-    private val root = ProjectCoordinates(":root")
+    private val root = ProjectCoordinates(":root", ":root")
     private val graph = graphOf(
       (root.identifier to ":lib").asCoordinates(),
       (root.identifier to "androidx.core:core:1.1.0").asCoordinates(),

--- a/src/test/kotlin/com/autonomousapps/internal/reason/ModuleAdviceExplainerTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/reason/ModuleAdviceExplainerTest.kt
@@ -1,6 +1,7 @@
 package com.autonomousapps.internal.reason
 
 import com.autonomousapps.model.AndroidScore
+import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.ProjectCoordinates
 import com.autonomousapps.utils.Colors.decolorize
 import com.google.common.truth.Truth.assertThat
@@ -62,7 +63,7 @@ internal class ModuleAdviceExplainerTest {
     var finalAndroidScore: AndroidScore = unfilteredAndroidScore
   ) {
 
-    private val root = ProjectCoordinates(":root", "unspecified:root")
+    private val root = ProjectCoordinates(":root", GradleVariantIdentification(emptySet(), emptyMap()))
 
     fun computer() = ModuleAdviceExplainer(
       project = root,

--- a/src/test/kotlin/com/autonomousapps/internal/reason/ModuleAdviceExplainerTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/reason/ModuleAdviceExplainerTest.kt
@@ -62,7 +62,7 @@ internal class ModuleAdviceExplainerTest {
     var finalAndroidScore: AndroidScore = unfilteredAndroidScore
   ) {
 
-    private val root = ProjectCoordinates(":root")
+    private val root = ProjectCoordinates(":root", "unspecified:root")
 
     fun computer() = ModuleAdviceExplainer(
       project = root,

--- a/src/test/kotlin/com/autonomousapps/model/AdviceTest.kt
+++ b/src/test/kotlin/com/autonomousapps/model/AdviceTest.kt
@@ -28,7 +28,7 @@ class AdviceTest {
    */
   @Test fun `an ordered set of advice contains no duplicates`() {
     // Given
-    val androidxLifecycle = ModuleCoordinates("androidx.lifecycle:lifecycle-common8", "n/a")
+    val androidxLifecycle = ModuleCoordinates("androidx.lifecycle:lifecycle-common8", "n/a", GradleVariantIdentification(emptySet(), emptyMap()))
     val adviceSet1 = setOf(Advice.ofRemove(androidxLifecycle, "foo"))
     val adviceSet2 = setOf(Advice.ofRemove(androidxLifecycle, "foo"))
     val list = listOf(adviceSet1, adviceSet2)

--- a/src/test/kotlin/com/autonomousapps/model/CoordinatesTest.kt
+++ b/src/test/kotlin/com/autonomousapps/model/CoordinatesTest.kt
@@ -8,16 +8,18 @@ import org.junit.jupiter.api.Test
 
 internal class CoordinatesTest {
 
+  private val gvi = GradleVariantIdentification(setOf("some:capability"), mapOf("someAttribute" to "blue"))
+
   @Test fun `can serialize and deserialize polymorphic ProjectCoordinates with moshi`() {
     val linterDependency = setOf(
       AndroidLinterDependency(
-        ProjectCoordinates(":app", "some.group:app"), "fooRegistry"
+        ProjectCoordinates(":app", gvi), "fooRegistry"
       )
     )
 
     val serialized = linterDependency.toJson()
     assertThat(serialized).isEqualTo(
-      """[{"coordinates":{"type":"project","identifier":":app","capability":"some.group:app"},"lintRegistry":"fooRegistry"}]"""
+      """[{"coordinates":{"type":"project","identifier":":app","gradleVariantIdentification":{"capabilities":["some:capability"],"attributes":{"someAttribute":"blue"}}},"lintRegistry":"fooRegistry"}]"""
     )
 
     val deserialized = serialized.fromJsonSet<AndroidLinterDependency>()
@@ -27,13 +29,13 @@ internal class CoordinatesTest {
   @Test fun `can serialize and deserialize polymorphic ModuleCoordinates with moshi`() {
     val linterDependency = setOf(
       AndroidLinterDependency(
-        ModuleCoordinates("magic:app", "1.0"), "fooRegistry"
+        ModuleCoordinates("magic:app", "1.0", gvi), "fooRegistry"
       )
     )
 
     val serialized = linterDependency.toJson()
     assertThat(serialized).isEqualTo(
-      """[{"coordinates":{"type":"module","identifier":"magic:app","resolvedVersion":"1.0","capability":"magic:app"},"lintRegistry":"fooRegistry"}]"""
+      """[{"coordinates":{"type":"module","identifier":"magic:app","resolvedVersion":"1.0","gradleVariantIdentification":{"capabilities":["some:capability"],"attributes":{"someAttribute":"blue"}}},"lintRegistry":"fooRegistry"}]"""
     )
 
     val deserialized = serialized.fromJsonSet<AndroidLinterDependency>()
@@ -57,12 +59,12 @@ internal class CoordinatesTest {
   }
 
   @Test fun `compares to behaves similar in both directions`() {
-    val moduleA = ModuleCoordinates("g:a", "1.0")
-    val moduleB = ModuleCoordinates("g:b", "1.0")
-    val includedB = IncludedBuildCoordinates("g:a", ProjectCoordinates(":a", "some.group:a"), "some.group:a")
-    val includedA = IncludedBuildCoordinates("g:b", ProjectCoordinates(":b", "some.group:b"), "some.group:b")
-    val projectA = ProjectCoordinates(":a", "some.group:a")
-    val projectB = ProjectCoordinates(":b", "some.group:b")
+    val moduleA = ModuleCoordinates("g:a", "1.0", gvi)
+    val moduleB = ModuleCoordinates("g:b", "1.0", gvi)
+    val includedB = IncludedBuildCoordinates("g:a", ProjectCoordinates(":a", gvi), gvi)
+    val includedA = IncludedBuildCoordinates("g:b", ProjectCoordinates(":b", gvi), gvi)
+    val projectA = ProjectCoordinates(":a", gvi)
+    val projectB = ProjectCoordinates(":b", gvi)
     val flatA = FlatCoordinates("a")
     val flatB = FlatCoordinates("a")
 

--- a/src/test/kotlin/com/autonomousapps/model/CoordinatesTest.kt
+++ b/src/test/kotlin/com/autonomousapps/model/CoordinatesTest.kt
@@ -17,7 +17,7 @@ internal class CoordinatesTest {
 
     val serialized = linterDependency.toJson()
     assertThat(serialized).isEqualTo(
-      """[{"coordinates":{"type":"project","identifier":":app"},"lintRegistry":"fooRegistry"}]"""
+      """[{"coordinates":{"type":"project","identifier":":app","featureVariantName":""},"lintRegistry":"fooRegistry"}]"""
     )
 
     val deserialized = serialized.fromJsonSet<AndroidLinterDependency>()
@@ -33,7 +33,7 @@ internal class CoordinatesTest {
 
     val serialized = linterDependency.toJson()
     assertThat(serialized).isEqualTo(
-      """[{"coordinates":{"type":"module","identifier":"magic:app","resolvedVersion":"1.0"},"lintRegistry":"fooRegistry"}]"""
+      """[{"coordinates":{"type":"module","identifier":"magic:app","resolvedVersion":"1.0","featureVariantName":""},"lintRegistry":"fooRegistry"}]"""
     )
 
     val deserialized = serialized.fromJsonSet<AndroidLinterDependency>()

--- a/src/test/kotlin/com/autonomousapps/model/CoordinatesTest.kt
+++ b/src/test/kotlin/com/autonomousapps/model/CoordinatesTest.kt
@@ -11,13 +11,13 @@ internal class CoordinatesTest {
   @Test fun `can serialize and deserialize polymorphic ProjectCoordinates with moshi`() {
     val linterDependency = setOf(
       AndroidLinterDependency(
-        ProjectCoordinates(":app"), "fooRegistry"
+        ProjectCoordinates(":app", "some.group:app"), "fooRegistry"
       )
     )
 
     val serialized = linterDependency.toJson()
     assertThat(serialized).isEqualTo(
-      """[{"coordinates":{"type":"project","identifier":":app","featureVariantName":""},"lintRegistry":"fooRegistry"}]"""
+      """[{"coordinates":{"type":"project","identifier":":app","capability":"some.group:app"},"lintRegistry":"fooRegistry"}]"""
     )
 
     val deserialized = serialized.fromJsonSet<AndroidLinterDependency>()
@@ -33,7 +33,7 @@ internal class CoordinatesTest {
 
     val serialized = linterDependency.toJson()
     assertThat(serialized).isEqualTo(
-      """[{"coordinates":{"type":"module","identifier":"magic:app","resolvedVersion":"1.0","featureVariantName":""},"lintRegistry":"fooRegistry"}]"""
+      """[{"coordinates":{"type":"module","identifier":"magic:app","resolvedVersion":"1.0","capability":"magic:app"},"lintRegistry":"fooRegistry"}]"""
     )
 
     val deserialized = serialized.fromJsonSet<AndroidLinterDependency>()
@@ -59,10 +59,10 @@ internal class CoordinatesTest {
   @Test fun `compares to behaves similar in both directions`() {
     val moduleA = ModuleCoordinates("g:a", "1.0")
     val moduleB = ModuleCoordinates("g:b", "1.0")
-    val includedB = IncludedBuildCoordinates("g:a", ProjectCoordinates(":a"))
-    val includedA = IncludedBuildCoordinates("g:b", ProjectCoordinates(":b"))
-    val projectA = ProjectCoordinates(":a")
-    val projectB = ProjectCoordinates(":b")
+    val includedB = IncludedBuildCoordinates("g:a", ProjectCoordinates(":a", "some.group:a"), "some.group:a")
+    val includedA = IncludedBuildCoordinates("g:b", ProjectCoordinates(":b", "some.group:b"), "some.group:b")
+    val projectA = ProjectCoordinates(":a", "some.group:a")
+    val projectB = ProjectCoordinates(":b", "some.group:b")
     val flatA = FlatCoordinates("a")
     val flatB = FlatCoordinates("a")
 

--- a/src/test/kotlin/com/autonomousapps/model/DependencyGraphViewTest.kt
+++ b/src/test/kotlin/com/autonomousapps/model/DependencyGraphViewTest.kt
@@ -25,7 +25,7 @@ internal class DependencyGraphViewTest {
     val serialized = graphView.toJson()
     assertThat(serialized).isEqualTo(
       """
-        {"variant":{"variant":"main","kind":"MAIN"},"configurationName":"compileClasspath","nodes":[{"type":"project","identifier":":secondary:root","featureVariantName":""},{"type":"project","identifier":":root","featureVariantName":""},{"type":"module","identifier":"foo:bar","resolvedVersion":"1","featureVariantName":""},{"type":"module","identifier":"bar:baz","resolvedVersion":"1","featureVariantName":""}],"edges":[{"source":{"type":"project","identifier":":root","featureVariantName":""},"target":{"type":"module","identifier":"foo:bar","resolvedVersion":"1","featureVariantName":""}},{"source":{"type":"module","identifier":"foo:bar","resolvedVersion":"1","featureVariantName":""},"target":{"type":"module","identifier":"bar:baz","resolvedVersion":"1","featureVariantName":""}}]}
+        {"variant":{"variant":"main","kind":"MAIN"},"configurationName":"compileClasspath","nodes":[{"type":"project","identifier":":secondary:root","capability":"some.group:root"},{"type":"project","identifier":":root","capability":"some.group:root"},{"type":"module","identifier":"foo:bar","resolvedVersion":"1","capability":"foo:bar"},{"type":"module","identifier":"bar:baz","resolvedVersion":"1","capability":"bar:baz"}],"edges":[{"source":{"type":"project","identifier":":root","capability":"some.group:root"},"target":{"type":"module","identifier":"foo:bar","resolvedVersion":"1","capability":"foo:bar"}},{"source":{"type":"module","identifier":"foo:bar","resolvedVersion":"1","capability":"foo:bar"},"target":{"type":"module","identifier":"bar:baz","resolvedVersion":"1","capability":"bar:baz"}}]}
       """.trimIndent()
     )
 
@@ -33,6 +33,6 @@ internal class DependencyGraphViewTest {
     assertThat(deserialized).isEqualTo(graphView)
   }
 
-  private fun String.toProject() = ProjectCoordinates(this)
+  private fun String.toProject() = ProjectCoordinates(this, "some.group${substring(lastIndexOf(":"))}")
   private fun String.toModule() = ModuleCoordinates(substringBeforeLast(':'), substringAfterLast(':'))
 }

--- a/src/test/kotlin/com/autonomousapps/model/DependencyGraphViewTest.kt
+++ b/src/test/kotlin/com/autonomousapps/model/DependencyGraphViewTest.kt
@@ -25,7 +25,7 @@ internal class DependencyGraphViewTest {
     val serialized = graphView.toJson()
     assertThat(serialized).isEqualTo(
       """
-        {"variant":{"variant":"main","kind":"MAIN"},"configurationName":"compileClasspath","nodes":[{"type":"project","identifier":":secondary:root","capability":"some.group:root"},{"type":"project","identifier":":root","capability":"some.group:root"},{"type":"module","identifier":"foo:bar","resolvedVersion":"1","capability":"foo:bar"},{"type":"module","identifier":"bar:baz","resolvedVersion":"1","capability":"bar:baz"}],"edges":[{"source":{"type":"project","identifier":":root","capability":"some.group:root"},"target":{"type":"module","identifier":"foo:bar","resolvedVersion":"1","capability":"foo:bar"}},{"source":{"type":"module","identifier":"foo:bar","resolvedVersion":"1","capability":"foo:bar"},"target":{"type":"module","identifier":"bar:baz","resolvedVersion":"1","capability":"bar:baz"}}]}
+        {"variant":{"variant":"main","kind":"MAIN"},"configurationName":"compileClasspath","nodes":[{"type":"project","identifier":":secondary:root","gradleVariantIdentification":{"capabilities":[],"attributes":{}}},{"type":"project","identifier":":root","gradleVariantIdentification":{"capabilities":[],"attributes":{}}},{"type":"module","identifier":"foo:bar","resolvedVersion":"1","gradleVariantIdentification":{"capabilities":[],"attributes":{}}},{"type":"module","identifier":"bar:baz","resolvedVersion":"1","gradleVariantIdentification":{"capabilities":[],"attributes":{}}}],"edges":[{"source":{"type":"project","identifier":":root","gradleVariantIdentification":{"capabilities":[],"attributes":{}}},"target":{"type":"module","identifier":"foo:bar","resolvedVersion":"1","gradleVariantIdentification":{"capabilities":[],"attributes":{}}}},{"source":{"type":"module","identifier":"foo:bar","resolvedVersion":"1","gradleVariantIdentification":{"capabilities":[],"attributes":{}}},"target":{"type":"module","identifier":"bar:baz","resolvedVersion":"1","gradleVariantIdentification":{"capabilities":[],"attributes":{}}}}]}
       """.trimIndent()
     )
 
@@ -33,6 +33,6 @@ internal class DependencyGraphViewTest {
     assertThat(deserialized).isEqualTo(graphView)
   }
 
-  private fun String.toProject() = ProjectCoordinates(this, "some.group${substring(lastIndexOf(":"))}")
-  private fun String.toModule() = ModuleCoordinates(substringBeforeLast(':'), substringAfterLast(':'))
+  private fun String.toProject() = ProjectCoordinates(this, GradleVariantIdentification(emptySet(), emptyMap()))
+  private fun String.toModule() = ModuleCoordinates(substringBeforeLast(':'), substringAfterLast(':'), GradleVariantIdentification(emptySet(), emptyMap()))
 }

--- a/src/test/kotlin/com/autonomousapps/model/DependencyGraphViewTest.kt
+++ b/src/test/kotlin/com/autonomousapps/model/DependencyGraphViewTest.kt
@@ -25,7 +25,7 @@ internal class DependencyGraphViewTest {
     val serialized = graphView.toJson()
     assertThat(serialized).isEqualTo(
       """
-        {"variant":{"variant":"main","kind":"MAIN"},"configurationName":"compileClasspath","nodes":[{"type":"project","identifier":":secondary:root"},{"type":"project","identifier":":root"},{"type":"module","identifier":"foo:bar","resolvedVersion":"1"},{"type":"module","identifier":"bar:baz","resolvedVersion":"1"}],"edges":[{"source":{"type":"project","identifier":":root"},"target":{"type":"module","identifier":"foo:bar","resolvedVersion":"1"}},{"source":{"type":"module","identifier":"foo:bar","resolvedVersion":"1"},"target":{"type":"module","identifier":"bar:baz","resolvedVersion":"1"}}]}
+        {"variant":{"variant":"main","kind":"MAIN"},"configurationName":"compileClasspath","nodes":[{"type":"project","identifier":":secondary:root","featureVariantName":""},{"type":"project","identifier":":root","featureVariantName":""},{"type":"module","identifier":"foo:bar","resolvedVersion":"1","featureVariantName":""},{"type":"module","identifier":"bar:baz","resolvedVersion":"1","featureVariantName":""}],"edges":[{"source":{"type":"project","identifier":":root","featureVariantName":""},"target":{"type":"module","identifier":"foo:bar","resolvedVersion":"1","featureVariantName":""}},{"source":{"type":"module","identifier":"foo:bar","resolvedVersion":"1","featureVariantName":""},"target":{"type":"module","identifier":"bar:baz","resolvedVersion":"1","featureVariantName":""}}]}
       """.trimIndent()
     )
 

--- a/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
+++ b/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
@@ -2,6 +2,7 @@ package com.autonomousapps.transform
 
 import com.autonomousapps.internal.utils.intoSet
 import com.autonomousapps.model.Advice
+import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.ModuleCoordinates
 import com.autonomousapps.model.declaration.Bucket
 import com.autonomousapps.model.declaration.Declaration
@@ -16,6 +17,8 @@ import org.junit.jupiter.params.provider.CsvSource
 
 internal class StandardTransformTest {
 
+  private val gvi = GradleVariantIdentification(emptySet(), emptyMap())
+
   private val supportedSourceSets = setOf(
     "main",
     "release", "debug",
@@ -28,12 +31,12 @@ internal class StandardTransformTest {
   @Nested inner class SingleVariant {
 
     @Test fun `no advice for correct declaration`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = usage(Bucket.IMPL, "debug").intoSet()
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = "implementation",
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -42,14 +45,14 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should be api`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val bucket = Bucket.API
       val usages = usage(bucket, "debug").intoSet()
       val oldConfiguration = Bucket.IMPL.value
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = oldConfiguration,
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -64,14 +67,14 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should be implementation`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val bucket = Bucket.IMPL
       val usages = usage(bucket, "debug").intoSet()
       val oldConfiguration = Bucket.API.value
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = oldConfiguration,
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -86,13 +89,13 @@ internal class StandardTransformTest {
     }
 
     @Test fun `no advice for correct variant declaration`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val bucket = Bucket.IMPL
       val usages = usage(bucket, "debug").intoSet()
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = "debugImplementation",
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -101,14 +104,14 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should remove unused dependency`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val bucket = Bucket.NONE
       val usages = usage(bucket, "debug").intoSet()
       val fromConfiguration = "api"
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = fromConfiguration,
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -117,7 +120,7 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should add dependency`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = usage(Bucket.IMPL, "debug").intoSet()
       val declarations = emptySet<Declaration>()
 
@@ -127,12 +130,12 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should not remove runtimeOnly declarations`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = usage(Bucket.NONE, "debug").intoSet()
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = "runtimeOnly",
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -141,12 +144,12 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should not remove compileOnly declarations`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = usage(Bucket.NONE, "debug").intoSet()
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = "compileOnly",
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -158,13 +161,13 @@ internal class StandardTransformTest {
   @Nested inner class MultiVariant {
 
     @Test fun `no advice for correct declaration`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val bucket = Bucket.IMPL
       val usages = setOf(usage(bucket, "debug"), usage(bucket, "release"))
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = "implementation",
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -173,7 +176,7 @@ internal class StandardTransformTest {
     }
 
     @Test fun `no advice for undeclared compileOnly usage`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val bucket = Bucket.COMPILE_ONLY
       val usages = setOf(usage(bucket, "debug"), usage(bucket, "release"))
       val declarations = emptySet<Declaration>()
@@ -184,7 +187,7 @@ internal class StandardTransformTest {
     }
 
     @Test fun `no advice for undeclared runtimeOnly usage`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = setOf(
         usage(Bucket.RUNTIME_ONLY, "debug"),
         usage(Bucket.RUNTIME_ONLY, "release")
@@ -197,13 +200,13 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should be api`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = setOf(usage(Bucket.API, "debug"), usage(Bucket.API, "release"))
       val fromConfiguration = "implementation"
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = fromConfiguration,
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -216,12 +219,12 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should be api on release variant`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.API, "release"))
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = "implementation",
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -233,14 +236,14 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should be kapt`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val bucket = Bucket.ANNOTATION_PROCESSOR
       val usages = setOf(usage(bucket, "debug"), usage(bucket, "release"))
       val oldConfiguration = "kaptDebug"
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = oldConfiguration,
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets, true).reduce(usages)
@@ -255,7 +258,7 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should not remove unused and undeclared dependency`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = setOf(usage(Bucket.NONE, "debug"), usage(Bucket.NONE, "release"))
       val declarations = emptySet<Declaration>()
 
@@ -265,13 +268,13 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should remove unused dependency`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = setOf(usage(Bucket.NONE, "debug"), usage(Bucket.NONE, "release"))
       val fromConfiguration = "api"
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = fromConfiguration,
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -280,7 +283,7 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should remove unused dependency on release variant`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = setOf(
         usage(Bucket.IMPL, "debug"),
         usage(Bucket.NONE, "release")
@@ -289,7 +292,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = fromConfiguration,
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -301,7 +304,7 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should add dependency`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.IMPL, "release"))
       val declarations = emptySet<Declaration>()
 
@@ -311,7 +314,7 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should add dependency to debug as impl and release as api`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.API, "release"))
       val declarations = emptySet<Declaration>()
 
@@ -324,7 +327,7 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should add dependency to debug as impl and not at all for release`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.NONE, "release"))
       val declarations = emptySet<Declaration>()
 
@@ -338,11 +341,11 @@ internal class StandardTransformTest {
 
     @Test fun `should consolidate on implementation declaration`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.IMPL, "release"))
       val declarations = setOf(
-        Declaration(id, "debugImplementation", id),
-        Declaration(id, "releaseApi", id)
+        Declaration(id, "debugImplementation", gvi),
+        Declaration(id, "releaseApi", gvi)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -355,11 +358,11 @@ internal class StandardTransformTest {
 
     @Test fun `should consolidate on implementation declaration, with pathological redundant declaration`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.IMPL, "release"))
       val declarations = setOf(
-        Declaration(id, "implementation", id),
-        Declaration(id, "releaseImplementation", id)
+        Declaration(id, "implementation", gvi),
+        Declaration(id, "releaseImplementation", gvi)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -370,14 +373,14 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should consolidate on kapt`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val bucket = Bucket.ANNOTATION_PROCESSOR
       val usages = setOf(usage(bucket, "debug"), usage(bucket, "release"))
       val declarations = setOf(
         Declaration(identifier = coordinates.identifier, configurationName = "kaptDebug",
-          targetCapability = coordinates.identifier),
+          gradleVariantIdentification = gvi),
         Declaration(identifier = coordinates.identifier, configurationName = "kaptRelease",
-          targetCapability = coordinates.identifier)
+          gradleVariantIdentification = gvi)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets, true).reduce(usages)
@@ -399,11 +402,11 @@ internal class StandardTransformTest {
 
     @Test fun `should remove release declaration and change debug to api`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(usage(Bucket.API, "debug"), usage(Bucket.NONE, "release"))
       val declarations = setOf(
-        Declaration(id, "debugImplementation", id),
-        Declaration(id, "releaseApi", id)
+        Declaration(id, "debugImplementation", gvi),
+        Declaration(id, "releaseApi", gvi)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -416,11 +419,11 @@ internal class StandardTransformTest {
 
     @Test fun `should remove both declarations`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(usage(Bucket.NONE, "debug"), usage(Bucket.NONE, "release"))
       val declarations = setOf(
-        Declaration(id, "debugImplementation", id),
-        Declaration(id, "releaseApi", id)
+        Declaration(id, "debugImplementation", gvi),
+        Declaration(id, "releaseApi", gvi)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -433,11 +436,11 @@ internal class StandardTransformTest {
 
     @Test fun `should change both declarations`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(usage(Bucket.API, "debug"), usage(Bucket.IMPL, "release"))
       val declarations = setOf(
-        Declaration(id, "debugImplementation", id),
-        Declaration(id, "releaseApi", id)
+        Declaration(id, "debugImplementation", gvi),
+        Declaration(id, "releaseApi", gvi)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -450,14 +453,14 @@ internal class StandardTransformTest {
 
     @Test fun `should change debug to debugImpl and release to releaseApi`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(
         usage(Bucket.IMPL, "debug"),
         usage(Bucket.API, "release")
       )
       val declarations = setOf(
-        Declaration(id, "implementation", id),
-        Declaration(id, "releaseImplementation", id)
+        Declaration(id, "implementation", gvi),
+        Declaration(id, "releaseImplementation", gvi)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -477,14 +480,14 @@ internal class StandardTransformTest {
 
     @Test fun `junit should be declared as testImplementation`() {
       val id = "junit:junit"
-      val coordinates = ModuleCoordinates(id, "4.13.2")
+      val coordinates = ModuleCoordinates(id, "4.13.2", gvi)
       val usages = setOf(
         usage(bucket = Bucket.NONE, variant = "debug", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.NONE, variant = "release", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.TEST),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
-      val declarations = Declaration(id, "implementation", id).intoSet()
+      val declarations = Declaration(id, "implementation", gvi).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
@@ -495,14 +498,14 @@ internal class StandardTransformTest {
 
     @Test fun `junit should be declared as androidTestImplementation`() {
       val id = "junit:junit"
-      val coordinates = ModuleCoordinates(id, "4.13.2")
+      val coordinates = ModuleCoordinates(id, "4.13.2", gvi)
       val usages = setOf(
         usage(bucket = Bucket.NONE, variant = "debug", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.NONE, variant = "release", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.ANDROID_TEST),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.ANDROID_TEST),
       )
-      val declarations = Declaration(id, "implementation", id).intoSet()
+      val declarations = Declaration(id, "implementation", gvi).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
@@ -513,7 +516,7 @@ internal class StandardTransformTest {
 
     @Test fun `junit should be removed from implementation`() {
       val id = "junit:junit"
-      val coordinates = ModuleCoordinates(id, "4.13.2")
+      val coordinates = ModuleCoordinates(id, "4.13.2", gvi)
       val usages = setOf(
         usage(bucket = Bucket.NONE, variant = "debug", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.TEST),
@@ -522,9 +525,9 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.ANDROID_TEST),
       )
       val declarations = setOf(
-        Declaration(id, "implementation", id),
-        Declaration(id, "testImplementation", id),
-        Declaration(id, "androidTestImplementation", id),
+        Declaration(id, "implementation", gvi),
+        Declaration(id, "testImplementation", gvi),
+        Declaration(id, "androidTestImplementation", gvi),
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -536,14 +539,14 @@ internal class StandardTransformTest {
 
     @Test fun `should be debugImplementation and testImplementation`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.NONE, variant = "release", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.TEST),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
-      val declarations = Declaration(id, "implementation", id).intoSet()
+      val declarations = Declaration(id, "implementation", gvi).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
@@ -555,14 +558,14 @@ internal class StandardTransformTest {
 
     @Test fun `should be debugImplementation and androidTestImplementation`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.NONE, variant = "release", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.ANDROID_TEST),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.ANDROID_TEST),
       )
-      val declarations = Declaration(id, "implementation", id).intoSet()
+      val declarations = Declaration(id, "implementation", gvi).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
@@ -574,7 +577,7 @@ internal class StandardTransformTest {
 
     @Test fun `should be debugImplementation`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.NONE, variant = "release", kind = SourceSetKind.MAIN),
@@ -582,8 +585,8 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
       val declarations = setOf(
-        Declaration(id, "implementation", id),
-        Declaration(id, "testImplementation", id)
+        Declaration(id, "implementation", gvi),
+        Declaration(id, "testImplementation", gvi)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -595,7 +598,7 @@ internal class StandardTransformTest {
 
     @Test fun `does not need to be declared on testImplementation`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.MAIN),
@@ -603,8 +606,8 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
       val declarations = setOf(
-        Declaration(id, "implementation", id),
-        Declaration(id, "testImplementation", id)
+        Declaration(id, "implementation", gvi),
+        Declaration(id, "testImplementation", gvi)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -616,7 +619,7 @@ internal class StandardTransformTest {
 
     @Test fun `does not need to be declared on androidTestImplementation`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.MAIN),
@@ -624,8 +627,8 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.ANDROID_TEST),
       )
       val declarations = setOf(
-        Declaration(id, "implementation", id),
-        Declaration(id, "androidTestImplementation", id)
+        Declaration(id, "implementation", gvi),
+        Declaration(id, "androidTestImplementation", gvi)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -637,7 +640,7 @@ internal class StandardTransformTest {
 
     @Test fun `should be declared on implementation, not testImplementation`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.MAIN),
@@ -645,7 +648,7 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
       val declarations = setOf(
-        Declaration(id, "testImplementation", id)
+        Declaration(id, "testImplementation", gvi)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -657,7 +660,7 @@ internal class StandardTransformTest {
 
     @Test fun `should be declared on implementation, not androidTestImplementation`() {
       val id = "com.foo:bar"
-      val coordinates = ModuleCoordinates(id, "1.0")
+      val coordinates = ModuleCoordinates(id, "1.0", gvi)
       val usages = setOf(
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.MAIN),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.MAIN),
@@ -665,7 +668,7 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.ANDROID_TEST),
       )
       val declarations = setOf(
-        Declaration(id, "androidTestImplementation", id)
+        Declaration(id, "androidTestImplementation", gvi)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -676,12 +679,12 @@ internal class StandardTransformTest {
     }
 
     @Test fun `should be debugRuntimeOnly`() {
-      val coordinates = ModuleCoordinates("com.foo:bar", "1.0")
+      val coordinates = ModuleCoordinates("com.foo:bar", "1.0", gvi)
       val usages = usage(Bucket.RUNTIME_ONLY, "debug").intoSet()
       val declarations = Declaration(
         identifier = coordinates.identifier,
         configurationName = "debugImplementation",
-        targetCapability = coordinates.identifier
+        gradleVariantIdentification = gvi
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -694,14 +697,14 @@ internal class StandardTransformTest {
 
     @Test fun `hilt is unused and should be removed`() {
       val id = "com.google.dagger:hilt-compiler"
-      val coordinates = ModuleCoordinates(id, "2.40.5")
+      val coordinates = ModuleCoordinates(id, "2.40.5", gvi)
       val usages = usage(
         bucket = Bucket.NONE,
         variant = "debug",
         kind = SourceSetKind.MAIN,
         reasons = Reason.Unused.intoSet()
       ).intoSet()
-      val declarations = Declaration(id, "kapt", id).intoSet()
+      val declarations = Declaration(id, "kapt", gvi).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets, true).reduce(usages)
 
@@ -712,7 +715,7 @@ internal class StandardTransformTest {
 
     @Test fun `hilt should be declared on releaseAnnotationProcessor`() {
       val id = "com.google.dagger:hilt-compiler"
-      val coordinates = ModuleCoordinates(id, "2.40.5")
+      val coordinates = ModuleCoordinates(id, "2.40.5", gvi)
       val usages = setOf(
         usage(
           bucket = Bucket.NONE,
@@ -726,7 +729,7 @@ internal class StandardTransformTest {
           kind = SourceSetKind.MAIN
         )
       )
-      val declarations = Declaration(id, "kapt", id).intoSet()
+      val declarations = Declaration(id, "kapt", gvi).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets, false).reduce(usages)
 
@@ -744,7 +747,7 @@ internal class StandardTransformTest {
     )
     fun `dagger is used and should be added`(usesKapt: Boolean, toConfiguration: String) {
       val id = "com.google.dagger:dagger-compiler"
-      val coordinates = ModuleCoordinates(id, "2.40.5")
+      val coordinates = ModuleCoordinates(id, "2.40.5", gvi)
       val usages = usage(
         bucket = Bucket.ANNOTATION_PROCESSOR,
         variant = "debug",

--- a/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
+++ b/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
@@ -32,7 +32,8 @@ internal class StandardTransformTest {
       val usages = usage(Bucket.IMPL, "debug").intoSet()
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = "implementation"
+        configurationName = "implementation",
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -47,7 +48,8 @@ internal class StandardTransformTest {
       val oldConfiguration = Bucket.IMPL.value
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = oldConfiguration
+        configurationName = oldConfiguration,
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -68,7 +70,8 @@ internal class StandardTransformTest {
       val oldConfiguration = Bucket.API.value
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = oldConfiguration
+        configurationName = oldConfiguration,
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -88,7 +91,8 @@ internal class StandardTransformTest {
       val usages = usage(bucket, "debug").intoSet()
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = "debugImplementation"
+        configurationName = "debugImplementation",
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -103,7 +107,8 @@ internal class StandardTransformTest {
       val fromConfiguration = "api"
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = fromConfiguration
+        configurationName = fromConfiguration,
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -126,7 +131,8 @@ internal class StandardTransformTest {
       val usages = usage(Bucket.NONE, "debug").intoSet()
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = "runtimeOnly"
+        configurationName = "runtimeOnly",
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -139,7 +145,8 @@ internal class StandardTransformTest {
       val usages = usage(Bucket.NONE, "debug").intoSet()
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = "compileOnly"
+        configurationName = "compileOnly",
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -156,7 +163,8 @@ internal class StandardTransformTest {
       val usages = setOf(usage(bucket, "debug"), usage(bucket, "release"))
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = "implementation"
+        configurationName = "implementation",
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -194,7 +202,8 @@ internal class StandardTransformTest {
       val fromConfiguration = "implementation"
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = fromConfiguration
+        configurationName = fromConfiguration,
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -211,7 +220,8 @@ internal class StandardTransformTest {
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.API, "release"))
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = "implementation"
+        configurationName = "implementation",
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -229,7 +239,8 @@ internal class StandardTransformTest {
       val oldConfiguration = "kaptDebug"
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = oldConfiguration
+        configurationName = oldConfiguration,
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets, true).reduce(usages)
@@ -259,7 +270,8 @@ internal class StandardTransformTest {
       val fromConfiguration = "api"
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = fromConfiguration
+        configurationName = fromConfiguration,
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -276,7 +288,8 @@ internal class StandardTransformTest {
       val fromConfiguration = "implementation"
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = fromConfiguration
+        configurationName = fromConfiguration,
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -328,8 +341,8 @@ internal class StandardTransformTest {
       val coordinates = ModuleCoordinates(id, "1.0")
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.IMPL, "release"))
       val declarations = setOf(
-        Declaration(id, "debugImplementation"),
-        Declaration(id, "releaseApi")
+        Declaration(id, "debugImplementation", id),
+        Declaration(id, "releaseApi", id)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -345,8 +358,8 @@ internal class StandardTransformTest {
       val coordinates = ModuleCoordinates(id, "1.0")
       val usages = setOf(usage(Bucket.IMPL, "debug"), usage(Bucket.IMPL, "release"))
       val declarations = setOf(
-        Declaration(id, "implementation"),
-        Declaration(id, "releaseImplementation")
+        Declaration(id, "implementation", id),
+        Declaration(id, "releaseImplementation", id)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -361,8 +374,10 @@ internal class StandardTransformTest {
       val bucket = Bucket.ANNOTATION_PROCESSOR
       val usages = setOf(usage(bucket, "debug"), usage(bucket, "release"))
       val declarations = setOf(
-        Declaration(identifier = coordinates.identifier, configurationName = "kaptDebug"),
-        Declaration(identifier = coordinates.identifier, configurationName = "kaptRelease")
+        Declaration(identifier = coordinates.identifier, configurationName = "kaptDebug",
+          targetCapability = coordinates.identifier),
+        Declaration(identifier = coordinates.identifier, configurationName = "kaptRelease",
+          targetCapability = coordinates.identifier)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets, true).reduce(usages)
@@ -387,8 +402,8 @@ internal class StandardTransformTest {
       val coordinates = ModuleCoordinates(id, "1.0")
       val usages = setOf(usage(Bucket.API, "debug"), usage(Bucket.NONE, "release"))
       val declarations = setOf(
-        Declaration(id, "debugImplementation"),
-        Declaration(id, "releaseApi")
+        Declaration(id, "debugImplementation", id),
+        Declaration(id, "releaseApi", id)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -404,8 +419,8 @@ internal class StandardTransformTest {
       val coordinates = ModuleCoordinates(id, "1.0")
       val usages = setOf(usage(Bucket.NONE, "debug"), usage(Bucket.NONE, "release"))
       val declarations = setOf(
-        Declaration(id, "debugImplementation"),
-        Declaration(id, "releaseApi")
+        Declaration(id, "debugImplementation", id),
+        Declaration(id, "releaseApi", id)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -421,8 +436,8 @@ internal class StandardTransformTest {
       val coordinates = ModuleCoordinates(id, "1.0")
       val usages = setOf(usage(Bucket.API, "debug"), usage(Bucket.IMPL, "release"))
       val declarations = setOf(
-        Declaration(id, "debugImplementation"),
-        Declaration(id, "releaseApi")
+        Declaration(id, "debugImplementation", id),
+        Declaration(id, "releaseApi", id)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -441,8 +456,8 @@ internal class StandardTransformTest {
         usage(Bucket.API, "release")
       )
       val declarations = setOf(
-        Declaration(id, "implementation"),
-        Declaration(id, "releaseImplementation")
+        Declaration(id, "implementation", id),
+        Declaration(id, "releaseImplementation", id)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -469,7 +484,7 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.TEST),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
-      val declarations = Declaration(id, "implementation").intoSet()
+      val declarations = Declaration(id, "implementation", id).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
@@ -487,7 +502,7 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.ANDROID_TEST),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.ANDROID_TEST),
       )
-      val declarations = Declaration(id, "implementation").intoSet()
+      val declarations = Declaration(id, "implementation", id).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
@@ -507,9 +522,9 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.ANDROID_TEST),
       )
       val declarations = setOf(
-        Declaration(id, "implementation"),
-        Declaration(id, "testImplementation"),
-        Declaration(id, "androidTestImplementation"),
+        Declaration(id, "implementation", id),
+        Declaration(id, "testImplementation", id),
+        Declaration(id, "androidTestImplementation", id),
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -528,7 +543,7 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.TEST),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
-      val declarations = Declaration(id, "implementation").intoSet()
+      val declarations = Declaration(id, "implementation", id).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
@@ -547,7 +562,7 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "debug", kind = SourceSetKind.ANDROID_TEST),
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.ANDROID_TEST),
       )
-      val declarations = Declaration(id, "implementation").intoSet()
+      val declarations = Declaration(id, "implementation", id).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
 
@@ -567,8 +582,8 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
       val declarations = setOf(
-        Declaration(id, "implementation"),
-        Declaration(id, "testImplementation")
+        Declaration(id, "implementation", id),
+        Declaration(id, "testImplementation", id)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -588,8 +603,8 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
       val declarations = setOf(
-        Declaration(id, "implementation"),
-        Declaration(id, "testImplementation")
+        Declaration(id, "implementation", id),
+        Declaration(id, "testImplementation", id)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -609,8 +624,8 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.ANDROID_TEST),
       )
       val declarations = setOf(
-        Declaration(id, "implementation"),
-        Declaration(id, "androidTestImplementation")
+        Declaration(id, "implementation", id),
+        Declaration(id, "androidTestImplementation", id)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -630,7 +645,7 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.TEST),
       )
       val declarations = setOf(
-        Declaration(id, "testImplementation")
+        Declaration(id, "testImplementation", id)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -650,7 +665,7 @@ internal class StandardTransformTest {
         usage(bucket = Bucket.IMPL, variant = "release", kind = SourceSetKind.ANDROID_TEST),
       )
       val declarations = setOf(
-        Declaration(id, "androidTestImplementation")
+        Declaration(id, "androidTestImplementation", id)
       )
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -665,7 +680,8 @@ internal class StandardTransformTest {
       val usages = usage(Bucket.RUNTIME_ONLY, "debug").intoSet()
       val declarations = Declaration(
         identifier = coordinates.identifier,
-        configurationName = "debugImplementation"
+        configurationName = "debugImplementation",
+        targetCapability = coordinates.identifier
       ).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets).reduce(usages)
@@ -685,7 +701,7 @@ internal class StandardTransformTest {
         kind = SourceSetKind.MAIN,
         reasons = Reason.Unused.intoSet()
       ).intoSet()
-      val declarations = Declaration(id, "kapt").intoSet()
+      val declarations = Declaration(id, "kapt", id).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets, true).reduce(usages)
 
@@ -710,7 +726,7 @@ internal class StandardTransformTest {
           kind = SourceSetKind.MAIN
         )
       )
-      val declarations = Declaration(id, "kapt").intoSet()
+      val declarations = Declaration(id, "kapt", id).intoSet()
 
       val actual = StandardTransform(coordinates, declarations, supportedSourceSets, false).reduce(usages)
 

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/BuildScript.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/BuildScript.kt
@@ -6,6 +6,7 @@ class BuildScript(
   val repositories: List<Repository> = emptyList(),
   val android: AndroidBlock? = null,
   val sourceSets: List<String> = emptyList(),
+  val featureVariants: List<String> = emptyList(),
   val dependencies: List<Dependency> = emptyList(),
   val additions: String = ""
 ) {
@@ -16,6 +17,7 @@ class BuildScript(
     var repositories: List<Repository> = emptyList()
     var android: AndroidBlock? = null
     var sourceSets: List<String> = emptyList()
+    var featureVariants: List<String> = emptyList()
     var dependencies: List<Dependency> = emptyList()
     var additions: String = ""
 
@@ -26,6 +28,7 @@ class BuildScript(
         repositories,
         android,
         sourceSets,
+        featureVariants,
         dependencies,
         additions
       )
@@ -37,7 +40,11 @@ class BuildScript(
     val pluginsBlock = blockFrom("plugins", plugins)
     val reposBlock = blockFrom("repositories", repositories)
     val androidBlock = if (android != null) "${android}\n" else ""
-    val sourceSetsBlock = blockFrom("sourceSets", sourceSets)
+    val sourceSetsBlock = blockFrom("sourceSets", sourceSets + featureVariants)
+    // A feature variant is always a 'sourceSet' declaration AND a registerFeature
+    val featureVariantsBlock = blockFrom("java", featureVariants.map {
+      "registerFeature('$it') { usingSourceSet(sourceSets.$it) }"
+    })
     val dependenciesBlock = blockFrom("dependencies", dependencies)
 
     val add =
@@ -47,7 +54,7 @@ class BuildScript(
         ""
       }
 
-    return buildscriptBlock + pluginsBlock + reposBlock + androidBlock + sourceSetsBlock + dependenciesBlock + add
+    return buildscriptBlock + pluginsBlock + reposBlock + androidBlock + sourceSetsBlock + featureVariantsBlock + dependenciesBlock + add
   }
 
   companion object {

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
@@ -318,7 +318,7 @@ class Dependency @JvmOverloads constructor(
     }.let {
       when {
         // Note: 'testFixtures("...")' is a shorthand for 'requireCapabilities("...-test-fixtures")'
-        capability == "test-fixtures" -> "testFixtures($it)"
+        capability == "test-fixtures" -> it.replace(configuration, "$configuration(testFixtures") + ")"
         capability != null -> "$it { capabilities { requireCapabilities('$capability') } }"
         else -> it
       }

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
@@ -6,7 +6,7 @@ class Dependency @JvmOverloads constructor(
   val configuration: String,
   private val dependency: String,
   private val ext: String? = null,
-  val capability: String? = null
+  private val capability: String? = null
 ) {
 
   private val isProject = dependency.startsWith(":")

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
@@ -6,7 +6,7 @@ class Dependency @JvmOverloads constructor(
   val configuration: String,
   private val dependency: String,
   private val ext: String? = null,
-  private val capability: String? = null
+  val capability: String? = null
 ) {
 
   private val isProject = dependency.startsWith(":")
@@ -291,6 +291,21 @@ class Dependency @JvmOverloads constructor(
     @JvmStatic
     fun slf4jTests(configuration: String): Dependency {
       return Dependency(configuration, "org.slf4j:slf4j-api:2.0.3:tests")
+    }
+
+    @JvmStatic
+    fun androidJoda(configuration: String): Dependency {
+      return Dependency(configuration, "net.danlew:android.joda:2.10.7.2")
+    }
+
+    @JvmStatic
+    fun jodaTimeNoTzdbClassifier(configuration: String): Dependency {
+      return Dependency(configuration, "joda-time:joda-time:2.10.7:no-tzdb")
+    }
+
+    @JvmStatic
+    fun jodaTimeNoTzdbFeature(configuration: String): Dependency {
+      return Dependency(configuration, "joda-time:joda-time:2.10.7", capability = "joda-time:joda-time-no-tzdb")
     }
 
     @JvmStatic

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/Dependency.kt
@@ -289,6 +289,11 @@ class Dependency @JvmOverloads constructor(
     }
 
     @JvmStatic
+    fun slf4jTests(configuration: String): Dependency {
+      return Dependency(configuration, "org.slf4j:slf4j-api:2.0.3:tests")
+    }
+
+    @JvmStatic
     fun antlr(): Dependency {
       return Dependency("antlr", "org.antlr:antlr4:4.8-1")
     }

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/GradleProject.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/GradleProject.kt
@@ -38,7 +38,7 @@ class GradleProject(
     if (project == rootProject) {
       return rootDir.toPath()
     }
-    return rootDir.toPath().resolve("${project.includedBuild?.let { "$it/" }?:""}${project.name}/")
+    return rootDir.toPath().resolve("${project.includedBuild?.let { "$it/" }?:""}${project.name.replace(":", "/")}/")
   }
 
   /**
@@ -123,13 +123,14 @@ class GradleProject(
     }
 
     fun withSubproject(name: String, block: Subproject.Builder.() -> Unit) {
+      val normalizedName = name.removePrefix(":")
       // If a builder with this name already exists, returning it for building-upon
-      val builder = subprojectMap[name] ?: Subproject.Builder()
+      val builder = subprojectMap[normalizedName] ?: Subproject.Builder()
       builder.apply {
-        this.name = name
+        this.name = normalizedName
         block(this)
       }
-      subprojectMap[name] = builder
+      subprojectMap[normalizedName] = builder
     }
 
     fun withSubprojectInIncludedBuild(includedBuild: String, name: String, block: Subproject.Builder.() -> Unit) {

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/GradleProjectWriter.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/GradleProjectWriter.kt
@@ -86,7 +86,7 @@ class GradleProjectWriter(private val gradleProject: GradleProject) {
   ) {
 
     protected val projectPath: Path = rootPath.resolve(
-      "${subproject.includedBuild?.let { "$it/" } ?: ""}${subproject.name}"
+      "${subproject.includedBuild?.let { "$it/" } ?: ""}${subproject.name.replace(":", "/")}"
     ).also {
       it.toFile().mkdirs()
     }


### PR DESCRIPTION
The main change in this PR is that it adds something I called `GradleVariantIdentification` to all `Coordinates`.

- On the declaration side (consumer) The `GradleVariantIdentification` collects all [capabilities](https://docs.gradle.org/current/userguide/feature_variants.html#sec::consuming_feature_variants) and [attributes](https://docs.gradle.org/current/userguide/variant_attributes.html) that are defined on a dependency. Shortcut notations like `platform(...)` and `testFixtures(...)` also add these under the hood.
- On the resolved graph side (producer) the `GradleVariantIdentification` contains all the _capabilities_ of the selected node. The attributes are ignored here as we do not need them (see also comments in code).

With this, the analysis plugin now recognizes the fact that it is possible to have multiple nodes with the same `identifier` but different `GradleVariantIdentification` in the graph. This is the case when the capabilities differ. Because it is allowed to have multiple variants of one component in the graph as long as they have different capabilities. For example, there can be two `org.example:foo` nodes: one with capability `org.example:foo` and one with capability `org.example:foo-test-fixtures`.

The most critical impact on the implementation is IMO that there are several places throughout the code base that assume/assumed that Coordinates are comparable for different reasons. We need to be careful now, as different coordinates can mean the same. For example, if I don't declare any capability, the "main" capability is automatically used. The "Declaration Coordinates" then do not have a capability, but the "Resolved Graph Coordinates" will have the "main" capability. 

Therefore, several places needed to be touched, but I am confident wit the implementation now. I tried several things before I ended up with this solution (can still be seen in the commit history). What we have now feels most sound and also future-proof. We now collect all information we need to identify a component+variant and then can use this later during advice computation to make decisions. This should cover all "Feature Variant" standard cases. But if we need more information in the future, we can extend what we put into `GradleVariantIdentification`. (For example, it could also contain 'classifier' information – #342 – if we could somehow get this for 'both sides'.)

I chose the name `GradleVariantIdentification` as the _main_ thing, because _capability_ already has a different meaning in the context of this plugin. But I am happy to rename that if there are better ideas. 😄 

The PR resolves and adds test coverage for:
- Resolves #298 🎉 
- Fixes #836 
- Gives a alternative solution for #859 (will comment there)
- Fixes #841 in so far that there are no more false positives (we still won't be able to suggest classifiers correctly, but that is #342) will comment there

