### PR TITLE
Add gradle property to disable compatibility mismatch

### DIFF
--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -2,6 +2,7 @@
 
 package com.autonomousapps
 
+import com.autonomousapps.Flags.compatibility
 import com.autonomousapps.internal.android.AgpVersion
 import com.autonomousapps.subplugin.ProjectPlugin
 import com.autonomousapps.subplugin.RootPlugin
@@ -39,12 +40,15 @@ class DependencyAnalysisPlugin : Plugin<Project> {
     }
 
     logger.debug("AgpVersion = $current")
-    if (!current.isSupported() && this == rootProject && !findProperty("dependencyAnalysis.disableCompatibilityWarning").toString().toBoolean()) {
-      logger.warn(
-        "The Dependency Analysis plugin is only known to work with versions of AGP between " +
-          "${AgpVersion.AGP_MIN.version} and ${AgpVersion.AGP_MAX.version}. You are using ${current.version}. " +
-          "Proceed at your own risk."
-      )
+    if (!current.isSupported() && this == rootProject) {
+      val message = "The Dependency Analysis plugin is only known to work with versions of AGP between " +
+        "${AgpVersion.AGP_MIN.version} and ${AgpVersion.AGP_MAX.version}. You are using ${current.version}. " +
+        "Proceed at your own risk."
+      when (compatibility()) {
+        Flags.Compatibility.NONE -> logger.debug(message)
+        Flags.Compatibility.WARN -> logger.warn(message)
+        Flags.Compatibility.ERROR -> logger.error(message)
+      }
     }
   }
 

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -40,14 +40,17 @@ class DependencyAnalysisPlugin : Plugin<Project> {
     }
 
     logger.debug("AgpVersion = $current")
-    if (!current.isSupported() && this == rootProject) {
+    val compatibility = compatibility()
+    if (compatibility != Flags.Compatibility.NONE && !current.isSupported() && this == rootProject) {
       val message = "The Dependency Analysis plugin is only known to work with versions of AGP between " +
         "${AgpVersion.AGP_MIN.version} and ${AgpVersion.AGP_MAX.version}. You are using ${current.version}. " +
         "Proceed at your own risk."
-      when (compatibility()) {
-        Flags.Compatibility.NONE -> logger.debug(message)
+      @Suppress("KotlinConstantConditions")
+      when (compatibility) {
+        Flags.Compatibility.DEBUG -> logger.debug(message)
         Flags.Compatibility.WARN -> logger.warn(message)
         Flags.Compatibility.ERROR -> logger.error(message)
+        Flags.Compatibility.NONE -> error("Not possible")
       }
     }
   }

--- a/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/DependencyAnalysisPlugin.kt
@@ -39,7 +39,7 @@ class DependencyAnalysisPlugin : Plugin<Project> {
     }
 
     logger.debug("AgpVersion = $current")
-    if (!current.isSupported() && this == rootProject) {
+    if (!current.isSupported() && this == rootProject && !findProperty("dependencyAnalysis.disableCompatibilityWarning").toString().toBoolean()) {
       logger.warn(
         "The Dependency Analysis plugin is only known to work with versions of AGP between " +
           "${AgpVersion.AGP_MIN.version} and ${AgpVersion.AGP_MAX.version}. You are using ${current.version}. " +

--- a/src/main/kotlin/com/autonomousapps/Flags.kt
+++ b/src/main/kotlin/com/autonomousapps/Flags.kt
@@ -50,7 +50,8 @@ object Flags {
 
   internal fun Project.compatibility(): Compatibility {
     return getGradlePropForConfiguration(FLAG_DISABLE_COMPATIBILITY, Compatibility.WARN.name).let {
-      Compatibility.valueOf(it.toUpperCase(Locale.US))
+      val value = it.toUpperCase(Locale.US)
+      Compatibility.values().find { it.name == value } ?: error("Unrecognized value '$it' for 'dependency.analysis.compatibility' property. Allowed values are ${Compatibility.values()}")
     }
   }
 

--- a/src/main/kotlin/com/autonomousapps/Flags.kt
+++ b/src/main/kotlin/com/autonomousapps/Flags.kt
@@ -75,6 +75,6 @@ object Flags {
       .toBoolean()
 
   internal enum class Compatibility {
-    NONE, WARN, ERROR
+    NONE, DEBUG, WARN, ERROR
   }
 }

--- a/src/main/kotlin/com/autonomousapps/Flags.kt
+++ b/src/main/kotlin/com/autonomousapps/Flags.kt
@@ -2,6 +2,7 @@
 
 package com.autonomousapps
 
+import java.util.Locale
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 
@@ -24,6 +25,8 @@ object Flags {
    */
   private const val FLAG_ANDROID_IGNORED_VARIANTS = "dependency.analysis.android.ignored.variants"
 
+  private const val FLAG_DISABLE_COMPATIBILITY = "dependency.analysis.compatibility"
+
   internal fun Project.shouldAnalyzeTests() = getGradleOrSysProp(FLAG_TEST_ANALYSIS, true)
   internal fun Project.shouldAutoApply() = getGradleOrSysProp(FLAG_AUTO_APPLY, true)
   internal fun Project.printBuildHealth() = getGradlePropForConfiguration(FLAG_PRINT_BUILD_HEALTH, false)
@@ -45,6 +48,12 @@ object Flags {
       .getOrElse(default)
   }
 
+  internal fun Project.compatibility(): Compatibility {
+    return getGradlePropForConfiguration(FLAG_DISABLE_COMPATIBILITY, Compatibility.WARN.name).let {
+      Compatibility.valueOf(it.toUpperCase(Locale.US))
+    }
+  }
+
   private fun Project.getGradleOrSysProp(name: String, default: Boolean): Boolean {
     val byGradle = getGradlePropForConfiguration(name, default)
     val bySys = getSysPropForConfiguration(name, default)
@@ -64,4 +73,8 @@ object Flags {
       .forUseAtConfigurationTime()
       .getOrElse(default.toString())
       .toBoolean()
+
+  internal enum class Compatibility {
+    NONE, WARN, ERROR
+  }
 }


### PR DESCRIPTION
This adds a new property to control the compatibility warning log. There are three levels: `NONE`, `DEBUG`, `WARN`, `ERROR`. These correspond to their logger visibilities.

```properties
dependency.analysis.compatibility=NONE
```

Resolves #801