### PR TITLE
Only share InMemoryCache across builds if the same classloader was used to load the plugin

### DIFF
--- a/src/functionalTest/groovy/com/autonomousapps/jvm/InMemoryCacheSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/InMemoryCacheSpec.groovy
@@ -1,0 +1,49 @@
+package com.autonomousapps.jvm
+
+import com.autonomousapps.jvm.projects.IncludedBuildWithDivergingPluginClasspathsProject
+import org.gradle.testkit.runner.BuildResult
+
+import static com.autonomousapps.utils.Runner.build
+
+class InMemoryCacheSpec extends AbstractJvmSpec {
+
+  def "in memory cache is reused across builds with same plugin classpath (#gradleVersion)"() {
+    given:
+    def project = new IncludedBuildWithDivergingPluginClasspathsProject(false)
+    gradleProject = project.gradleProject
+
+    when:
+    def result = build(gradleVersion, gradleProject.rootDir, ':buildHealth', ':second-build:buildHealth')
+
+    then:
+    def serviceObjects = parseServiceObjects(result)
+    serviceObjects[0] == serviceObjects[1]
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  def "in memory cache is not reused across builds with different plugin classpaths (#gradleVersion)"() {
+    // Attempting to reuse the cache accross build in such a setup leads to a error like:
+    // Cannot set property 'inMemoryCache' of type com.autonomousapps.services.InMemoryCache using a provider of type com.autonomousapps.services.InMemoryCache
+    // This is because the plugin, and with that the InMemoryCache class, is loaded multiple times by different classloaders.
+    // See: https://github.com/gradle/gradle/issues/17559
+    given:
+    def project = new IncludedBuildWithDivergingPluginClasspathsProject(true)
+    gradleProject = project.gradleProject
+
+    when:
+    def result = build(gradleVersion, gradleProject.rootDir, ':buildHealth', ':second-build:buildHealth')
+
+    then:
+    def serviceObjects = parseServiceObjects(result)
+    serviceObjects[0] != serviceObjects[1]
+
+    where:
+    gradleVersion << gradleVersions()
+  }
+
+  private List<String> parseServiceObjects(BuildResult result) {
+    result.output.readLines().findAll { it.startsWith('com.autonomousapps.services.InMemoryCache$Inject@') }
+  }
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithDivergingPluginClasspathsProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IncludedBuildWithDivergingPluginClasspathsProject.groovy
@@ -1,0 +1,43 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+
+final class IncludedBuildWithDivergingPluginClasspathsProject extends AbstractProject {
+
+  final GradleProject gradleProject
+
+  IncludedBuildWithDivergingPluginClasspathsProject(boolean divergingPluginClasspaths) {
+    this.gradleProject = build(divergingPluginClasspaths)
+  }
+
+  private GradleProject build(boolean divergingPluginClasspaths) {
+    def builder = newGradleProjectBuilder()
+    def printServiceObject = """\
+      afterEvaluate { // needs 'afterEvaluate' because plugin code also uses 'afterEvaluate'
+        tasks.named('explodeJarMain') {
+          doLast { println(inMemoryCache.get()) }
+        }
+      }
+    """
+    builder.withRootProject { root ->
+      root.withBuildScript { bs ->
+        bs.plugins.add(Plugin.javaLibraryPlugin)
+        bs.additions = printServiceObject
+      }
+      root.settingsScript.additions = "\nincludeBuild 'second-build'"
+    }
+    builder.withIncludedBuild('second-build') { second ->
+      second.withBuildScript { bs ->
+        bs.plugins.add(Plugin.javaLibraryPlugin)
+        if (divergingPluginClasspaths) bs.plugins.add(Plugin.springBootPlugin)
+        bs.additions = printServiceObject
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+}

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/AndroidProjectAnalyzer.kt
@@ -131,11 +131,9 @@ internal abstract class AndroidAnalyzer(
       output.set(outputPaths.androidAssetsPath)
     }
 
-  final override fun registerFindDeclaredProcsTask(
-    inMemoryCache: Provider<InMemoryCache>,
-  ): TaskProvider<FindDeclaredProcsTask> =
+  final override fun registerFindDeclaredProcsTask(): TaskProvider<FindDeclaredProcsTask> =
     project.tasks.register<FindDeclaredProcsTask>("findDeclaredProcs$taskNameSuffix") {
-      inMemoryCacheProvider.set(inMemoryCache)
+      inMemoryCacheProvider.set(InMemoryCache.register(project))
       kaptConf()?.let {
         setKaptArtifacts(it.incoming.artifacts)
       }

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/DependencyAnalyzer.kt
@@ -78,9 +78,7 @@ internal interface DependencyAnalyzer {
 
   fun registerFindAndroidAssetProvidersTask(): TaskProvider<FindAndroidAssetProviders>? = null
 
-  fun registerFindDeclaredProcsTask(
-    inMemoryCache: Provider<InMemoryCache>
-  ): TaskProvider<FindDeclaredProcsTask>
+  fun registerFindDeclaredProcsTask(): TaskProvider<FindDeclaredProcsTask>
 
   /**
    * This is a no-op for `com.android.application` and JVM `application` projects (including Spring Boot), since they

--- a/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/analyzer/JvmProjectAnalyzer.kt
@@ -76,11 +76,9 @@ internal abstract class JvmAnalyzer(
     }
   }
 
-  final override fun registerFindDeclaredProcsTask(
-    inMemoryCache: Provider<InMemoryCache>
-  ): TaskProvider<FindDeclaredProcsTask> {
+  final override fun registerFindDeclaredProcsTask(): TaskProvider<FindDeclaredProcsTask> {
     return project.tasks.register<FindDeclaredProcsTask>("findDeclaredProcs$variantNameCapitalized") {
-      inMemoryCacheProvider.set(inMemoryCache)
+      inMemoryCacheProvider.set(InMemoryCache.register(project))
       kaptConf()?.let {
         setKaptArtifacts(it.incoming.artifacts)
       }

--- a/src/main/kotlin/com/autonomousapps/subplugin/RootPlugin.kt
+++ b/src/main/kotlin/com/autonomousapps/subplugin/RootPlugin.kt
@@ -18,6 +18,8 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.register
 
+internal const val DEPENDENCY_ANALYSIS_PLUGIN = "com.autonomousapps.dependency-analysis"
+
 /**
  * This "plugin" is applied to the root project only.
  */
@@ -53,7 +55,7 @@ internal class RootPlugin(private val project: Project) {
     logger.debug("Applying plugin to all subprojects")
     subprojects {
       logger.debug("Auto-applying to $path.")
-      apply(plugin = "com.autonomousapps.dependency-analysis")
+      apply(plugin = DEPENDENCY_ANALYSIS_PLUGIN)
     }
   }
 


### PR DESCRIPTION
Follow up to #914 

Users can run into https://github.com/gradle/gradle/issues/17559 is the plugin is loaded with different classloaders in different builds. In these cases we now keep the old behavior of having separate caches for separate builds.

There is now a test checking the two different cases.