### PR TITLE
Remove pretty-printed files.

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/OutputPaths.kt
@@ -18,10 +18,8 @@ internal class OutputPaths(
   private val intermediatesDir = "${variantDirectory}/intermediates"
 
   val artifactsPath = file("${intermediatesDir}/artifacts.json")
-  val artifactsPrettyPath = file("${intermediatesDir}/artifacts-pretty.json")
   val externalDependenciesPath = file("${intermediatesDir}/external-dependencies.txt")
   val allDeclaredDepsPath = file("${intermediatesDir}/all-declared-dependencies.json")
-  val allDeclaredDepsPrettyPath = file("${intermediatesDir}/all-declared-dependencies-pretty.json")
   val inlineUsagePath = file("${intermediatesDir}/inline-usage.json")
   val androidResPath = file("${intermediatesDir}/android-res.json")
   val androidResToResUsagePath = file("${intermediatesDir}/android-res-by-res-usage.json")
@@ -32,7 +30,6 @@ internal class OutputPaths(
   val androidLintersPath = file("${intermediatesDir}/android-linters.json")
   val androidAssetsPath = file("${intermediatesDir}/android-asset-providers.json")
   val declaredProcPath = file("${intermediatesDir}/procs-declared.json")
-  val declaredProcPrettyPath = file("${intermediatesDir}/procs-declared-pretty.json")
   val abiAnalysisPath = file("${intermediatesDir}/abi.json")
   val abiDumpPath = file("${variantDirectory}/abi-dump.txt")
   val dependenciesDir = dir("${variantDirectory}/dependencies")
@@ -105,7 +102,6 @@ internal class RedundantSubPluginOutputPaths(private val project: Project) {
 }
 
 // TODO used by tests
-fun getVariantDirectory(variantName: String) = "$ROOT_DIR/$variantName"
 fun getAdvicePathV2() = "$ROOT_DIR/final-advice.json"
 fun getAggregateAdvicePathV2() = "$ROOT_DIR/final-advice.json"
 fun getFinalAdvicePathV2() = "$ROOT_DIR/build-health-report.json"

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
@@ -144,7 +144,6 @@ internal abstract class AndroidAnalyzer(
       }
 
       output.set(outputPaths.declaredProcPath)
-      outputPretty.set(outputPaths.declaredProcPrettyPath)
     }
 
   private fun kaptConfName(): String {

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -89,7 +89,6 @@ internal abstract class JvmAnalyzer(
       }
 
       output.set(outputPaths.declaredProcPath)
-      outputPretty.set(outputPaths.declaredProcPrettyPath)
     }
   }
 

--- a/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/ProjectPlugin.kt
@@ -24,6 +24,7 @@ import com.autonomousapps.model.declaration.SourceSetKind
 import com.autonomousapps.model.declaration.Variant
 import com.autonomousapps.services.InMemoryCache
 import com.autonomousapps.tasks.*
+import org.gradle.api.NamedDomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.RegularFile
@@ -503,7 +504,6 @@ internal class ProjectPlugin(private val project: Project) {
       )
 
       output.set(outputPaths.artifactsPath)
-      outputPretty.set(outputPaths.artifactsPrettyPath)
     }
 
     // Produce a DAG of the compile and runtime classpaths rooted on this project.
@@ -584,7 +584,6 @@ internal class ProjectPlugin(private val project: Project) {
       }
 
       output.set(outputPaths.allDeclaredDepsPath)
-      outputPretty.set(outputPaths.allDeclaredDepsPrettyPath)
     }
 
     // Find the inline members of this project's dependencies.
@@ -915,7 +914,7 @@ internal class ProjectPlugin(private val project: Project) {
 
   private class JavaSources(project: Project) {
 
-    val sourceSets = project.the<SourceSetContainer>().matching {
+    val sourceSets: NamedDomainObjectSet<SourceSet> = project.the<SourceSetContainer>().matching {
       s -> !project.getExtension().issueHandler.ignoreSourceSet(s.name, project.path)
         && (project.shouldAnalyzeTests() || s.name != SourceSet.TEST_SOURCE_SET_NAME)
     }
@@ -929,8 +928,8 @@ internal class ProjectPlugin(private val project: Project) {
     private val sourceSets = project.the<SourceSetContainer>()
     private val kotlinSourceSets = project.the<KotlinProjectExtension>().sourceSets
 
-    val main = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-    val test = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME)
+    val main: SourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+    val test: SourceSet = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME)
 
     val kotlinMain: org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet? =
       kotlinSourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)

--- a/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/ArtifactsReportTask.kt
@@ -54,21 +54,13 @@ abstract class ArtifactsReportTask : DefaultTask() {
   @get:OutputFile
   abstract val output: RegularFileProperty
 
-  /**
-   * Pretty-formatted version of [output]. Useful for quick debugging.
-   */
-  @get:OutputFile
-  abstract val outputPretty: RegularFileProperty
-
   @TaskAction
   fun action() {
     val reportFile = output.getAndDelete()
-    val reportPrettyFile = outputPretty.getAndDelete()
 
     val allArtifacts = toPhysicalArtifacts(compileArtifacts)
 
     reportFile.bufferWriteJsonSet(allArtifacts)
-    reportPrettyFile.bufferPrettyWriteJsonSet(allArtifacts)
   }
 
   private fun toPhysicalArtifacts(artifacts: ArtifactCollection): Set<PhysicalArtifact> {

--- a/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
+++ b/src/main/kotlin/com/autonomousapps/tasks/FindDeclaredProcsTask.kt
@@ -79,9 +79,6 @@ abstract class FindDeclaredProcsTask : DefaultTask() {
   @get:OutputFile
   abstract val output: RegularFileProperty
 
-  @get:OutputFile
-  abstract val outputPretty: RegularFileProperty
-
   @get:Internal
   abstract val inMemoryCacheProvider: Property<InMemoryCache>
 
@@ -90,7 +87,6 @@ abstract class FindDeclaredProcsTask : DefaultTask() {
 
   @TaskAction fun action() {
     val outputFile = output.getAndDelete()
-    val outputPrettyFile = outputPretty.getAndDelete()
 
     val kaptClassLoader = newClassLoader("for-kapt", getKaptArtifactFiles())
     val apClassLoader = newClassLoader("for-annotation-processor", getAnnotationProcessorArtifactFiles())
@@ -100,7 +96,6 @@ abstract class FindDeclaredProcsTask : DefaultTask() {
     val procs = kaptProcs + annotationProcessorProcs
 
     outputFile.bufferWriteJsonList(procs)
-    outputPrettyFile.bufferPrettyWriteJsonList(procs)
   }
 
   private fun newClassLoader(name: String, files: FileCollection?): ClassLoader? {


### PR DESCRIPTION
Their purpose was during early development to simplify some common debugging tasks. They have outlived their usefulness.

https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/903