### PR TITLE
Bump tested AGP versions.

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -22,10 +22,11 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_4_2 = AgpVersion.version('4.2.2')
   protected static final AGP_7_0 = AgpVersion.version('7.0.4')
   protected static final AGP_7_1 = AgpVersion.version('7.1.3')
-  protected static final AGP_7_2 = AgpVersion.version('7.2.1')
+  protected static final AGP_7_2 = AgpVersion.version('7.2.2')
   protected static final AGP_7_3 = AgpVersion.version('7.3.1')
-  protected static final AGP_7_4 = AgpVersion.version('7.4.0')
-  protected static final AGP_8_0 = AgpVersion.version('8.0.0-alpha11')
+  protected static final AGP_7_4 = AgpVersion.version('7.4.1')
+  protected static final AGP_8_0 = AgpVersion.version('8.0.0-beta01')
+  protected static final AGP_8_1 = AgpVersion.version('8.1.0-alpha02')
 
   protected static final SUPPORTED_AGP_VERSIONS = [
     AGP_4_2,
@@ -35,6 +36,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
 //    AGP_7_3,
     AGP_7_4,
 //    AGP_8_0,
+//    AGP_8_1,
   ]
 
   protected static List<AgpVersion> agpVersions(AgpVersion minAgpVersion = AgpVersion.AGP_MIN) {

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -10,7 +10,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
   companion object {
 
     @JvmStatic val AGP_MIN = version("4.2.2")
-    @JvmStatic val AGP_MAX = version("7.4.0")
+    @JvmStatic val AGP_MAX = version("7.4.1")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)


### PR DESCRIPTION
Still not testing against 8.0+.

See also https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/pull/802.