### PR TITLE
More agp

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,10 +31,18 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-      - name: Execute tests
+      - name: Execute check (non-functional tests)
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: check -s
+          arguments: check -s -x :functionalTest
+      - name: Execute JVM functional tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ':functionalTest -DfuncTest.package=jvm'
+      - name: Execute Android functional tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ':functionalTest -DfuncTest.package=android'
       - name: Comment on PR with build scan
         uses: mshick/add-pr-comment@v2
         if: failure()

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,10 +33,18 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-      - name: Execute tests
+      - name: Execute check (non-functional tests)
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: check -s
+          arguments: check -s -x :functionalTest
+      - name: Execute JVM functional tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ':functionalTest -DfuncTest.package=jvm'
+      - name: Execute Android functional tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ':functionalTest -DfuncTest.package=android'
       - name: Publish snapshot
         uses: eskatos/gradle-command-action@v1
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -224,10 +224,32 @@ val functionalTest by tasks.registering(Test::class) {
     logger.lifecycle("Running test: $this")
   })
 
-  // TODO cleanup: do only for AGP tests?
-  javaLauncher.set(javaToolchains.launcherFor {
-    languageVersion.set(JavaLanguageVersion.of(17))
-  })
+  // ./gradlew :functionalTest -DfuncTest.package=<all|jvm|android>
+  when (providers.systemProperty("funcTest.package").getOrElse("all").lowercase()) {
+    "jvm" -> {
+      logger.quiet("Run JVM tests")
+      include("com/autonomousapps/jvm/**")
+    }
+
+    "android" -> {
+      logger.quiet("Run Android tests")
+      include("com/autonomousapps/android/**")
+
+      // Android requires JDK 17 from AGP 8.0.
+      javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(17))
+      })
+    }
+
+    else -> {
+      logger.quiet("Run all tests")
+
+      // Android requires JDK 17 from AGP 8.0.
+      javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(17))
+      })
+    }
+  }
 }
 
 val quickFunctionalTest by tasks.registering {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,6 +131,9 @@ dependencies {
   compileOnly(libs.agp) {
     because("Auto-wiring into Android projects")
   }
+  compileOnly(libs.android.tools.common) {
+    because("com.android.Version")
+  }
   compileOnly(libs.kotlin.gradle) {
     because("Auto-wiring into Kotlin projects")
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,13 @@ moshi = "1.14.0"
 moshix = "0.19.0"
 retrofit = "2.9.0"
 
+agp = "7.4.2"
+agp-common = "30.4.2"
+
+
 [libraries]
-agp = "com.android.tools.build:gradle:4.2.2"
+agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+android-tools-common = { module = "com.android.tools:common", version.ref = "agp-common" }
 
 caffeine = "com.github.ben-manes.caffeine:caffeine:3.1.0"
 commons-io = "commons-io:commons-io:2.11.0"


### PR DESCRIPTION
The goals here are:
* Build against a later version of AGP (7.4.2 instead of 4.2.2)
* Continue to run JVM functional tests against JDK 11 (minimum supported JDK)
* Ensure Android tests are always run against JDK 17 (minimum supported JDK for AGP 8+)
* Add new system property to allow users to more easily specify which functional test package to test.
```bash
# passing 'all' is equivalent to omitting the system property altogether
./gradlew :functionalTest -DfuncTest.package=<all|android|jvm>
```

Not entirely sure I got the yaml syntax correct. Let's find out!