### PR TITLE
Add test to showcase included build annotation processor issue

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/IncludedBuildSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/IncludedBuildSpec.groovy
@@ -72,4 +72,19 @@ final class IncludedBuildSpec extends AbstractJvmSpec {
     where:
     gradleVersion << INCLUDED_BUILD_SUPPORT_GRADLE_VERSIONS
   }
+
+  def "can handle annotation processors from cache in subsequent builds"() {
+    given:
+    def project = new IncludedBuildWithSubprojectsProject(true)
+    gradleProject = project.gradleProject
+
+    when: 'build does not fail'
+    build(gradleVersion, gradleProject.rootDir, ':buildHealth')
+
+    then: 'and there is no advice'
+    assertThat(project.actualIncludedBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << INCLUDED_BUILD_SUPPORT_GRADLE_VERSIONS
+  }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithSubprojectsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithSubprojectsProject.groovy
@@ -1,6 +1,7 @@
 package com.autonomousapps.jvm.projects
 
 import com.autonomousapps.AbstractProject
+import com.autonomousapps.fixtures.JvmAutoServiceProject
 import com.autonomousapps.kit.*
 import com.autonomousapps.model.Advice
 import com.autonomousapps.model.ProjectAdvice
@@ -24,6 +25,8 @@ final class IncludedBuildWithSubprojectsProject extends AbstractProject {
       }
       root.settingsScript.additions = """\
         includeBuild 'second-build'
+        includeBuild 'processor-build'
+        include 'user-of-processor'
       """.stripIndent()
       root.sources = [
         new Source(
@@ -85,6 +88,93 @@ final class IncludedBuildWithSubprojectsProject extends AbstractProject {
         )
       ]
     }
+    builder.withSubprojectInIncludedBuild('processor-build', 'sub-processor1') { secondSub ->
+      secondSub.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.dependencies = [
+          new Dependency('annotationProcessor', 'com.google.auto.service:auto-service:1.0-rc6'),
+          new Dependency('compileOnly', 'com.google.auto.service:auto-service-annotations:1.0-rc6'),
+        ]
+        bs.repositories = [
+          Repository.GOOGLE,
+          Repository.MAVEN_CENTRAL
+        ]
+        bs.additions = """\
+          group = 'my.custom.processor'
+        """.stripIndent()
+      }
+      secondSub.sources = [
+              new Source(
+                      SourceType.JAVA, 'Field', 'com/example/included/processor1',
+                      """\
+        package com.example.included.processor1;
+        
+        import java.lang.annotation.ElementType;
+        import java.lang.annotation.Retention;
+        import java.lang.annotation.RetentionPolicy;
+        import java.lang.annotation.Target;
+
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target({ElementType.FIELD})
+        public @interface Field {
+        }
+          """.stripIndent()
+              ),
+              new Source(
+                      SourceType.JAVA, 'Processor1', 'com/example/included/processor1',
+                      """\
+        package com.example.included.processor1;
+        
+        import java.util.HashSet;
+        import java.util.List;
+        import java.util.Set;
+        import javax.annotation.processing.AbstractProcessor;
+        import javax.annotation.processing.Processor;
+        import javax.annotation.processing.RoundEnvironment;
+        import javax.lang.model.element.TypeElement;
+        
+        import com.google.auto.service.AutoService;
+
+        @AutoService(Processor.class)
+        public class Processor1 extends AbstractProcessor {
+          @Override
+          public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment env) {
+            return true;
+          }
+
+          @Override
+          public Set<String> getSupportedAnnotationTypes() {
+            return new HashSet<>(List.of(Field.class.getName()));
+          }
+        }
+          """.stripIndent()
+              )
+      ]
+    }
+    builder.withSubproject("user-of-processor", userOfProcessor -> {
+      userOfProcessor.withBuildScript {bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.dependencies = [
+          new Dependency('implementation', 'my.custom.processor:sub-processor1'),
+          new Dependency('annotationProcessor', 'my.custom.processor:sub-processor1'),
+        ]
+      }
+
+      userOfProcessor.sources = [
+              new Source(
+                      SourceType.JAVA, 'UserOfProcessor', 'com/example/user/of/processor1',
+                      """\
+        package com.example.user.of.processor1;
+        
+        import com.example.included.processor1.Field;
+
+        public class UserOfProcessor {
+          public @Field int field;
+        }
+          """.stripIndent()
+              )
+      ]
+    })
 
     def project = builder.build()
     project.writer().write()
@@ -110,5 +200,9 @@ final class IncludedBuildWithSubprojectsProject extends AbstractProject {
   final Set<ProjectAdvice> expectedIncludedBuildHealth = [
     projectAdviceForDependencies(':second-sub1', [] as Set<Advice>),
     projectAdviceForDependencies(':second-sub2', [] as Set<Advice>)
+  ]
+
+  final Set<ProjectAdvice> expectedUserOfProcessorBuildHealth = [
+    projectAdviceForDependencies(':user-of-processor', [] as Set<Advice>)
   ]
 }


### PR DESCRIPTION
We are seeing issues with using annotation processor results from included builds when retrieving the information from the cache. I mirrored our setup in this test, by introducing two new projects:
1. A new included build called `processor-build` that defines an annotation processor and uses the Google AutoService to define it
2. A new submodule in this project, which uses the processor to process one of its fields

The problem is the following (although I couldn't fully define that in the test): when we run `:projectHealth` on this, it stores the information in our build cache. When we then attempt to retrieve it in a subsequent run, the `:projectHealth` task fails with the following error:

```
> Transitively used dependencies that should be declared directly as indicated:
    annotationProcessor project('my.custom.processor:sub-processor1')
```

It seems like the information retrieved from the cache is incomplete, where it somehow deduces that the annotation processor is unused. Again, if we run it without the cache, it is all fine. Only when the `:user-of-processor:findDeclaredProcsMain` is `FROM-CACHE`, it fails.

This only happens when using included builds. If the subprojects are part of the same build, we don't observe any caching problems.

Next to that, we also noticed that the `usages-annotation-processors.json` includes fully qualified project references. However, the cache key for this task does not take into account the fully qualified names of dependencies. In the sense that: when we run the task in 1 build (where the `rootProject.group` is set to `Group1`) and we run it again in another build where the group is set to `Group2`, the task would also fail, as it doesn't match the group.

We fixed this issue by aligning the group names, but I think that's a problem that can be fixed in the plugin as well. To do so, we can mark the `rootProject.group` as `inputs.property()` to these tasks. (Note that the `rootProject.group` is of the dependency, not the project that defines the plugin task, which makes it slightly more complicated).

I created this PR as a request of @jjohannes who wanted to see the example. I am not sure Jendrik if I did this correctly and if these test expectations are correct. I had trouble trying to formulate what the advice should be, as the test is now failing with an assertion error I don't understand. Hopefully it is clear enough with this setup.