### PR TITLE
Consistently use IncludedBuildCoordinates to refer to other projects

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
@@ -49,8 +49,8 @@ final class AdviceHelper {
     return projectCoordinates(dep.identifier)
   }
 
-  static ProjectCoordinates projectCoordinates(String projectPath, String capability = null, String buildName = ':') {
-    return new ProjectCoordinates(projectPath, defaultGVI(capability), buildName)
+  static ProjectCoordinates projectCoordinates(String projectPath, String capability = null, String buildPath = ':') {
+    return new ProjectCoordinates(projectPath, defaultGVI(capability), buildPath)
   }
 
   static Coordinates includedBuildCoordinates(String identifier, ProjectCoordinates resolvedProject, String capability = null) {

--- a/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AdviceHelper.groovy
@@ -49,8 +49,8 @@ final class AdviceHelper {
     return projectCoordinates(dep.identifier)
   }
 
-  static ProjectCoordinates projectCoordinates(String projectPath, String capability = null) {
-    return new ProjectCoordinates(projectPath, defaultGVI(capability))
+  static ProjectCoordinates projectCoordinates(String projectPath, String capability = null, String buildName = ':') {
+    return new ProjectCoordinates(projectPath, defaultGVI(capability), buildName)
   }
 
   static Coordinates includedBuildCoordinates(String identifier, ProjectCoordinates resolvedProject, String capability = null) {

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/IncludedBuildSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/IncludedBuildSpec.groovy
@@ -123,7 +123,7 @@ final class IncludedBuildSpec extends AbstractJvmSpec {
     then:
     assertThat(project.actualIncludedBuildHealth()).containsExactlyElementsIn(project.expectedIncludedBuildHealth('second-build'))
 
-    when: 'The second build is the root - the "buildName" attribute of ProjectCoordinates changes'
+    when: 'The second build is the root - the "buildPath" attribute of ProjectCoordinates changes'
     build(gradleVersion, new File(gradleProject.rootDir, 'second-build'), ':buildHealth')
 
     then:

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildProject.groovy
@@ -21,6 +21,10 @@ final class IncludedBuildProject extends AbstractProject {
       root.withBuildScript { bs ->
         bs.plugins.add(Plugin.javaLibraryPlugin)
         bs.dependencies = [new Dependency('implementation', 'second:second-build:1.0')]
+        bs.additions = """\
+          group = 'first'
+          version = '1.0'
+        """.stripIndent()
       }
       root.settingsScript.additions = """\
         includeBuild 'second-build'
@@ -38,12 +42,16 @@ final class IncludedBuildProject extends AbstractProject {
     }
     builder.withIncludedBuild('second-build') { second ->
       second.withBuildScript { bs ->
-        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.plugins.add(Plugin.javaLibraryPlugin)
+        bs.dependencies = [new Dependency('testImplementation', 'first:the-project:1.0')]
         bs.additions = """\
           group = 'second'
           version = '1.0'
         """.stripIndent()
       }
+      second.settingsScript.additions = """\
+        includeBuild('..') { name = 'the-project' }
+      """.stripIndent()
       second.sources = [
         new Source(
           SourceType.JAVA, 'Second', 'com/example/included',
@@ -65,12 +73,27 @@ final class IncludedBuildProject extends AbstractProject {
     return actualProjectAdvice(gradleProject)
   }
 
-  final Set<ProjectAdvice> expectedBuildHealth = [
+  Set<ProjectAdvice> actualBuildHealthOfSecondBuild() {
+    def included = gradleProject.includedBuilds[0]
+    def project = new GradleProject(new java.io.File(gradleProject.rootDir, 'second-build'), null, included, [], [])
+    return actualProjectAdvice(project)
+  }
+
+  static Set<ProjectAdvice> expectedBuildHealth(String buildNameInAdvice) {[
     projectAdviceForDependencies(':', [
       Advice.ofRemove(
-        includedBuildCoordinates('second:second-build', projectCoordinates(':', 'second:second-build')),
+        includedBuildCoordinates('second:second-build', projectCoordinates(':', 'second:second-build', buildNameInAdvice)),
         'implementation'
       )
     ] as Set<Advice>)
-  ]
+  ]}
+
+  static Set<ProjectAdvice> expectedBuildHealthOfIncludedBuild(String buildNameInAdvice) {[
+    projectAdviceForDependencies(':', [
+      Advice.ofRemove(
+        includedBuildCoordinates('first:the-project', projectCoordinates(':', 'first:the-project', buildNameInAdvice)),
+        'testImplementation'
+      )
+    ] as Set<Advice>)
+  ]}
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildProject.groovy
@@ -79,19 +79,19 @@ final class IncludedBuildProject extends AbstractProject {
     return actualProjectAdvice(project)
   }
 
-  static Set<ProjectAdvice> expectedBuildHealth(String buildNameInAdvice) {[
+  static Set<ProjectAdvice> expectedBuildHealth(String buildPathInAdvice) {[
     projectAdviceForDependencies(':', [
       Advice.ofRemove(
-        includedBuildCoordinates('second:second-build', projectCoordinates(':', 'second:second-build', buildNameInAdvice)),
+        includedBuildCoordinates('second:second-build', projectCoordinates(':', 'second:second-build', buildPathInAdvice)),
         'implementation'
       )
     ] as Set<Advice>)
   ]}
 
-  static Set<ProjectAdvice> expectedBuildHealthOfIncludedBuild(String buildNameInAdvice) {[
+  static Set<ProjectAdvice> expectedBuildHealthOfIncludedBuild(String buildPathInAdvice) {[
     projectAdviceForDependencies(':', [
       Advice.ofRemove(
-        includedBuildCoordinates('first:the-project', projectCoordinates(':', 'first:the-project', buildNameInAdvice)),
+        includedBuildCoordinates('first:the-project', projectCoordinates(':', 'first:the-project', buildPathInAdvice)),
         'testImplementation'
       )
     ] as Set<Advice>)

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithAnnotationProcessorProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithAnnotationProcessorProject.groovy
@@ -1,0 +1,126 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.*
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+
+final class IncludedBuildWithAnnotationProcessorProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  IncludedBuildWithAnnotationProcessorProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withRootProject { root ->
+      root.settingsScript.additions = """\
+        includeBuild 'processor-build'
+        include 'user-of-processor'
+      """.stripIndent()
+    }
+    builder.withSubprojectInIncludedBuild('processor-build', 'sub-processor1') { secondSub ->
+      secondSub.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.dependencies = [
+          new Dependency('annotationProcessor', 'com.google.auto.service:auto-service:1.0-rc6'),
+          new Dependency('compileOnly', 'com.google.auto.service:auto-service-annotations:1.0-rc6'),
+        ]
+        bs.repositories = [
+          Repository.GOOGLE,
+          Repository.MAVEN_CENTRAL
+        ]
+        bs.additions = """\
+          group = 'my.custom.processor'
+        """.stripIndent()
+      }
+      secondSub.sources = [
+        new Source(
+          SourceType.JAVA, 'Field', 'com/example/included/processor1',
+          """\
+        package com.example.included.processor1;
+        
+        import java.lang.annotation.ElementType;
+        import java.lang.annotation.Retention;
+        import java.lang.annotation.RetentionPolicy;
+        import java.lang.annotation.Target;
+
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target({ElementType.FIELD})
+        public @interface Field {
+        }
+          """.stripIndent()
+        ),
+        new Source(
+          SourceType.JAVA, 'Processor1', 'com/example/included/processor1',
+          """\
+        package com.example.included.processor1;
+        
+        import java.util.HashSet;
+        import java.util.List;
+        import java.util.Set;
+        import javax.annotation.processing.AbstractProcessor;
+        import javax.annotation.processing.Processor;
+        import javax.annotation.processing.RoundEnvironment;
+        import javax.lang.model.element.TypeElement;
+        
+        import com.google.auto.service.AutoService;
+
+        @AutoService(Processor.class)
+        public class Processor1 extends AbstractProcessor {
+          @Override
+          public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment env) {
+            return true;
+          }
+
+          @Override
+          public Set<String> getSupportedAnnotationTypes() {
+            return new HashSet<>(List.of(Field.class.getName()));
+          }
+        }
+          """.stripIndent()
+        )
+      ]
+    }
+    builder.withSubproject("user-of-processor", userOfProcessor -> {
+      userOfProcessor.withBuildScript {bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.dependencies = [
+          new Dependency('api', 'my.custom.processor:sub-processor1'),
+          new Dependency('annotationProcessor', 'my.custom.processor:sub-processor1'),
+        ]
+      }
+
+      userOfProcessor.sources = [
+        new Source(
+          SourceType.JAVA, 'UserOfProcessor', 'com/example/user/of/processor1',
+          """\
+        package com.example.user.of.processor1;
+        
+        import com.example.included.processor1.Field;
+
+        public class UserOfProcessor {
+          public @Field int field;
+        }
+          """.stripIndent()
+        )
+      ]
+    })
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':user-of-processor', [] as Set<Advice>)
+  ]
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithSubprojectsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithSubprojectsProject.groovy
@@ -109,11 +109,11 @@ final class IncludedBuildWithSubprojectsProject extends AbstractProject {
     return actualProjectAdvice(project)
   }
 
-  final Set<ProjectAdvice> expectedIncludedBuildHealth(String buildNameInAdvice) {[
+  final Set<ProjectAdvice> expectedIncludedBuildHealth(String buildPathInAdvice) {[
     projectAdviceForDependencies(':second-sub1', [
       useProjectDependencyWherePossible
-        ? Advice.ofChange(projectCoordinates(':second-sub2', null, buildNameInAdvice), 'api', 'implementation')
-        : Advice.ofChange(includedBuildCoordinates('second:second-sub2', projectCoordinates(':second-sub2', 'second:second-sub2', buildNameInAdvice)), 'api', 'implementation')
+        ? Advice.ofChange(projectCoordinates(':second-sub2', null, buildPathInAdvice), 'api', 'implementation')
+        : Advice.ofChange(includedBuildCoordinates('second:second-sub2', projectCoordinates(':second-sub2', 'second:second-sub2', buildPathInAdvice)), 'api', 'implementation')
     ] as Set<Advice>),
     projectAdviceForDependencies(':second-sub2', [] as Set<Advice>)
   ]}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithSubprojectsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithSubprojectsProject.groovy
@@ -10,12 +10,14 @@ import static com.autonomousapps.AdviceHelper.*
 final class IncludedBuildWithSubprojectsProject extends AbstractProject {
 
   final GradleProject gradleProject
+  final boolean useProjectDependencyWherePossible
 
   IncludedBuildWithSubprojectsProject(boolean useProjectDependencyWherePossible = false) {
-    this.gradleProject = build(useProjectDependencyWherePossible)
+    this.useProjectDependencyWherePossible = useProjectDependencyWherePossible
+    this.gradleProject = build()
   }
 
-  private GradleProject build(boolean useProjectDependencyWherePossible) {
+  private GradleProject build() {
     def builder = newGradleProjectBuilder()
     builder.withRootProject { root ->
       root.withBuildScript { bs ->
@@ -42,11 +44,11 @@ final class IncludedBuildWithSubprojectsProject extends AbstractProject {
     }
     builder.withSubprojectInIncludedBuild('second-build', 'second-sub1') { secondSub ->
       secondSub.withBuildScript { bs ->
-        bs.plugins = [Plugin.javaLibraryPlugin]
+        bs.plugins.add(Plugin.javaLibraryPlugin)
         if (useProjectDependencyWherePossible) {
-          bs.dependencies = [new Dependency('implementation', ':second-sub2')]
+          bs.dependencies = [new Dependency('api', ':second-sub2')]
         } else {
-          bs.dependencies = [new Dependency('implementation', 'second:second-sub2')]
+          bs.dependencies = [new Dependency('api', 'second:second-sub2')]
         }
         bs.additions = """\
           group = 'second'
@@ -107,8 +109,12 @@ final class IncludedBuildWithSubprojectsProject extends AbstractProject {
     return actualProjectAdvice(project)
   }
 
-  final Set<ProjectAdvice> expectedIncludedBuildHealth = [
-    projectAdviceForDependencies(':second-sub1', [] as Set<Advice>),
+  final Set<ProjectAdvice> expectedIncludedBuildHealth(String buildNameInAdvice) {[
+    projectAdviceForDependencies(':second-sub1', [
+      useProjectDependencyWherePossible
+        ? Advice.ofChange(projectCoordinates(':second-sub2', null, buildNameInAdvice), 'api', 'implementation')
+        : Advice.ofChange(includedBuildCoordinates('second:second-sub2', projectCoordinates(':second-sub2', 'second:second-sub2', buildNameInAdvice)), 'api', 'implementation')
+    ] as Set<Advice>),
     projectAdviceForDependencies(':second-sub2', [] as Set<Advice>)
-  ]
+  ]}
 }

--- a/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
@@ -59,13 +59,18 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
   fun maybePrimary(addAdvice: Advice, originalCoordinates: Coordinates): Advice {
     check(addAdvice.isAdd()) { "Must be add-advice" }
     return primaryPointers[originalCoordinates]?.let { primary ->
-      addAdvice.copy(coordinates = primary.withoutDefaultCapability())
+      val preferredCoordinatesNotation = if (primary is IncludedBuildCoordinates && addAdvice.coordinates is ProjectCoordinates) {
+        primary.resolvedProject
+      } else {
+        primary
+      }
+      addAdvice.copy(coordinates = preferredCoordinatesNotation.withoutDefaultCapability())
     } ?: addAdvice
   }
 
   companion object {
     fun of(
-      projectNode: ProjectCoordinates,
+      projectPath: String,
       dependencyGraph: Map<String, DependencyGraphView>,
       bundleRules: SerializableBundles,
       dependencyUsages: Map<Coordinates, Set<Usage>>,
@@ -77,12 +82,13 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
       bundleRules.primaries.forEach { (name, primaryId) ->
         val regexes = bundleRules.rules[name]!!
         dependencyGraph.forEach { (_, view) ->
+          val projectNode = view.graph.nodes().find { it.identifier == projectPath }!!
           view.graph.reachableNodes(projectNode)
-            .find { it.identifier == primaryId }
+            .find { coordinatesOrPathEquals(it, primaryId) }
             ?.let { primaryNode ->
               val reachableNodes = view.graph.reachableNodes(primaryNode)
               reachableNodes.filter { subordinateNode ->
-                regexes.any { it.matches(subordinateNode.identifier) }
+                regexes.any { coordinatesOrPathMatch(subordinateNode, it) }
               }.forEach { subordinateNode ->
                 bundles.setPrimary(primaryNode, subordinateNode)
               }
@@ -92,6 +98,7 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
 
       // Handle bundles that don't have a primary entry point
       dependencyGraph.forEach { (_, view) ->
+        val projectNode = view.graph.nodes().find { it.identifier == projectPath }!!
         view.graph.children(projectNode).forEach { parentNode ->
           val rules = bundleRules.matchingBundles(parentNode)
 
@@ -100,7 +107,7 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
             val reachableNodes = view.graph.reachableNodes(parentNode)
             rules.forEach { (_, regexes) ->
               reachableNodes.filter { childNode ->
-                regexes.any { it.matches(childNode.identifier) }
+                regexes.any { coordinatesOrPathMatch(childNode, it) }
               }.forEach { childNode ->
                 bundles[parentNode] = childNode
               }
@@ -112,7 +119,7 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
             if (parentNode.identifier.endsWith("-ktx")) {
               val baseId = parentNode.identifier.substringBeforeLast("-ktx")
               view.graph.children(parentNode).find { child ->
-                child.identifier == baseId
+                coordinatesOrPathEquals(child, baseId)
               }?.let { bundles[parentNode] = it }
             }
           }
@@ -120,7 +127,7 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
           // Implicit KMP bundles (inverse form compared to ktx)
           val jvmCandidate = parentNode.identifier + "-jvm"
           view.graph.children(parentNode)
-            .find { it.identifier == jvmCandidate }
+            .find { coordinatesOrPathEquals(it, jvmCandidate) }
             ?.let { bundles[parentNode] = it }
         }
 
@@ -144,5 +151,12 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
 
       return bundles
     }
+
+    private fun coordinatesOrPathEquals(coordinates: Coordinates, primaryId: String) =
+      coordinates.identifier == primaryId || (coordinates is IncludedBuildCoordinates) && coordinates.resolvedProject.identifier == primaryId
+
+    private fun coordinatesOrPathMatch(coordinates: Coordinates, regex: Regex) =
+      regex.matches(coordinates.identifier) || (coordinates is IncludedBuildCoordinates) && regex.matches(coordinates.resolvedProject.identifier)
+
   }
 }

--- a/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
@@ -98,6 +98,7 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
 
       // Handle bundles that don't have a primary entry point
       dependencyGraph.forEach { (_, view) ->
+        // Find the node that represents the current project, which always exists in the graph
         val projectNode = view.graph.nodes().find { it.identifier == projectPath }!!
         view.graph.children(projectNode).forEach { parentNode ->
           val rules = bundleRules.matchingBundles(parentNode)

--- a/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/Bundles.kt
@@ -154,10 +154,10 @@ internal class Bundles(private val dependencyUsages: Map<Coordinates, Set<Usage>
     }
 
     private fun coordinatesOrPathEquals(coordinates: Coordinates, primaryId: String) =
-      coordinates.identifier == primaryId || (coordinates is IncludedBuildCoordinates) && coordinates.resolvedProject.identifier == primaryId
+      coordinates.identifier == primaryId || coordinates is IncludedBuildCoordinates && coordinates.resolvedProject.identifier == primaryId
 
     private fun coordinatesOrPathMatch(coordinates: Coordinates, regex: Regex) =
-      regex.matches(coordinates.identifier) || (coordinates is IncludedBuildCoordinates) && regex.matches(coordinates.resolvedProject.identifier)
+      regex.matches(coordinates.identifier) || coordinates is IncludedBuildCoordinates && regex.matches(coordinates.resolvedProject.identifier)
 
   }
 }

--- a/src/main/kotlin/com/autonomousapps/internal/graph/GraphViewBuilder.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/graph/GraphViewBuilder.kt
@@ -57,7 +57,7 @@ internal class GraphViewBuilder(conf: Configuration) {
       // For similar reasons as above
       .filterNot { it.isJavaPlatform() }
       // Sometimes there is a self-dependency?
-      .filterNot { it.selected == root }
+      .filterNot { it.toCoordinates() == rootId }
       .forEach { dependencyResult ->
         // Might be from an included build, in which case the coordinates reflect the _requested_ dependency instead of
         // the _resolved_ dependency.

--- a/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
@@ -38,6 +38,7 @@ private fun ResolvedDependencyResult.compositeRequest(): IncludedBuildCoordinate
   val resolved = ProjectCoordinates(
     identifier = (selected.id as ProjectComponentIdentifier).identityPath(),
     gradleVariantIdentification = gradleVariantIdentification,
+    // FIXME use 'buildState.buildIdentifier.buildPath' with Gradle 8.2+
     buildPath = (selected.id as ProjectComponentIdentifier).build.name
   )
 

--- a/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt
@@ -38,7 +38,7 @@ private fun ResolvedDependencyResult.compositeRequest(): IncludedBuildCoordinate
   val resolved = ProjectCoordinates(
     identifier = (selected.id as ProjectComponentIdentifier).identityPath(),
     gradleVariantIdentification = gradleVariantIdentification,
-    buildName = (selected.id as ProjectComponentIdentifier).build.name
+    buildPath = (selected.id as ProjectComponentIdentifier).build.name
   )
 
   return IncludedBuildCoordinates.of(requested, resolved)

--- a/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
@@ -116,7 +116,7 @@ sealed class Coordinates(
 data class ProjectCoordinates(
   override val identifier: String,
   override val gradleVariantIdentification: GradleVariantIdentification,
-  val buildName: String? = null // Name of the build in a composite for which the project coordinates are valid
+  val buildPath: String? = null // Name of the build in a composite for which the project coordinates are valid
 ) : Coordinates(identifier, gradleVariantIdentification) {
 
   init {

--- a/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
+++ b/src/main/kotlin/com/autonomousapps/model/Coordinates.kt
@@ -74,7 +74,7 @@ sealed class Coordinates(
           this
         }
       }
-    } ?: this
+    }
   }
 
   private fun isDefaultCapability(capability: String, identifier: String) =
@@ -115,7 +115,8 @@ sealed class Coordinates(
 @JsonClass(generateAdapter = false)
 data class ProjectCoordinates(
   override val identifier: String,
-  override val gradleVariantIdentification: GradleVariantIdentification
+  override val gradleVariantIdentification: GradleVariantIdentification,
+  val buildName: String? = null // Name of the build in a composite for which the project coordinates are valid
 ) : Coordinates(identifier, gradleVariantIdentification) {
 
   init {

--- a/src/main/kotlin/com/autonomousapps/model/GradleVariantIdentification.kt
+++ b/src/main/kotlin/com/autonomousapps/model/GradleVariantIdentification.kt
@@ -24,14 +24,16 @@ data class GradleVariantIdentification(
     is FlatCoordinates -> true
     is ProjectCoordinates -> if (capabilities.isEmpty()) {
       target.gradleVariantIdentification.capabilities.any {
-        it.endsWith(target.identifier.substring(target.identifier.lastIndexOf(":"))) // If empty, needs to contain the 'default' capability (for projects we need to check with endsWith)
+        // If empty, needs to contain the 'default' capability (for projects we need to check with endsWith)
+        it.endsWith(target.identifier.substring(target.identifier.lastIndexOf(":")))
       }
     } else {
       target.gradleVariantIdentification.capabilities.containsAll(capabilities)
     }
     else -> if (capabilities.isEmpty()) {
       target.gradleVariantIdentification.capabilities.any {
-        it == target.identifier // If empty, needs to contain the 'default' capability
+        // If empty, needs to contain the 'default' capability
+        it == target.identifier
       }
     } else {
       target.gradleVariantIdentification.capabilities.containsAll(capabilities)

--- a/src/main/kotlin/com/autonomousapps/model/GradleVariantIdentification.kt
+++ b/src/main/kotlin/com/autonomousapps/model/GradleVariantIdentification.kt
@@ -15,4 +15,26 @@ data class GradleVariantIdentification(
 
   private fun toSingleString() =
     capabilities.sorted().joinToString() + attributes.map { (k, v) -> "$k=$v" }.sorted().joinToString()
+
+  /**
+   * Check that all the requested capabilities are declared in the 'target'. Otherwise, the target can't be a target
+   * of the given declarations. The requested capabilities ALWAYS have to exist in a target to be selected.
+   */
+  fun variantMatches(target: Coordinates): Boolean = when(target) {
+    is FlatCoordinates -> true
+    is ProjectCoordinates -> if (capabilities.isEmpty()) {
+      target.gradleVariantIdentification.capabilities.any {
+        it.endsWith(target.identifier.substring(target.identifier.lastIndexOf(":"))) // If empty, needs to contain the 'default' capability (for projects we need to check with endsWith)
+      }
+    } else {
+      target.gradleVariantIdentification.capabilities.containsAll(capabilities)
+    }
+    else -> if (capabilities.isEmpty()) {
+      target.gradleVariantIdentification.capabilities.any {
+        it == target.identifier // If empty, needs to contain the 'default' capability
+      }
+    } else {
+      target.gradleVariantIdentification.capabilities.containsAll(capabilities)
+    }
+  }
 }

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -31,7 +31,9 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.internal.build.BuildState
 import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.support.serviceOf
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -748,6 +750,7 @@ internal class ProjectPlugin(private val project: Project) {
     }
     computeAdviceTask = tasks.register<ComputeAdviceTask>("computeAdvice") {
       projectPath.set(theProjectPath)
+      buildName.set(serviceOf<BuildState>().buildIdentifier.name)
       declarations.set(findDeclarationsTask.flatMap { it.output })
       bundles.set(getExtension().dependenciesHandler.serializableBundles())
       supportedSourceSets.set(supportedSourceSetNames())

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -503,7 +503,7 @@ internal class ProjectPlugin(private val project: Project) {
       setCompileClasspath(
         configurations[dependencyAnalyzer.compileConfigurationName].artifactsFor(dependencyAnalyzer.attributeValueJar)
       )
-      buildName.set(buildName())
+      buildPath.set(buildPath())
 
       output.set(outputPaths.artifactsPath)
       outputPretty.set(outputPaths.artifactsPrettyPath)
@@ -514,7 +514,7 @@ internal class ProjectPlugin(private val project: Project) {
       setCompileClasspath(configurations[dependencyAnalyzer.compileConfigurationName])
       setRuntimeClasspath(configurations[dependencyAnalyzer.runtimeConfigurationName])
       jarAttr.set(dependencyAnalyzer.attributeValueJar)
-      buildName.set(buildName())
+      buildPath.set(buildPath())
       projectPath.set(thisProjectPath)
       variant.set(variantName)
       kind.set(dependencyAnalyzer.kind)
@@ -752,7 +752,7 @@ internal class ProjectPlugin(private val project: Project) {
     }
     computeAdviceTask = tasks.register<ComputeAdviceTask>("computeAdvice") {
       projectPath.set(theProjectPath)
-      buildName.set(buildName())
+      buildPath.set(buildPath())
       declarations.set(findDeclarationsTask.flatMap { it.output })
       bundles.set(getExtension().dependenciesHandler.serializableBundles())
       supportedSourceSets.set(supportedSourceSetNames())
@@ -840,7 +840,7 @@ internal class ProjectPlugin(private val project: Project) {
     )
   }
 
-  private fun Project.buildName(): String = serviceOf<BuildState>().buildIdentifier.name
+  private fun Project.buildPath(): String = serviceOf<BuildState>().buildIdentifier.name
 
   private fun Project.isKaptApplied() = providers.provider { plugins.hasPlugin("kotlin-kapt") }
 

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -503,6 +503,7 @@ internal class ProjectPlugin(private val project: Project) {
       setCompileClasspath(
         configurations[dependencyAnalyzer.compileConfigurationName].artifactsFor(dependencyAnalyzer.attributeValueJar)
       )
+      buildName.set(buildName())
 
       output.set(outputPaths.artifactsPath)
       outputPretty.set(outputPaths.artifactsPrettyPath)
@@ -513,6 +514,7 @@ internal class ProjectPlugin(private val project: Project) {
       setCompileClasspath(configurations[dependencyAnalyzer.compileConfigurationName])
       setRuntimeClasspath(configurations[dependencyAnalyzer.runtimeConfigurationName])
       jarAttr.set(dependencyAnalyzer.attributeValueJar)
+      buildName.set(buildName())
       projectPath.set(thisProjectPath)
       variant.set(variantName)
       kind.set(dependencyAnalyzer.kind)
@@ -750,7 +752,7 @@ internal class ProjectPlugin(private val project: Project) {
     }
     computeAdviceTask = tasks.register<ComputeAdviceTask>("computeAdvice") {
       projectPath.set(theProjectPath)
-      buildName.set(serviceOf<BuildState>().buildIdentifier.name)
+      buildName.set(buildName())
       declarations.set(findDeclarationsTask.flatMap { it.output })
       bundles.set(getExtension().dependenciesHandler.serializableBundles())
       supportedSourceSets.set(supportedSourceSetNames())
@@ -837,6 +839,8 @@ internal class ProjectPlugin(private val project: Project) {
       output = computeResolvedDependenciesTask.flatMap { it.output }
     )
   }
+
+  private fun Project.buildName(): String = serviceOf<BuildState>().buildIdentifier.name
 
   private fun Project.isKaptApplied() = providers.provider { plugins.hasPlugin("kotlin-kapt") }
 

--- a/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
@@ -33,7 +33,7 @@ abstract class ArtifactsReportTask : DefaultTask() {
 
   /** Needed to make sure task gives the same result if the build configuration in a composite changed between runs. */
   @get:Input
-  abstract val buildName: Property<String>
+  abstract val buildPath: Property<String>
 
   /**
    * This artifact collection is the result of resolving the compile classpath.

--- a/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
@@ -12,6 +12,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 
 /**
@@ -29,6 +30,10 @@ abstract class ArtifactsReportTask : DefaultTask() {
   }
 
   private lateinit var compileArtifacts: ArtifactCollection
+
+  /** Needed to make sure task gives the same result if the build configuration in a composite changed between runs. */
+  @get:Input
+  abstract val buildName: Property<String>
 
   /**
    * This artifact collection is the result of resolving the compile classpath.

--- a/src/main/kotlin/com/autonomousapps/tasks/ComputeDominatorTreeTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ComputeDominatorTreeTask.kt
@@ -52,7 +52,7 @@ abstract class ComputeDominatorTreeTask : DefaultTask() {
       coord to file
     }
     val graphView = graphView.fromJson<DependencyGraphView>()
-    val project = ProjectCoordinates(projectPath.get(), GradleVariantIdentification(emptySet(), emptyMap()))
+    val project = ProjectCoordinates(projectPath.get(), GradleVariantIdentification(setOf("ROOT"), emptyMap()), ":")
 
     val tree = DominanceTree(graphView.graph, project)
     val nodeWriter = BySize(
@@ -125,7 +125,12 @@ abstract class ComputeDominatorTreeTask : DefaultTask() {
           builder.append(' ')
         }
 
-      builder.append(node.gav())
+      val preferredCoordinatesNotation = if (node is IncludedBuildCoordinates) {
+        node.resolvedProject
+      } else {
+        node
+      }
+      builder.append(preferredCoordinatesNotation.gav())
       return builder.toString()
     }
   }

--- a/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
@@ -70,7 +70,7 @@ abstract class GraphViewTask : DefaultTask() {
 
   /** Needed to make sure task gives the same result if the build configuration in a composite changed between runs. */
   @get:Input
-  abstract val buildName: Property<String>
+  abstract val buildPath: Property<String>
 
   /** Needed to disambiguate other projects that might have otherwise identical inputs. */
   @get:Input

--- a/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/GraphViewTask.kt
@@ -68,6 +68,10 @@ abstract class GraphViewTask : DefaultTask() {
   @get:InputFile
   abstract val declarations: RegularFileProperty
 
+  /** Needed to make sure task gives the same result if the build configuration in a composite changed between runs. */
+  @get:Input
+  abstract val buildName: Property<String>
+
   /** Needed to disambiguate other projects that might have otherwise identical inputs. */
   @get:Input
   abstract val projectPath: Property<String>

--- a/src/main/kotlin/com/autonomousapps/tasks/ReasonTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ReasonTask.kt
@@ -180,7 +180,7 @@ abstract class ReasonTask @Inject constructor(
 
     override fun execute() {
       val reason = DependencyAdviceExplainer(
-        project = ProjectCoordinates(projectPath, GradleVariantIdentification(emptySet(), emptyMap())),
+        project = ProjectCoordinates(projectPath, GradleVariantIdentification(setOf("ROOT"), emptyMap()), ":"),
         target = coord,
         usages = usages,
         advice = finalAdvice,

--- a/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/SynthesizeProjectViewTask.kt
@@ -194,7 +194,7 @@ abstract class SynthesizeProjectViewTask @Inject constructor(
         GradleVariantIdentification(emptySet(), emptyMap()))
       val ignoreSelfDependencies = parameters.buildType.isPresent // ignore on Android
       val classpath = graph.graph.nodes().asSequence().filterNot {
-        ignoreSelfDependencies && it == projectCoordinates
+        ignoreSelfDependencies && it is IncludedBuildCoordinates && it.resolvedProject.identifier == projectCoordinates.identifier
       }.toSortedSet()
       val annotationProcessors = parameters.annotationProcessors.fromJsonSet<AnnotationProcessorDependency>()
         .mapToSet { it.coordinates }

--- a/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
+++ b/src/main/kotlin/com/autonomousapps/transform/StandardTransform.kt
@@ -19,7 +19,7 @@ internal class StandardTransform(
   private val coordinates: Coordinates,
   private val declarations: Set<Declaration>,
   private val supportedSourceSets: Set<String>,
-  private val buildName: String,
+  private val buildPath: String,
   private val isKaptApplied: Boolean = false
 ) : Usage.Transform {
 
@@ -216,7 +216,7 @@ internal class StandardTransform(
       // Don't add runtimeOnly or compileOnly (compileOnly, compileOnlyApi, providedCompile) declarations
       .filterNot { it.bucket == Bucket.RUNTIME_ONLY || it.bucket == Bucket.COMPILE_ONLY }
       .mapTo(advice) { usage ->
-        val preferredCoordinatesNotation = if (coordinates is IncludedBuildCoordinates && coordinates.resolvedProject.buildName == buildName) {
+        val preferredCoordinatesNotation = if (coordinates is IncludedBuildCoordinates && coordinates.resolvedProject.buildPath == buildPath) {
           coordinates.resolvedProject
         } else {
           coordinates

--- a/src/test/kotlin/com/autonomousapps/internal/BundlesTest.kt
+++ b/src/test/kotlin/com/autonomousapps/internal/BundlesTest.kt
@@ -39,7 +39,7 @@ class BundlesTest {
 
       // the thing under test
       val bundles = Bundles.of(
-        projectNode = ProjectCoordinates(":consumer", gvi),
+        projectPath = ":consumer",
         dependencyGraph = graph,
         bundleRules = dependenciesHandler.serializableBundles(),
         dependencyUsages = dependencyUsages,
@@ -99,7 +99,7 @@ class BundlesTest {
       )
 
       return Bundles.of(
-        projectNode = ProjectCoordinates(":consumer", gvi),
+        projectPath = ":consumer",
         dependencyGraph = graph,
         bundleRules = dependenciesHandler.serializableBundles(),
         dependencyUsages = dependencyUsages,

--- a/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
+++ b/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
@@ -41,7 +41,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -58,7 +58,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(
@@ -81,7 +81,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(
@@ -103,7 +103,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -120,7 +120,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(ModuleCoordinates(identifier, "1.0", emptyGVI), fromConfiguration))
@@ -132,7 +132,7 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofAdd(ModuleCoordinates(identifier, "1.0", emptyGVI), "implementation"))
@@ -148,7 +148,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -163,7 +163,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -182,7 +182,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -194,7 +194,7 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -208,7 +208,7 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -224,7 +224,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(
@@ -243,7 +243,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(identifier, "1.0", emptyGVI), "implementation", "debugImplementation"),
@@ -263,7 +263,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, true).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":", true).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(
@@ -280,7 +280,7 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).isEmpty()
     }
@@ -296,7 +296,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(ModuleCoordinates(identifier, "1.0", emptyGVI), fromConfiguration))
@@ -316,7 +316,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       // change from impl -> debugImpl (implicit "remove from release variant")
       assertThat(actual).containsExactly(
@@ -330,7 +330,7 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(Advice.ofAdd(ModuleCoordinates(identifier, "1.0", emptyGVI), "implementation"))
     }
@@ -341,7 +341,7 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofAdd(ModuleCoordinates(identifier, "1.0", emptyGVI), "debugImplementation"),
@@ -355,7 +355,7 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofAdd(ModuleCoordinates(identifier, "1.0", emptyGVI), "debugImplementation"))
@@ -373,7 +373,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "1.0", emptyGVI), "debugImplementation", "implementation"),
@@ -390,7 +390,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(ModuleCoordinates(id, "1.0", emptyGVI), "releaseImplementation")
@@ -409,7 +409,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, true).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":", true).reduce(usages)
 
       // The fact that it's kaptDebug -> kapt and kaptRelease -> null and not the other way around is due to alphabetic
       // ordering (Debug comes before Release).
@@ -435,7 +435,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "1.0", emptyGVI), "debugImplementation", "debugApi"),
@@ -452,7 +452,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(ModuleCoordinates(id, "1.0", emptyGVI), "debugImplementation"),
@@ -469,7 +469,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "1.0", emptyGVI), "debugImplementation", "debugApi"),
@@ -489,7 +489,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "1.0", emptyGVI), "implementation", "debugImplementation"),
@@ -515,7 +515,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "implementation", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "4.13.2", emptyGVI), "implementation", "testImplementation")
@@ -533,7 +533,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "implementation", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "4.13.2", emptyGVI), "implementation", "androidTestImplementation")
@@ -555,7 +555,7 @@ internal class StandardTransformTest {
         Declaration(id, "androidTestImplementation", emptyGVI),
       )
 
-      val actual = StandardTransform(ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+      val actual = StandardTransform(ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(ModuleCoordinates(id, "4.13.2", emptyGVI), "implementation")
@@ -573,7 +573,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "implementation", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "1.0", emptyGVI), "implementation", "debugImplementation"),
@@ -592,7 +592,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "implementation", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "1.0", emptyGVI), "implementation", "debugImplementation"),
@@ -608,7 +608,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "testImplementation", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "4.4", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "4.4", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "4.4", emptyGVI), "testImplementation", "testRuntimeOnly"),
@@ -629,7 +629,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "1.0", emptyGVI), "implementation", "debugImplementation")
@@ -650,7 +650,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(ModuleCoordinates(id, "1.0", emptyGVI), "testImplementation"),
@@ -671,7 +671,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(ModuleCoordinates(id, "1.0", emptyGVI), "androidTestImplementation"),
@@ -691,7 +691,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "1.0", emptyGVI), "testImplementation", "implementation"),
@@ -711,7 +711,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "1.0", emptyGVI), "androidTestImplementation", "implementation"),
@@ -728,7 +728,7 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets).reduce(usages)
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":").reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(identifier, "1.0", emptyGVI), "debugImplementation", "debugRuntimeOnly"))
@@ -748,7 +748,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "kapt", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "2.40.5", gvi(id)), declarations, supportedSourceSets, true).reduce(usages)
+        ModuleCoordinates(id, "2.40.5", gvi(id)), declarations, supportedSourceSets, ":", true).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofRemove(ModuleCoordinates(id, "2.40.5", emptyGVI), "kapt")
@@ -773,7 +773,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "kapt", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "2.40.5", gvi(id)), declarations, supportedSourceSets, false).reduce(usages)
+        ModuleCoordinates(id, "2.40.5", gvi(id)), declarations, supportedSourceSets, ":", false).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofChange(ModuleCoordinates(id, "2.40.5", emptyGVI), "kapt", "releaseAnnotationProcessor")
@@ -798,7 +798,7 @@ internal class StandardTransformTest {
       ).intoSet()
       val declarations = emptySet<Declaration>()
 
-      val actual = StandardTransform(coordinates, declarations, supportedSourceSets, usesKapt).reduce(usages)
+      val actual = StandardTransform(coordinates, declarations, supportedSourceSets, ":", usesKapt).reduce(usages)
 
       assertThat(actual).containsExactly(
         Advice.ofAdd(coordinates, toConfiguration)


### PR DESCRIPTION
There is a bug that leads to wrong/inconsistent advices if included builds are involved. I first thought this is probably an easy fix, but then discovered a more fundamental problem with the _included builds_ handling and went down that rabbit hole.

The assumption at the moment is that if a 'project path' matches the 'identity path', the dependency is not in an included build.

This is in:
[`gradleStrings.ResolvedArtifactResult.toCoordinates()`](https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/blob/main/src/main/kotlin/com/autonomousapps/internal/utils/gradleStrings.kt#L66)




While this works in the case where we do not use included builds (much), it is generally wrong. There can also be references to other projects inside other included builds. And, more problematic, an included build can refer back to the "root" build. The plugin then assumes that a a project in the root build could be addressed via 'project(":path")' notation from that other build, which is not true. So depending on where you start the build (which of your builds is the "root") the plugin may yield different advices.

This PR proposed to use `IncludedBuildCoordinates` consistently throughout the analysis. Then we also do not need to handle both in the middle of the advice calculation. Then only in the end when an advice is given, we decide which representation of the coordinates is shown to the user. For 'add' advices, we need to track the build ID (build name), to decide if a project is in the same build and can hence be addressed by project coordinates.

Maybe #896 is related. It seems to be in the same area – issues with build/project identity in a composite.