### PR TITLE
Make 'ignoreSourceSet(...)' DSL construct consistent with others

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/TestFixturesTestProject.groovy
@@ -31,7 +31,7 @@ final class TestFixturesTestProject extends AbstractProject {
             dependencyAnalysis {
               issues {
                 all {
-                  ignoreSourceSet("testFixtures")
+                  ignoreSourceSet("unknown", "testFixtures")
                   ignoreSourceSet("unknown") // no effect
                 }
               }

--- a/src/main/kotlin/com/autonomousapps/extension/IssueHandler.kt
+++ b/src/main/kotlin/com/autonomousapps/extension/IssueHandler.kt
@@ -9,7 +9,6 @@ import org.gradle.api.Named
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
-import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.setProperty
 import java.io.Serializable
@@ -238,15 +237,15 @@ open class ProjectIssueHandler @Inject constructor(
     it.convention(false)
   }
 
-  internal val ignoreSourceSets = objects.listProperty<String>()
+  internal val ignoreSourceSets = objects.setProperty<String>()
 
   fun ignoreKtx(ignore: Boolean) {
     ignoreKtx.set(ignore)
     ignoreKtx.disallowChanges()
   }
 
-  fun ignoreSourceSet(sourceSetName: String) {
-    ignoreSourceSets.add(sourceSetName)
+  fun ignoreSourceSet(vararg ignore: String) {
+    ignoreSourceSets.addAll(ignore.toSet())
   }
 
   fun onAny(action: Action<Issue>) {


### PR DESCRIPTION
...for example 'exclude(...)'.
It is now 'vararg' and fills a Set (instead of a List).

Follow up to: https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/pull/882#issuecomment-1516575385