### PR TITLE
Test against AGP 8.1.0 as latest supported stable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Dependency Analysis Plugin Changelog
 
 # TBR
+* AGP 8.1.0 is the latest supported version
 
 # Version 1.21.0
 * [Fixed] Include Android res IDs in analysis.

--- a/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/AbstractFunctionalSpec.groovy
@@ -63,7 +63,9 @@ abstract class AbstractFunctionalSpec extends Specification {
   }
 
   protected static boolean isCompatible(GradleVersion gradleVersion, AgpVersion agpVersion) {
-    if (agpVersion >= AgpVersion.version('8.0.0')) {
+    if (agpVersion >= AgpVersion.version('8.2.0')) {
+      return gradleVersion >= GradleVersion.version('8.1')
+    } else if (agpVersion >= AgpVersion.version('8.0.0')) {
       return gradleVersion >= GradleVersion.version('8.0')
     } else if (agpVersion >= AgpVersion.version('7.4.0')) {
       return gradleVersion >= GradleVersion.version('7.5')

--- a/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/android/AbstractAndroidSpec.groovy
@@ -26,13 +26,13 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
   protected static final AGP_7_3 = AgpVersion.version('7.3.1')
   protected static final AGP_7_4 = AgpVersion.version('7.4.2')
   protected static final AGP_8_0 = AgpVersion.version('8.0.2')
-  protected static final AGP_8_1 = AgpVersion.version('8.1.0-rc01')
-  protected static final AGP_8_2 = AgpVersion.version('8.2.0-alpha13')
+  protected static final AGP_8_1 = AgpVersion.version('8.1.0')
+  protected static final AGP_8_2 = AgpVersion.version('8.2.0-alpha16')
 
   protected static final AGP_LATEST = AGP_8_2
 
   /**
-   * {@code AGP_7_4} represents the minimum stable _tested_ version. {@code AGP_8_0} represents the maximum stable
+   * {@code AGP_7_4} represents the minimum stable _tested_ version. {@code AGP_8_1} represents the maximum stable
    * _tested_ version. We also test against the latest alpha, {@code AGP_8_2} at time of writing. DAGP may work with
    * other versions of AGP, but they aren't tested, primarily for CI performance reasons.
    *
@@ -45,8 +45,8 @@ abstract class AbstractAndroidSpec extends AbstractFunctionalSpec {
 //    AGP_7_2,
 //    AGP_7_3,
     AGP_7_4,
-    AGP_8_0,
-//    AGP_8_1,
+//    AGP_8_0,
+    AGP_8_1,
     AGP_8_2,
   ]
 

--- a/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/android/AgpVersion.kt
@@ -10,7 +10,7 @@ internal class AgpVersion private constructor(val version: String) : Comparable<
   companion object {
 
     @JvmStatic val AGP_MIN = version("4.2.2")
-    @JvmStatic val AGP_MAX = version("8.0.2")
+    @JvmStatic val AGP_MAX = version("8.1.0")
 
     @JvmStatic fun current(): AgpVersion = AgpVersion(agpVersion())
     @JvmStatic fun version(version: String): AgpVersion = AgpVersion(version)


### PR DESCRIPTION
I had some test failures running this locally that looked like flakes (failed running all of `functionalTest` but pass when running individually in IDE), lets see if CI agrees