### PR TITLE
Allow ignoring the incompatibility warning.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -2,6 +2,7 @@
 
 package com.autonomousapps
 
+import com.autonomousapps.Flags.androidIgnoredVersion
 import com.autonomousapps.internal.android.AgpVersion
 import com.autonomousapps.subplugin.ProjectPlugin
 import com.autonomousapps.subplugin.RootPlugin
@@ -39,11 +40,12 @@ class DependencyAnalysisPlugin : Plugin<Project> {
     }
 
     logger.debug("AgpVersion = $current")
-    if (!current.isSupported() && this == rootProject) {
+    if (!current.isSupported() && this == rootProject && androidIgnoredVersion() != current.version) {
       logger.warn(
         "The Dependency Analysis plugin is only known to work with versions of AGP between " +
-          "${AgpVersion.AGP_MIN.version} and ${AgpVersion.AGP_MAX.version}. You are using ${current.version}. " +
-          "Proceed at your own risk."
+          "${AgpVersion.AGP_MIN.version} and ${AgpVersion.AGP_MAX.version}. " +
+          "You are using ${current.version}. Proceed at your own risk. \n" +
+          "If you would like to suppress this message, add ${Flags.FLAG_ANDROID_IGNORED_PLUGIN_VERSION}=${current.version} to you gradle.properties file."
       )
     }
   }

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -40,7 +40,7 @@ class DependencyAnalysisPlugin : Plugin<Project> {
     }
 
     logger.debug("AgpVersion = $current")
-    if (!current.isSupported() && this == rootProject && androidIgnoredVersion() != current.version) {
+    if (!current.isSupported() && this == rootProject && !current.version.startsWith(androidIgnoredVersion())) {
       logger.warn(
         "The Dependency Analysis plugin is only known to work with versions of AGP between " +
           "${AgpVersion.AGP_MIN.version} and ${AgpVersion.AGP_MAX.version}. " +

--- a/src/main/kotlin/com/autonomousapps/Flags.kt
+++ b/src/main/kotlin/com/autonomousapps/Flags.kt
@@ -28,10 +28,10 @@ object Flags {
   internal fun Project.shouldAutoApply(): Boolean = getGradleOrSysProp(FLAG_AUTO_APPLY, true)
   internal fun Project.printBuildHealth(): Boolean = getGradlePropForConfiguration(FLAG_PRINT_BUILD_HEALTH, false)
   internal fun Project.androidIgnoredVariants(): List<String> =
-    getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_VARIANTS, "").split(",")
+    getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_VARIANTS, "")!!.split(",")
 
   internal fun Project.projectPathRegex(): Regex =
-    getGradlePropForConfiguration(FLAG_PROJECT_INCLUDES, ".*").toRegex()
+    getGradlePropForConfiguration(FLAG_PROJECT_INCLUDES, ".*")!!.toRegex()
 
   internal fun Project.cacheSize(default: Long): Long {
     return providers.systemProperty(FLAG_MAX_CACHE_SIZE)
@@ -52,13 +52,13 @@ object Flags {
     return byGradle && bySys
   }
 
-  private fun Project.getGradlePropForConfiguration(name: String, default: String): String =
+  private fun Project.getGradlePropForConfiguration(name: String, default: String?): String? =
     providers.gradleProperty(name)
       .forUseAtConfigurationTime()
       .getOrElse(default)
 
   private fun Project.getGradlePropForConfiguration(name: String, default: Boolean): Boolean =
-    getGradlePropForConfiguration(name, default.toString()).toBoolean()
+    getGradlePropForConfiguration(name, default.toString())!!.toBoolean()
 
   private fun Project.getSysPropForConfiguration(name: String, default: Boolean): Boolean =
     providers.systemProperty(name)

--- a/src/main/kotlin/com/autonomousapps/Flags.kt
+++ b/src/main/kotlin/com/autonomousapps/Flags.kt
@@ -24,10 +24,11 @@ object Flags {
    */
   private const val FLAG_ANDROID_IGNORED_VARIANTS = "dependency.analysis.android.ignored.variants"
 
-  internal fun Project.shouldAnalyzeTests() = getGradleOrSysProp(FLAG_TEST_ANALYSIS, true)
-  internal fun Project.shouldAutoApply() = getGradleOrSysProp(FLAG_AUTO_APPLY, true)
-  internal fun Project.printBuildHealth() = getGradlePropForConfiguration(FLAG_PRINT_BUILD_HEALTH, false)
-  internal fun Project.androidIgnoredVariants() = getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_VARIANTS, "").split(",")
+  internal fun Project.shouldAnalyzeTests(): Boolean = getGradleOrSysProp(FLAG_TEST_ANALYSIS, true)
+  internal fun Project.shouldAutoApply(): Boolean = getGradleOrSysProp(FLAG_AUTO_APPLY, true)
+  internal fun Project.printBuildHealth(): Boolean = getGradlePropForConfiguration(FLAG_PRINT_BUILD_HEALTH, false)
+  internal fun Project.androidIgnoredVariants(): List<String> =
+    getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_VARIANTS, "").split(",")
 
   internal fun Project.projectPathRegex(): Regex =
     getGradlePropForConfiguration(FLAG_PROJECT_INCLUDES, ".*").toRegex()
@@ -59,7 +60,7 @@ object Flags {
   private fun Project.getGradlePropForConfiguration(name: String, default: Boolean): Boolean =
     getGradlePropForConfiguration(name, default.toString()).toBoolean()
 
-  private fun Project.getSysPropForConfiguration(name: String, default: Boolean) =
+  private fun Project.getSysPropForConfiguration(name: String, default: Boolean): Boolean =
     providers.systemProperty(name)
       .forUseAtConfigurationTime()
       .getOrElse(default.toString())

--- a/src/main/kotlin/com/autonomousapps/Flags.kt
+++ b/src/main/kotlin/com/autonomousapps/Flags.kt
@@ -34,6 +34,9 @@ object Flags {
    * dependency.analysis.android.ignored.version=7.4.2
    * ```
    * will silence the warning.
+   * 
+   * If dynamic versions are used, or the version is updated frequently, prefix matching is also supported,
+   * so `8.0.0-beta` will ignore all `8.0.0-beta01`, `8.0.0-beta02`, etc. versions.
    */
   internal const val FLAG_ANDROID_IGNORED_PLUGIN_VERSION = "dependency.analysis.android.ignored.version"
 
@@ -43,7 +46,7 @@ object Flags {
   internal fun Project.androidIgnoredVariants(): List<String> =
     getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_VARIANTS, "").split(",")
   internal fun Project.androidIgnoredVersion(): String =
-    getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_PLUGIN_VERSION, "")
+    getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_PLUGIN_VERSION, "nothing")
 
   internal fun Project.projectPathRegex(): Regex =
     getGradlePropForConfiguration(FLAG_PROJECT_INCLUDES, ".*").toRegex()

--- a/src/main/kotlin/com/autonomousapps/Flags.kt
+++ b/src/main/kotlin/com/autonomousapps/Flags.kt
@@ -41,12 +41,12 @@ object Flags {
   internal fun Project.shouldAutoApply(): Boolean = getGradleOrSysProp(FLAG_AUTO_APPLY, true)
   internal fun Project.printBuildHealth(): Boolean = getGradlePropForConfiguration(FLAG_PRINT_BUILD_HEALTH, false)
   internal fun Project.androidIgnoredVariants(): List<String> =
-    getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_VARIANTS, "")!!.split(",")
-  internal fun Project.androidIgnoredVersion(): String? =
-    getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_PLUGIN_VERSION, null)
+    getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_VARIANTS, "").split(",")
+  internal fun Project.androidIgnoredVersion(): String =
+    getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_PLUGIN_VERSION, "")
 
   internal fun Project.projectPathRegex(): Regex =
-    getGradlePropForConfiguration(FLAG_PROJECT_INCLUDES, ".*")!!.toRegex()
+    getGradlePropForConfiguration(FLAG_PROJECT_INCLUDES, ".*").toRegex()
 
   internal fun Project.cacheSize(default: Long): Long {
     return providers.systemProperty(FLAG_MAX_CACHE_SIZE)
@@ -67,13 +67,13 @@ object Flags {
     return byGradle && bySys
   }
 
-  private fun Project.getGradlePropForConfiguration(name: String, default: String?): String? =
+  private fun Project.getGradlePropForConfiguration(name: String, default: String): String =
     providers.gradleProperty(name)
       .forUseAtConfigurationTime()
       .getOrElse(default)
 
   private fun Project.getGradlePropForConfiguration(name: String, default: Boolean): Boolean =
-    getGradlePropForConfiguration(name, default.toString())!!.toBoolean()
+    getGradlePropForConfiguration(name, default.toString()).toBoolean()
 
   private fun Project.getSysPropForConfiguration(name: String, default: Boolean): Boolean =
     providers.systemProperty(name)

--- a/src/main/kotlin/com/autonomousapps/Flags.kt
+++ b/src/main/kotlin/com/autonomousapps/Flags.kt
@@ -24,11 +24,26 @@ object Flags {
    */
   private const val FLAG_ANDROID_IGNORED_VARIANTS = "dependency.analysis.android.ignored.variants"
 
+  /**
+   * Android Gradle Plugin version to ignore, that is to say:
+   * it's unsupported, but the user opts in to accepting the risk of incompatibility.
+   *
+   * Example: [com.autonomousapps.internal.android.AgpVersion.AGP_MAX] is `7.4.1`,
+   * but user is running in `7.4.2`. At this point
+   * ```properties
+   * dependency.analysis.android.ignored.version=7.4.2
+   * ```
+   * will silence the warning.
+   */
+  internal const val FLAG_ANDROID_IGNORED_PLUGIN_VERSION = "dependency.analysis.android.ignored.version"
+
   internal fun Project.shouldAnalyzeTests(): Boolean = getGradleOrSysProp(FLAG_TEST_ANALYSIS, true)
   internal fun Project.shouldAutoApply(): Boolean = getGradleOrSysProp(FLAG_AUTO_APPLY, true)
   internal fun Project.printBuildHealth(): Boolean = getGradlePropForConfiguration(FLAG_PRINT_BUILD_HEALTH, false)
   internal fun Project.androidIgnoredVariants(): List<String> =
     getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_VARIANTS, "")!!.split(",")
+  internal fun Project.androidIgnoredVersion(): String? =
+    getGradlePropForConfiguration(FLAG_ANDROID_IGNORED_PLUGIN_VERSION, null)
 
   internal fun Project.projectPathRegex(): Regex =
     getGradlePropForConfiguration(FLAG_PROJECT_INCLUDES, ".*")!!.toRegex()

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -18,7 +18,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
     private fun agpVersion(): String = Version.ANDROID_GRADLE_PLUGIN_VERSION
   }
 
-  fun isSupported(): Boolean = current() in AGP_MIN..AGP_MAX
+  fun isSupported(): Boolean = this in AGP_MIN..AGP_MAX
 
   override fun compareTo(other: AgpVersion): Int {
     return if (versionNumber.qualifier?.isNotEmpty() == true && other.versionNumber.qualifier?.isNotEmpty() == true) {

--- a/src/test/groovy/com/autonomousapps/internal/android/AgpVersionSpec.groovy
+++ b/src/test/groovy/com/autonomousapps/internal/android/AgpVersionSpec.groovy
@@ -1,0 +1,28 @@
+package com.autonomousapps.internal.android
+
+import spock.lang.Specification
+
+final class AgpVersionSpec extends Specification {
+
+  def "isSupported #expectedSupported for AGP #agpVersion"() {
+    given:
+    def version = AgpVersion.version(agpVersion)
+
+    expect:
+    version.isSupported() == expectedSupported
+
+    where:
+    agpVersion      | expectedSupported
+    '4.2.0-alpha12' | false
+    '4.2.0-beta04'  | false
+    '4.2.1'         | false
+    '4.2.2'         | true
+    '7.0.0'         | true
+    '7.1.3'         | true
+    '7.3.2'         | true
+    '7.4.1'         | true
+    '7.4.2'         | false
+    '8.0.0-beta01'  | false
+    '8.1.0-alpha06' | false
+  }
+}


### PR DESCRIPTION
```
> Configure project :
The Dependency Analysis plugin is only known to work with versions of AGP between 4.2.2 and 7.4.1. You are using 7.4.2. Proceed at your own risk.
If you would like to suppress this message, add dependency.analysis.android.ignored.version=7.4.2 to you gradle.properties file.
```
and if you add
```properties
dependency.analysis.android.ignored.version=7.4.2
```
then it prints nothing. ☮
