### PR TITLE
Use BuildIdentifier.getBuildPath() starting with Gradle 8.2

### DIFF
--- a/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
@@ -5,5 +5,7 @@ import org.gradle.util.GradleVersion
 internal object GradleVersions {
   val current: GradleVersion = GradleVersion.current()
   val gradle74: GradleVersion = GradleVersion.version("7.4")
+  val gradle82: GradleVersion = GradleVersion.version("8.2")
   val isAtLeastGradle74: Boolean = current >= gradle74
+  val isAtLeastGradle82: Boolean = current >= gradle82
 }


### PR DESCRIPTION
Right now, 8.3 prints a deprecation warning for the getName() method: https://scans.gradle.com/s/s23mexkai26qe/deprecations