### PR TITLE
Fix issues with sourceset-based analysis.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,6 +108,8 @@ dependencies {
   implementation(libs.kotlin.stdlib.jdk8)
   implementation(libs.moshi.kotlin)
   implementation(libs.moshix.sealed.reflect)
+  implementation(libs.okio)
+
   implementation(libs.kotlinx.metadata.jvm) {
     because("For Kotlin ABI analysis")
     // Depends on Kotlin 1.6, which I don't want. We also don't want to set a strict constraint, because

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-antlr-shadowed = "4.10.1.4"
+antlr-shadowed = "4.10.1.5"
 grammar = "0.2"
 java = "11"
 junit = "5.8.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ junit = "5.8.2"
 kotlin = "1.9.10"
 moshi = "1.14.0"
 moshix = "0.19.0"
+okio = "2.10.0"
 retrofit = "2.9.0"
 
 agp = "7.4.2"
@@ -39,6 +40,7 @@ moshix-sealed-reflect = { module = "dev.zacsweers.moshix:moshi-sealed-reflect", 
 moshix-sealed-runtime = { module = "dev.zacsweers.moshix:moshi-sealed-runtime", version.ref = "moshix" }
 
 okhttp3 = "com.squareup.okhttp3:okhttp:4.9.0"
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 
 relocated-antlr = { module = "com.autonomousapps:antlr", version.ref = "antlr-shadowed" }
 relocated-asm = "com.autonomousapps:asm-relocated:9.4.0.1"

--- a/graph-support/build.gradle.kts
+++ b/graph-support/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.autonomousapps"
-version = "0.1"
+version = "0.2"
 
 kotlin {
   explicitApi()
@@ -35,7 +35,6 @@ dependencies {
 
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.junit.api)
-  testImplementation(libs.junit.params)
   testImplementation(libs.truth)
   testRuntimeOnly(libs.junit.engine)
 

--- a/graph-support/src/main/kotlin/com/autonomousapps/graph/Graphs.kt
+++ b/graph-support/src/main/kotlin/com/autonomousapps/graph/Graphs.kt
@@ -15,6 +15,14 @@ public object Graphs {
     }
   }
 
+  /**
+   * Returns the first node it finds that has an in-degree of 0. This is the root node if this DAG contains only one
+   * such node.
+   */
+  public fun <N : Any> Graph<N>.root(): N = nodes().first {
+    inDegree(it) == 0
+  }
+
   public fun <N : Any> Graph<N>.parents(node: N): Set<N> = predecessors(node)
 
   public fun <N : Any> Graph<N>.children(node: N): Set<N> = successors(node)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,7 +24,7 @@ pluginManagement {
     }
   }
   plugins {
-    id("com.autonomousapps.dependency-analysis") version "1.10.0"//latestSnapshot
+    id("com.autonomousapps.dependency-analysis") version "1.22.0"//latestSnapshot
     id("com.github.johnrengelman.shadow") version "7.1.2"
     id("com.gradle.enterprise") version "3.10.2"
     id("com.gradle.plugin-publish") version "1.1.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ pluginManagement {
   }
   plugins {
     id("com.autonomousapps.dependency-analysis") version "1.22.0"//latestSnapshot
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.1.1"
     id("com.gradle.enterprise") version "3.10.2"
     id("com.gradle.plugin-publish") version "1.1.0"
     id("org.jetbrains.kotlin.jvm") version "1.9.10"

--- a/shadowed/antlr/build.gradle.kts
+++ b/shadowed/antlr/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 val antlrVersion = "4.10.1"
 group = "com.autonomousapps"
-version = "$antlrVersion.4"
+version = "$antlrVersion.5"
 
 val isSnapshot = version.toString().endsWith("SNAPSHOT", true)
 
@@ -64,7 +64,20 @@ tasks.withType<Test>().configureEach {
 
 tasks.shadowJar {
   archiveClassifier.set("")
+
   relocate("org.antlr", "com.autonomousapps.internal.antlr")
+  relocate("org.glassfish.json", "com.autonomousapps.internal.glassfish.json")
+
+  dependencies {
+    // Don't bundle Kotlin or other Jetbrains dependencies
+    exclude {
+      it.moduleGroup.startsWith("org.jetbrains")
+    }
+    // Don't bundle in emoji support
+    exclude {
+      it.moduleGroup == "com.ibm.icu"
+    }
+  }
 }
 
 tasks.named<Jar>("sourcesJar") {

--- a/shadowed/asm-relocated/build.gradle.kts
+++ b/shadowed/asm-relocated/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
-
 plugins {
   `java-library`
   id("com.github.johnrengelman.shadow")
@@ -37,13 +35,7 @@ dagp {
   publishTaskDescription("Publishes to Maven Central and promotes.")
 }
 
-val relocateShadowJar = tasks.register<ConfigureShadowRelocation>("relocateShadowJar") {
-  notCompatibleWithConfigurationCache("Shadow plugin is incompatible")
-  target = tasks.shadowJar.get()
-}
-
 tasks.shadowJar {
-  dependsOn(relocateShadowJar)
   archiveClassifier.set("")
   relocate("org.objectweb.asm", "com.autonomousapps.internal.asm")
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/CustomSourceSetSpec.groovy
@@ -2,7 +2,6 @@
 package com.autonomousapps.jvm
 
 import com.autonomousapps.jvm.projects.*
-import org.gradle.util.GradleVersion
 
 import static com.autonomousapps.jvm.projects.SourceSetFilteringProject.Severity.*
 import static com.autonomousapps.utils.Runner.build
@@ -166,5 +165,22 @@ final class CustomSourceSetSpec extends AbstractJvmSpec {
       gradleVersions(),
       [IGNORE, FAIL]
     )
+  }
+
+  // This validates logic in StandardTransform.simplify() that handles redundant declarations as well as preventing
+  // upgrading test dependencies.
+  def "don't suggest redundant declarations in related source sets, nor upgrade test dependencies (#gradleVersion)"() {
+    given:
+    def project = new CustomTestSourceSetProject()
+    gradleProject = project.gradleProject
+
+    when:
+    build(gradleVersion, gradleProject.rootDir, 'buildHealth')
+
+    then:
+    assertThat(project.actualBuildHealth()).containsExactlyElementsIn(project.expectedBuildHealth)
+
+    where:
+    gradleVersion << gradleVersions()
   }
 }

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/CustomTestSourceSetProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/CustomTestSourceSetProject.groovy
@@ -1,0 +1,94 @@
+package com.autonomousapps.jvm.projects
+
+import com.autonomousapps.AbstractProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.Plugin
+import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.SourceType
+import com.autonomousapps.model.Advice
+import com.autonomousapps.model.ProjectAdvice
+
+import static com.autonomousapps.AdviceHelper.actualProjectAdvice
+import static com.autonomousapps.AdviceHelper.projectAdviceForDependencies
+import static com.autonomousapps.kit.Dependency.commonsCollections
+import static com.autonomousapps.kit.Dependency.junit
+
+final class CustomTestSourceSetProject extends AbstractProject {
+
+  /** Inherited by our functionalTest source set. */
+  private static final commonsCollections = commonsCollections('testImplementation')
+  private static final junit = junit('testImplementation')
+
+  final GradleProject gradleProject
+
+  CustomTestSourceSetProject() {
+    this.gradleProject = build()
+  }
+
+  private GradleProject build() {
+    def builder = newGradleProjectBuilder()
+    builder.withSubproject('proj') { s ->
+      s.sources = sources
+      s.withBuildScript { bs ->
+        bs.plugins = [Plugin.javaLibraryPlugin, Plugin.kotlinPluginNoVersion]
+        bs.dependencies = [commonsCollections, junit]
+        bs.additions = '''\
+          sourceSets {
+            functionalTest {
+              compileClasspath += main.output + configurations.testRuntimeClasspath
+              runtimeClasspath += output + compileClasspath
+            }
+          }
+          configurations {
+            functionalTestImplementation.extendsFrom testImplementation
+          }'''.stripIndent()
+      }
+    }
+
+    def project = builder.build()
+    project.writer().write()
+    return project
+  }
+
+  private List<Source> sources = [
+    new Source(
+      SourceType.KOTLIN, 'FunctionalTest', 'com/example/func',
+      """\
+        package com.example.func
+
+        import org.apache.commons.collections4.Bag
+
+        class FunctionalTest {
+          // part of the "API" (but this is a test, no API)
+          fun magic(): Bag<String> {
+            TODO()
+          }
+        }""".stripIndent(),
+      'functionalTest'
+    ),
+    new Source(
+      SourceType.KOTLIN, "Spec", "com/example/test",
+      """\
+        package com.example.test
+        
+        import org.apache.commons.collections4.bag.HashBag
+        import org.junit.Test
+        
+        class Spec {
+          @Test fun test() {
+            // part of the implementation for this source set
+            val bag = HashBag<String>();
+          }
+        }""".stripIndent(),
+      'test'
+    )
+  ]
+
+  Set<ProjectAdvice> actualBuildHealth() {
+    return actualProjectAdvice(gradleProject)
+  }
+
+  final Set<ProjectAdvice> expectedBuildHealth = [
+    projectAdviceForDependencies(':proj', [] as Set<Advice>)
+  ]
+}

--- a/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IntegrationTestProject.groovy
+++ b/src/functionalTest/groovy/com/autonomousapps/jvm/projects/IntegrationTestProject.groovy
@@ -78,8 +78,7 @@ final class IntegrationTestProject extends AbstractProject {
           public void sendMessage(String message) {
             sender.send(message);
           }
-        }
-      """.stripIndent()
+        }""".stripIndent()
     ),
     new Source(SourceType.JAVA, "MockEmailChannel", "com/example/integrationTest",
       """\
@@ -92,8 +91,8 @@ final class IntegrationTestProject extends AbstractProject {
           public void send(String message) {
             // Don't send email on CI
           }
-        }
-      """.stripIndent(), "integrationTest"
+        }""".stripIndent(),
+      'integrationTest'
     )
   ]
 
@@ -108,8 +107,7 @@ final class IntegrationTestProject extends AbstractProject {
         public void send(String message) {
           // Some true implementation
         }
-      }
-    """.stripIndent()
+      }""".stripIndent()
   )
 
   private Source CORE_PRODUCER = new Source(SourceType.JAVA, "NotificationSender", "com/example/core",
@@ -118,8 +116,7 @@ final class IntegrationTestProject extends AbstractProject {
       
       public abstract class NotificationSender {
         public abstract void send(String message);
-      }
-    """.stripIndent()
+      }""".stripIndent()
   )
 
   Set<ProjectAdvice> actualBuildHealth() {
@@ -146,5 +143,5 @@ final class IntegrationTestProject extends AbstractProject {
         ] as Set<Advice>)
       ]
     }
-}
+  }
 }

--- a/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/GradleVersions.kt
@@ -3,9 +3,11 @@ package com.autonomousapps.internal
 import org.gradle.util.GradleVersion
 
 internal object GradleVersions {
-  val current: GradleVersion = GradleVersion.current()
-  val gradle74: GradleVersion = GradleVersion.version("7.4")
-  val gradle82: GradleVersion = GradleVersion.version("8.2")
+
+  private val current: GradleVersion = GradleVersion.current()
+  private val gradle74: GradleVersion = GradleVersion.version("7.4")
+  private val gradle82: GradleVersion = GradleVersion.version("8.2")
+
   val isAtLeastGradle74: Boolean = current >= gradle74
   val isAtLeastGradle82: Boolean = current >= gradle82
 }

--- a/src/main/kotlin/com/autonomousapps/internal/utils/multimaps.kt
+++ b/src/main/kotlin/com/autonomousapps/internal/utils/multimaps.kt
@@ -1,0 +1,13 @@
+package com.autonomousapps.internal.utils
+
+import com.google.common.collect.MultimapBuilder
+import com.google.common.collect.Multimaps
+import com.google.common.collect.SetMultimap
+
+internal fun <K, V> emptySetMultimap(): SetMultimap<K, V> = Multimaps.unmodifiableSetMultimap(
+  MultimapBuilder.hashKeys().hashSetValues().build<K, V>()
+)
+
+internal fun <K, V> newSetMultimap(): SetMultimap<K, V> {
+  return MultimapBuilder.hashKeys().hashSetValues().build()
+}

--- a/src/main/kotlin/com/autonomousapps/model/declaration/Variant.kt
+++ b/src/main/kotlin/com/autonomousapps/model/declaration/Variant.kt
@@ -10,6 +10,7 @@ import com.squareup.moshi.JsonClass
  */
 @JsonClass(generateAdapter = false)
 data class Variant(
+  /** The name of the source set (e.g., "main", "test", "debug", "release", etc.) */
   val variant: String,
   val kind: SourceSetKind
 ) : Comparable<Variant> {

--- a/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
+++ b/src/test/kotlin/com/autonomousapps/transform/StandardTransformTest.kt
@@ -1,12 +1,15 @@
 package com.autonomousapps.transform
 
+import com.autonomousapps.internal.utils.emptySetMultimap
 import com.autonomousapps.internal.utils.intoSet
+import com.autonomousapps.internal.utils.newSetMultimap
 import com.autonomousapps.model.Advice
 import com.autonomousapps.model.GradleVariantIdentification
 import com.autonomousapps.model.ModuleCoordinates
 import com.autonomousapps.model.declaration.Bucket
 import com.autonomousapps.model.declaration.Declaration
 import com.autonomousapps.model.declaration.SourceSetKind
+import com.autonomousapps.model.declaration.Variant
 import com.autonomousapps.model.intermediates.Reason
 import com.autonomousapps.test.usage
 import com.google.common.truth.Truth.assertThat
@@ -41,7 +44,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        coordinates = ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations = declarations,
+        nonTransitiveDependencies = emptySetMultimap(), // TODO: use non-empty?
+        supportedSourceSets = supportedSourceSets,
+        buildPath = ":"
       ).reduce(usages)
 
       assertThat(actual).isEmpty()
@@ -59,7 +66,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -83,7 +94,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -106,7 +121,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).isEmpty()
@@ -124,7 +143,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -138,7 +161,11 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -156,7 +183,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).isEmpty()
@@ -172,7 +203,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).isEmpty()
@@ -192,7 +227,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).isEmpty()
@@ -205,7 +244,11 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).isEmpty()
@@ -220,7 +263,11 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).isEmpty()
@@ -237,7 +284,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -257,7 +308,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -278,7 +333,12 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":", true
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":",
+        true
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -296,7 +356,11 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).isEmpty()
@@ -313,7 +377,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -335,7 +403,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       // change from impl -> debugImpl (implicit "remove from release variant")
@@ -350,7 +422,11 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(Advice.ofAdd(ModuleCoordinates(identifier, "1.0", emptyGVI), "implementation"))
@@ -362,7 +438,11 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -377,7 +457,11 @@ internal class StandardTransformTest {
       val declarations = emptySet<Declaration>()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -397,7 +481,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -415,7 +499,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -439,7 +523,12 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":", true
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":",
+        true
       ).reduce(usages)
 
       // The fact that it's kaptDebug -> kapt and kaptRelease -> null and not the other way around is due to alphabetic
@@ -466,7 +555,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -484,7 +573,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -502,7 +591,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -523,7 +612,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -550,7 +639,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "implementation", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -569,7 +658,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "implementation", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -593,7 +682,13 @@ internal class StandardTransformTest {
       )
 
       val actual =
-        StandardTransform(ModuleCoordinates(id, "4.13.2", gvi(id)), declarations, supportedSourceSets, ":").reduce(
+        StandardTransform(
+          ModuleCoordinates(id, "4.13.2", gvi(id)),
+          declarations,
+          emptySetMultimap(),
+          supportedSourceSets,
+          ":"
+        ).reduce(
           usages
         )
 
@@ -613,7 +708,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "implementation", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -633,7 +728,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "implementation", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -650,7 +745,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "testImplementation", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "4.4", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "4.4", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -672,7 +767,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -694,7 +789,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -716,7 +811,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -737,7 +832,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -758,7 +853,7 @@ internal class StandardTransformTest {
       )
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "1.0", gvi(id)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(id, "1.0", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -776,7 +871,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, "1.0", gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -800,7 +899,11 @@ internal class StandardTransformTest {
       ).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(identifier, resolvedVersion, gvi(identifier)), declarations, supportedSourceSets, ":"
+        ModuleCoordinates(identifier, resolvedVersion, gvi(identifier)),
+        declarations,
+        emptySetMultimap(),
+        supportedSourceSets,
+        ":"
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -826,7 +929,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "kapt", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "2.40.5", gvi(id)), declarations, supportedSourceSets, ":", true
+        ModuleCoordinates(id, "2.40.5", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":", true
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -852,7 +955,7 @@ internal class StandardTransformTest {
       val declarations = Declaration(id, "kapt", emptyGVI).intoSet()
 
       val actual = StandardTransform(
-        ModuleCoordinates(id, "2.40.5", gvi(id)), declarations, supportedSourceSets, ":", false
+        ModuleCoordinates(id, "2.40.5", gvi(id)), declarations, emptySetMultimap(), supportedSourceSets, ":", false
       ).reduce(usages)
 
       assertThat(actual).containsExactly(
@@ -878,11 +981,65 @@ internal class StandardTransformTest {
       ).intoSet()
       val declarations = emptySet<Declaration>()
 
-      val actual = StandardTransform(coordinates, declarations, supportedSourceSets, ":", usesKapt).reduce(usages)
+      val actual =
+        StandardTransform(coordinates, declarations, emptySetMultimap(), supportedSourceSets, ":", usesKapt).reduce(
+          usages
+        )
 
       assertThat(actual).containsExactly(
         Advice.ofAdd(coordinates, toConfiguration)
       )
+    }
+  }
+
+  @Nested inner class TestScenarios {
+    @Test fun `functionalTest extends from test`() {
+      val identifier = "junit:junit"
+      val sourceSet = "functionalTest"
+      val bucket = Bucket.API
+      val usages = usage(
+        bucket = bucket,
+        variant = sourceSet,
+        kind = SourceSetKind.CUSTOM_JVM
+      ).intoSet()
+      val nonTransitiveDependencies = newSetMultimap<String, Variant>().apply {
+        put(identifier, Variant(sourceSet, SourceSetKind.CUSTOM_JVM))
+      }
+
+      val actual = StandardTransform(
+        coordinates = ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations = emptySet(),
+        nonTransitiveDependencies = nonTransitiveDependencies,
+        supportedSourceSets = supportedSourceSets,
+        buildPath = ":"
+      ).reduce(usages)
+
+      assertThat(actual).isEmpty()
+    }
+
+    @Test fun `test dependency should not be API`() {
+      val identifier = "junit:junit"
+      val sourceSet = "test"
+      val bucket = Bucket.API
+      val usages = usage(
+        bucket = bucket,
+        variant = sourceSet,
+        kind = SourceSetKind.TEST
+      ).intoSet()
+      val declarations = Declaration(identifier, "testImplementation", emptyGVI).intoSet()
+      val nonTransitiveDependencies = newSetMultimap<String, Variant>().apply {
+        put(identifier, Variant(sourceSet, SourceSetKind.TEST))
+      }
+
+      val actual = StandardTransform(
+        coordinates = ModuleCoordinates(identifier, "1.0", gvi(identifier)),
+        declarations = declarations,
+        nonTransitiveDependencies = nonTransitiveDependencies,
+        supportedSourceSets = supportedSourceSets,
+        buildPath = ":"
+      ).reduce(usages)
+
+      assertThat(actual).isEmpty()
     }
   }
 }

--- a/testkit/src/main/kotlin/com/autonomousapps/kit/BuildScript.kt
+++ b/testkit/src/main/kotlin/com/autonomousapps/kit/BuildScript.kt
@@ -49,12 +49,12 @@ class BuildScript(
 
     val add =
       if (additions.isNotEmpty()) {
-        "\n$additions"
+        "\n$additions\n"
       } else {
         ""
       }
 
-    return buildscriptBlock + pluginsBlock + reposBlock + androidBlock + sourceSetsBlock + featureVariantsBlock + dependenciesBlock + add
+    return buildscriptBlock + pluginsBlock + reposBlock + androidBlock + sourceSetsBlock + featureVariantsBlock + add + dependenciesBlock
   }
 
   companion object {


### PR DESCRIPTION
Addresses multiple issues around sourceset-based analysis:
1. When analyzing the `test` sourceset, don't suggest "upgrading" dependency declarations to something `api`-like. That sourceset has no ABI; it is not published.
2. When analyzing sourcesets that extend other sourcesets, don't redundantly suggest adding dependencies to them that are inherited from their upstream sourcesets.