### PR TITLE
Add test: nested projects with same name have different identities

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/NestedProjectsSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/NestedProjectsSpec.groovy
@@ -1,0 +1,50 @@
+package com.autonomousapps.jvm
+
+
+import com.autonomousapps.jvm.projects.NestedSubprojectsProject
+
+import static com.autonomousapps.utils.Runner.build
+import static com.autonomousapps.utils.Runner.buildAndFail
+import static com.google.common.truth.Truth.assertThat
+
+final class NestedProjectsSpec extends AbstractJvmSpec {
+
+  def "handles projects with same name but different nested path"() {
+    given:
+    def project = new NestedSubprojectsProject()
+    gradleProject = project.gradleProject
+
+    when: 'build does not fail'
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then: 'the build health is as expected'
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "does not handle projects with same name and group but different nested path"() {
+    // Gradle does not allow this. As soon group+name of a project are identical they have the same identity from
+    // Gradle's perspective and that leads to errors during dependency resolution already.
+    // This test is here to document that.
+
+    given:
+    def project = new NestedSubprojectsProject(true)
+    gradleProject = project.gradleProject
+
+    when: 'building with several projects with the same identity'
+    def result = buildAndFail(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then: 'build fails with circular dependency issue'
+    result.output.contains '''
+      Circular dependency between the following tasks:
+      :featureC:public:compileJava
+      \\--- :featureC:public:compileJava (*)
+    '''.stripIndent()
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/NestedSubprojectsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/NestedSubprojectsProject.groovy
@@ -1,0 +1,114 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.*
+import static com.autonomousapps.kit.Dependency.*
+
+final class NestedSubprojectsProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  NestedSubprojectsProject(boolean sameGroup = false) {
+    this.gradleProject = build(sameGroup)
+  }
+
+  private GradleProject build(boolean sameGroup) {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('featureA:public') { s ->
+      s.sources = sourcesA
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        if (sameGroup) bs.additions = 'group = "org.example"'
+        bs.dependencies = [
+          commonsText('api'),
+        ]
+      }
+    }
+    builder.withSubproject('featureB:public') { s ->
+      s.sources = sourcesB
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        if (sameGroup) bs.additions = 'group = "org.example"'
+        bs.dependencies = [
+          commonsIO('api'),
+        ]
+      }
+    }
+    builder.withSubproject('featureC:public') { s ->
+      s.sources = sourcesC
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin]
+        if (sameGroup) bs.additions = 'group = "org.example"'
+        bs.dependencies = [
+          commonsCollections('api'),
+          project('api', ':featureA:public'),
+          project('api', ':featureB:public'),
+        ]
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private List<Source> sourcesA = [
+    new Source(
+      SourceType.JAVA, "A", "com/example/a",
+      """\
+        package com.example.a;
+
+        public class A { }
+      """.stripIndent()
+    )
+  ]
+
+  private List<Source> sourcesB = [
+    new Source(
+      SourceType.JAVA, "B", "com/example/b",
+      """\
+        package com.example.b;
+
+        public class B { }
+      """.stripIndent()
+    )
+  ]
+
+  private List<Source> sourcesC = [
+    new Source(
+      SourceType.JAVA, "C", "com/example/c",
+      """\
+        package com.example.c;
+
+        import com.example.b.B;
+
+        public class C {
+          private B b = new B();
+        }
+      """.stripIndent()
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':featureA:public',
+      [Advice.ofRemove(moduleCoordinates(commonsText('api')), 'api')] as Set<Advice>),
+    projectAdviceForDependencies(':featureB:public',
+      [Advice.ofRemove(moduleCoordinates(commonsIO('api')), 'api')] as Set<Advice>),
+    projectAdviceForDependencies(':featureC:public', [
+      Advice.ofRemove(moduleCoordinates(commonsCollections('api')), 'api'),
+      Advice.ofRemove(projectCoordinates(':featureA:public'), 'api'),
+      Advice.ofChange(projectCoordinates(':featureB:public'), 'api', 'implementation'),
+    ] as Set<Advice>)
+  ]
+}


### PR DESCRIPTION
Because by default, the 'group' is derived from the project path, the identity differs even if if GA from the IncludeBuildCoordinates is used as identity.

Confirms that there is no problem here after the changes from #916.

See:
https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/pull/916#discussion_r1244109793