### PR TITLE
Bump AGP minor 7.4.1 to 7.4.2

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -24,7 +24,7 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_7_1 = AgpVersion.version('7.1.3')
   protected static final AGP_7_2 = AgpVersion.version('7.2.2')
   protected static final AGP_7_3 = AgpVersion.version('7.3.1')
-  protected static final AGP_7_4 = AgpVersion.version('7.4.1')
+  protected static final AGP_7_4 = AgpVersion.version('7.4.2')
   protected static final AGP_8_0 = AgpVersion.version('8.0.0-beta01')
   protected static final AGP_8_1 = AgpVersion.version('8.1.0-alpha02')
 

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -10,7 +10,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
   companion object {
 
     @JvmStatic val AGP_MIN = version("4.2.2")
-    @JvmStatic val AGP_MAX = version("7.4.1")
+    @JvmStatic val AGP_MAX = version("7.4.2")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)


### PR DESCRIPTION
```
> Configure project :
The Dependency Analysis plugin is only known to work with versions of AGP between 4.2.2 and 7.4.1. You are using 7.4.2. Proceed at your own risk.
```
